### PR TITLE
update to keep a local git repo in sync with updated data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
 # Use Python 3.11 slim image
 FROM python:3.11-slim
 
+# Add SPIN user id
+RUN addgroup --system --gid 76761 beril_app
+RUN adduser --system --uid 76761 beril
+
+# Create public directory with proper permissions for beril user to write config
+RUN mkdir -p /tmp/beril_data_cache && \
+    chown beril:beril_app /tmp/beril_data_cache && \
+    chmod 755 /tmp/beril_data_cache
+
 # Set working directory to the repository root
 WORKDIR /repo
+
+# Install git
+RUN apt-get update && \
+    apt-get install -y git
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/ui/app/config.py
+++ b/ui/app/config.py
@@ -12,7 +12,11 @@ class Settings(BaseSettings):
     app_dir: Path = Path(__file__).parent
     ui_dir: Path = app_dir.parent
     repo_dir: Path = ui_dir.parent  # The research repository root
-    data_source_url: str | None = None
+
+    # Git data source configuration
+    data_repo_url: str | None = None  # Git repository URL
+    data_repo_branch: str = "data-cache"  # Branch to checkout
+    data_repo_path: Path = Path("/tmp/beril_data_cache")  # Local clone path
 
     # Webhook configuration
     webhook_secret: str | None = None

--- a/ui/app/git_data_sync.py
+++ b/ui/app/git_data_sync.py
@@ -1,0 +1,121 @@
+"""Git-based data synchronization module.
+
+Handles cloning and pulling data from a Git repository.
+"""
+
+import asyncio
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Global lock to prevent concurrent git operations
+_git_lock = asyncio.Lock()
+
+
+async def ensure_repo_cloned(repo_url: str, branch: str, local_path: Path) -> None:
+    """
+    Ensure the git repository is cloned and up to date.
+
+    Args:
+        repo_url: Git repository URL
+        branch: Branch to checkout
+        local_path: Local path where repo should be cloned
+
+    Raises:
+        subprocess.CalledProcessError: If git operations fail
+    """
+    async with _git_lock:
+        if local_path.exists() and (local_path / ".git").exists():
+            logger.info(f"Repository exists at {local_path}, pulling latest changes")
+            await _git_pull(local_path, branch)
+        else:
+            logger.info(f"Cloning repository from {repo_url} to {local_path}")
+            await _git_clone(repo_url, branch, local_path)
+
+
+async def pull_latest(local_path: Path, branch: str) -> None:
+    """
+    Pull the latest changes from the remote repository.
+
+    Args:
+        local_path: Local path to the repository
+        branch: Branch to pull
+
+    Raises:
+        subprocess.CalledProcessError: If git pull fails
+    """
+    async with _git_lock:
+        logger.info(f"Pulling latest changes for branch {branch}")
+        await _git_pull(local_path, branch)
+
+
+async def _git_clone(repo_url: str, branch: str, local_path: Path) -> None:
+    """Shallow clone a single branch."""
+    # Create parent directory if it doesn't exist
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Shallow clone with single branch
+    cmd = [
+        "git",
+        "clone",
+        "--depth", "1",
+        "--single-branch",
+        "--branch", branch,
+        repo_url,
+        str(local_path),
+    ]
+
+    logger.debug(f"Running: {' '.join(cmd)}")
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stdout, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        error_msg = stderr.decode().strip()
+        logger.error(f"Git clone failed: {error_msg}")
+        raise subprocess.CalledProcessError(
+            process.returncode, cmd, stdout, stderr
+        )
+
+    logger.info(f"Repository cloned successfully to {local_path}")
+
+
+async def _git_pull(local_path: Path, branch: str) -> None:
+    """Pull latest changes from remote."""
+    # Reset any local changes
+    reset_cmd = ["git", "-C", str(local_path), "reset", "--hard", f"origin/{branch}"]
+    logger.debug(f"Running: {' '.join(reset_cmd)}")
+
+    process = await asyncio.create_subprocess_exec(
+        *reset_cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await process.communicate()
+
+    # Pull latest changes
+    pull_cmd = ["git", "-C", str(local_path), "pull", "origin", branch]
+    logger.debug(f"Running: {' '.join(pull_cmd)}")
+
+    process = await asyncio.create_subprocess_exec(
+        *pull_cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stdout, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        error_msg = stderr.decode().strip()
+        logger.error(f"Git pull failed: {error_msg}")
+        raise subprocess.CalledProcessError(
+            process.returncode, pull_cmd, stdout, stderr
+        )
+
+    logger.info("Repository updated successfully")


### PR DESCRIPTION
As the title says. The changes here do the following.
* remove the workflow that tries to pull data-cache files from raw.githubcontent.com, since those can have a 5 minute cache delay
* add a workflow that starts by pulling the repo on app loadup, only fetch the data-cache branch, and used the cached data there to populate the page
* the `/api/webhook/data-update` path now, when successful, triggers the app to pull the latest version of that branch from github and reload the data

This should avoid updates loading incorrectly due to the cache time, and should scale decently well as the data-cache file grows. This should last long enough to get us to think of what to do with this prototype.