### PR TITLE
Remove stale references to deleted skills

### DIFF
--- a/.claude/skills/literature-review/SKILL.md
+++ b/.claude/skills/literature-review/SKILL.md
@@ -29,7 +29,7 @@ Clarify what the user wants to search for. Ask if needed:
 - Time frame (recent papers only, or comprehensive)?
 - Scope: quick check (5-10 papers) or thorough review (20-50 papers)?
 
-If invoked from `/hypothesis`, the hypothesis provides the search context.
+If invoked during the `/berdl_start` research workflow, the hypothesis provides the search context.
 
 ### Step 2: Construct Search Queries
 
@@ -166,8 +166,8 @@ If the literature review reveals organisms, genes, or pathways present in BERDL:
 
 ## Integration with Other Skills
 
-### From `/hypothesis`
-After generating a hypothesis, the user can invoke `/literature-review` to:
+### From hypothesis generation (via `/berdl_start`)
+After generating a hypothesis, `/literature-review` can be used to:
 - Check if the hypothesis has already been tested
 - Find supporting or contradicting evidence
 - Identify methods used in similar studies

--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -37,7 +37,7 @@ Run these checks against the project directory and print a checklist summary:
 **Advisory checks** (warn but allow submission):
 - Discoveries documented in `docs/discoveries.md` — search for `[{project_id}]` tag
 - Pitfalls documented in `docs/pitfalls.md` — search for the project name or id
-- Research plan documented — check if `projects/{project_id}/RESEARCH_PLAN.md` exists (or `research_plan.md` for legacy projects) (created by `/research-plan`)
+- Research plan documented — check if `projects/{project_id}/RESEARCH_PLAN.md` exists (or `research_plan.md` for legacy projects)
 - Interpretation documented — check if `projects/{project_id}/REPORT.md` exists and contains a `## Interpretation` section
 - References documented — check if `projects/{project_id}/references.md` exists (created by `/literature-review`)
 - Project files committed to git — run `git status --porcelain projects/{project_id}/` and warn if there are uncommitted or untracked changes

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -106,10 +106,10 @@ This gives you an overview of BERDL, lists available skills and existing project
 
 The typical workflow looks like this:
 
-1. **Ask questions** — describe what you want to investigate and let the AI help you formulate a research question
+1. **Ask questions** — describe what you want to investigate and the agent will help formulate a research question
 2. **Explore data** — use `/berdl` to query BERDL databases with Spark SQL
-3. **Generate hypotheses** — use `/hypothesis` to develop testable research questions from the data
-4. **Write notebooks** — create Jupyter notebooks that run directly on the JupyterHub Spark cluster
+3. **Plan and analyze** — the agent develops hypotheses, writes a research plan, and generates notebooks
+4. **Run notebooks** — execute them on the JupyterHub Spark cluster
 5. **Document findings** — record discoveries, pitfalls, and insights as you go
 
 Your notebooks execute on the same Spark cluster you logged into, so queries run against the full lakehouse without any extra setup.
@@ -150,10 +150,11 @@ You can keep working on the project after submitting — submission is not a one
 
 | Skill | Description |
 |-------|-------------|
-| `/berdl_start` | Get oriented — overview of BERDL, available skills, existing projects |
+| `/berdl_start` | Get oriented and start a research project — the agent drives the full workflow |
 | `/berdl` | Query BERDL databases with Spark SQL |
 | `/berdl-discover` | Discover and document new BERDL databases |
-| `/hypothesis` | Generate testable research hypotheses from BERDL data |
+| `/literature-review` | Search PubMed, Europe PMC, and other sources for relevant literature |
+| `/synthesize` | Interpret results and draft findings |
 | `/submit` | Submit a project for automated validation and AI review |
 
 ## Resources


### PR DESCRIPTION
## Summary

- Removes references to `/hypothesis` and `/research-plan` from `docs/getting_started.md`, `literature-review/SKILL.md`, and `submit/SKILL.md`
- Updates the getting_started skills table to list the current user-invocable skills
- Follow-up to #29 which deleted the skill directories but missed these cross-references

## Test plan

- [x] `grep -r "/hypothesis" --include="*.md"` returns only historical docs/plans/ (gitignored)
- [x] No remaining references to `/research-plan` as a standalone command

🤖 Generated with [Claude Code](https://claude.com/claude-code)