### PR TITLE
Add sort options to projects list UI

### DIFF
--- a/ui/app/static/css/main.css
+++ b/ui/app/static/css/main.css
@@ -329,6 +329,47 @@ a:hover {
 }
 
 /* ============================================
+   Sort Controls
+   ============================================ */
+
+.sort-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-8);
+}
+
+.sort-label {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin-right: var(--space-1);
+}
+
+.sort-option {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.sort-option:hover {
+  color: var(--text-primary);
+  background: var(--surface-overlay);
+  border-color: var(--surface-border);
+}
+
+.sort-option.active {
+  color: var(--accent-primary);
+  background: var(--accent-primary-bg);
+  border-color: var(--accent-primary-muted);
+}
+
+/* ============================================
    Cards
    ============================================ */
 

--- a/ui/app/templates/projects/list.html
+++ b/ui/app/templates/projects/list.html
@@ -11,6 +11,13 @@
     </p>
 </div>
 
+<div class="sort-controls">
+    <span class="sort-label">Sort by:</span>
+    <a href="?sort=recent" class="sort-option {% if current_sort == 'recent' %}active{% endif %}">Recent Activity</a>
+    <a href="?sort=status" class="sort-option {% if current_sort == 'status' %}active{% endif %}">Status</a>
+    <a href="?sort=alpha" class="sort-option {% if current_sort == 'alpha' %}active{% endif %}">Alphabetical</a>
+</div>
+
 <div class="grid grid-2">
     {% for project in projects %}
     <article class="card">


### PR DESCRIPTION
## Summary

- Adds sort controls to the projects list page: **Recent Activity** (default), **Status**, and **Alphabetical**
- Fixes project date ordering by using `git log` commit dates instead of filesystem `st_mtime`, which was unreliable in CI (GitHub Actions checks out all files simultaneously, giving every project the same mtime)
- Sort controls are pill-style links matching the existing dark theme

## Test plan

- [x] Visit `/projects` — projects sorted by most recent git commit, "Recent Activity" highlighted
- [x] Click "Status" — Completed first, then In Progress, then Proposed
- [x] Click "Alphabetical" — A-Z by title
- [ ] Home page (`/`) unaffected — still shows latest 3 projects
- [ ] Data cache rebuild picks up correct git dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)