### PR TITLE
Fix project detail page bugs: section parsing, links, contributors, titles

### DIFF
--- a/ui/app/main.py
+++ b/ui/app/main.py
@@ -259,6 +259,16 @@ async def notebook_viewer(request: Request, project_id: str, notebook_name: str)
         return templates.TemplateResponse("error.html", context, status_code=500)
 
 
+@app.get("/projects/{project_id}/{filename:path}", response_class=HTMLResponse)
+async def project_file_redirect(request: Request, project_id: str, filename: str):
+    """Redirect markdown file links to the project detail page."""
+    from fastapi.responses import RedirectResponse
+
+    if filename.endswith(".md"):
+        return RedirectResponse(url=f"/projects/{project_id}", status_code=302)
+    raise HTTPException(status_code=404, detail="File not found")
+
+
 @app.get("/collections", response_class=HTMLResponse)
 async def collections_overview(request: Request):
     """Collections overview page - browse all BERDL collections."""

--- a/ui/app/templates/home.html
+++ b/ui/app/templates/home.html
@@ -127,7 +127,7 @@
         <article class="card">
             <div class="card-header">
                 <h3 class="card-title">
-                    <a href="/projects/{{ project.id }}">{{ project.title }}</a>
+                    <a href="/projects/{{ project.id }}">{{ project.title | markdown_inline }}</a>
                 </h3>
                 {% if project.status.value == "Completed" %}
                 <span class="badge badge-completed">{{ project.status.value }}</span>

--- a/ui/app/templates/projects/detail.html
+++ b/ui/app/templates/projects/detail.html
@@ -7,12 +7,12 @@
 <nav class="mb-8">
     <a href="/projects" class="text-muted">Projects</a>
     <span class="text-muted"> / </span>
-    <span>{{ project.title }}</span>
+    <span>{{ project.title | markdown_inline }}</span>
 </nav>
 
 <div class="page-header">
     <div class="flex items-center gap-4 mb-4">
-        <h1 class="page-title" style="margin-bottom: 0;">{{ project.title }}</h1>
+        <h1 class="page-title" style="margin-bottom: 0;">{{ project.title | markdown_inline }}</h1>
         {% if project.status.value == "Completed" %}
         <span class="badge badge-completed">{{ project.status.value }}</span>
         {% elif project.status.value == "In Progress" %}

--- a/ui/app/templates/projects/list.html
+++ b/ui/app/templates/projects/list.html
@@ -23,7 +23,7 @@
     <article class="card">
         <div class="card-header">
             <h3 class="card-title">
-                <a href="/projects/{{ project.id }}">{{ project.title }}</a>
+                <a href="/projects/{{ project.id }}">{{ project.title | markdown_inline }}</a>
             </h3>
             {% if project.status.value == "Completed" %}
             <span class="badge badge-completed">{{ project.status.value }}</span>

--- a/ui/app/templates/projects/notebook.html
+++ b/ui/app/templates/projects/notebook.html
@@ -178,7 +178,7 @@
 <nav class="mb-8">
     <a href="/projects" class="text-muted">Projects</a>
     <span class="text-muted"> / </span>
-    <a href="/projects/{{ project.id }}" class="text-muted">{{ project.title }}</a>
+    <a href="/projects/{{ project.id }}" class="text-muted">{{ project.title | markdown_inline }}</a>
     <span class="text-muted"> / </span>
     <span>{{ notebook.filename }}</span>
 </nav>
@@ -186,7 +186,7 @@
 <div class="page-header">
     <h1 class="page-title">{{ notebook.title or notebook.filename }}</h1>
     <p class="page-description">
-        Jupyter notebook from the <a href="/projects/{{ project.id }}">{{ project.title }}</a> project.
+        Jupyter notebook from the <a href="/projects/{{ project.id }}">{{ project.title | markdown_inline }}</a> project.
     </p>
 </div>
 


### PR DESCRIPTION
## Summary

- Fix `_extract_section()` regex to not stop at `###` subsections, so sections like Interpretation capture their full content including Literature Context, Novel Contribution, and Limitations
- Add redirect route for `.md` file links under `/projects/{id}/` paths (REPORT.md, RESEARCH_PLAN.md)
- Rewrite bare `.md` links in markdown content to absolute project-relative paths so the browser resolves them correctly (without trailing slash, `[Report](REPORT.md)` was resolving to `/projects/REPORT.md` instead of `/projects/{id}/REPORT.md`)
- Fix contributor parser to handle `(ORCID: [id](url)) -- Affiliation` format in addition to pipe-separated format
- Fix discovery parser to strip `## YYYY-MM` date headers from card content and track date transitions by character position
- Apply `markdown_inline` filter to project titles in all templates so species names like `*Desulfovibrio vulgaris*` render as italics

## Test plan

- [ ] Visit `/projects/costly_dispensable_genes` — Interpretation section includes Literature Context, Novel Contribution, and Limitations subsections
- [ ] Click "Report" link in Overview — redirects to project page (no 404)
- [ ] Visit `/community/contributors` — Paramvir shows affiliation as "Lawrence Berkeley National Laboratory" with correct ORCID, no garbled text
- [ ] Visit `/knowledge/discoveries` — no `## 2026-02` date text inside discovery cards
- [ ] Visit `/projects` — species names render in italics (e.g., *Desulfovibrio vulgaris*)
- [ ] Notebook links still work at `/projects/{id}/notebooks/{name}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)