### PR TITLE
Make hero stat boxes clickable

### DIFF
--- a/ui/app/static/css/main.css
+++ b/ui/app/static/css/main.css
@@ -568,6 +568,13 @@ a:hover {
   border-radius: var(--radius-lg);
   padding: var(--space-4) var(--space-6);
   box-shadow: var(--shadow-glow);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.stat-card:hover {
+  border-color: var(--accent-primary-muted);
 }
 
 .stat-value {

--- a/ui/app/templates/home.html
+++ b/ui/app/templates/home.html
@@ -21,22 +21,22 @@
     </div>
 
     <div class="hero-stats">
-        <div class="stat-card">
+        <a href="/collections" class="stat-card">
             <div class="stat-value">{{ collection_count }}</div>
             <div class="stat-label">collections</div>
-        </div>
-        <div class="stat-card">
+        </a>
+        <a href="/projects" class="stat-card">
             <div class="stat-value">{{ project_count }}</div>
             <div class="stat-label">projects</div>
-        </div>
-        <div class="stat-card">
+        </a>
+        <a href="/knowledge/discoveries" class="stat-card">
             <div class="stat-value">{{ discovery_count }}</div>
             <div class="stat-label">discoveries</div>
-        </div>
-        <div class="stat-card">
+        </a>
+        <a href="/community/contributors" class="stat-card">
             <div class="stat-value">{{ contributor_count }}</div>
             <div class="stat-label">contributors</div>
-        </div>
+        </a>
     </div>
 </section>
 


### PR DESCRIPTION
## Summary

- Convert the 4 hero stat boxes (collections, projects, discoveries, contributors) from `<div>` to `<a>` tags linking to their respective pages
- Add hover style matching the existing `.card:hover` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)