### PR TITLE
Move Partner / Enabling Effort section below team on About page

### DIFF
--- a/ui/app/templates/about/about.html
+++ b/ui/app/templates/about/about.html
@@ -171,6 +171,76 @@
     </p>
 </section>
 
+<!-- Partner / Enabling Effort -->
+<section class="section">
+    <h2>Partner / Enabling Effort</h2>
+    <div class="team-grid">
+        <div class="card team-card">
+            <div style="position: relative;">
+                <img src="https://biosciences.lbl.gov/wp-content/uploads/2015/09/ArkinAdam.jpg"
+                     alt="Headshot of Adam Arkin" class="team-avatar"
+                     onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
+                <div class="avatar-initials" style="display:none">AA</div>
+            </div>
+            <div>
+                <strong>Adam Arkin</strong>
+                <p class="text-muted text-small" style="margin: 0;">Vision/leadership for BERDL (KBase)</p>
+            </div>
+        </div>
+        <div class="card team-card">
+            <div style="position: relative;">
+                <img src="https://www.kbase.us/wp-content/uploads/sites/6/2020/06/ChrisHenryPicture.jpg"
+                     alt="Headshot of Chris Henry" class="team-avatar"
+                     onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
+                <div class="avatar-initials" style="display:none">CH</div>
+            </div>
+            <div>
+                <strong>Chris Henry</strong>
+                <p class="text-muted text-small" style="margin: 0;">Driving BERDL data resources and curation</p>
+            </div>
+        </div>
+        <div class="card team-card">
+            <div style="position: relative;">
+                <img src="https://www.kbase.us/wp-content/uploads/sites/6/2024/02/mahmud-gazi.jpg"
+                     alt="Headshot of Gazi Mahmud" class="team-avatar"
+                     onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
+                <div class="avatar-initials" style="display:none">GM</div>
+            </div>
+            <div>
+                <strong>Gazi Mahmud</strong>
+                <p class="text-muted text-small" style="margin: 0;">BERDL architect</p>
+            </div>
+        </div>
+        <div class="card team-card">
+            <div style="position: relative;">
+                <img src="https://jgi.doe.gov/sites/default/files/styles/medium/public/2024-12/Kjiersten-Fagnan-JLT.jpg.webp?itok=sdcPmWCR"
+                     alt="Headshot of Kjiersten Fagnan" class="team-avatar"
+                     onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
+                <div class="avatar-initials" style="display:none">KF</div>
+            </div>
+            <div>
+                <strong>Kjiersten Fagnan</strong>
+                <p class="text-muted text-small" style="margin: 0;">BERIL co-PI</p>
+            </div>
+        </div>
+        <div class="card team-card">
+            <div style="position: relative;">
+                <img src="https://www.pnnl.gov/sites/default/files/styles/portrait/public/media/image/Ratna_Saripalli_PNNL.jpg?h=3dd0356d&itok=E5wMIvuA"
+                     alt="Headshot of Ratna Saripalli" class="team-avatar"
+                     onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
+                <div class="avatar-initials" style="display:none">RS</div>
+            </div>
+            <div>
+                <strong>Ratna Saripalli</strong>
+                <p class="text-muted text-small" style="margin: 0;">BERIL co-PI</p>
+            </div>
+        </div>
+    </div>
+    <p class="text-muted text-small" style="margin-top: var(--space-4);">
+        Recognizes enabling roles in BERDL/BERIL/KBase; the Research Observatory UI is led and maintained by Paramvir S. Dehal.
+    </p>
+</section>
+
 <!-- What is BERDL? -->
 <section class="section">
     <h2>What is BERDL?</h2>
@@ -243,80 +313,6 @@
         </p>
         <pre style="background: var(--surface-overlay); padding: var(--space-4); border-radius: var(--radius-md); font-size: 0.875rem; line-height: 1.6; white-space: pre-wrap;">Paramvir S. Dehal. Research Observatory (BERIL) — v0.1, 2026. Built on the KBase BER Data Lakehouse (BERDL).</pre>
     </div>
-</section>
-
-<!-- Acknowledgements -->
-<section class="section">
-    <details>
-        <summary style="cursor: pointer; font-size: 1.25rem; font-weight: 600; color: var(--text-primary); margin-bottom: var(--space-4);">
-            Acknowledgements (enabling efforts)
-        </summary>
-        <div class="team-grid" style="margin-top: var(--space-4);">
-            <div class="card team-card">
-                <div style="position: relative;">
-                    <img src="https://biosciences.lbl.gov/wp-content/uploads/2015/09/ArkinAdam.jpg"
-                         alt="Headshot of Adam Arkin" class="team-avatar"
-                         onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
-                    <div class="avatar-initials" style="display:none">AA</div>
-                </div>
-                <div>
-                    <strong>Adam Arkin</strong>
-                    <p class="text-muted text-small" style="margin: 0;">Vision/leadership for BERDL (KBase)</p>
-                </div>
-            </div>
-            <div class="card team-card">
-                <div style="position: relative;">
-                    <img src="https://www.kbase.us/wp-content/uploads/sites/6/2020/06/ChrisHenryPicture.jpg"
-                         alt="Headshot of Chris Henry" class="team-avatar"
-                         onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
-                    <div class="avatar-initials" style="display:none">CH</div>
-                </div>
-                <div>
-                    <strong>Chris Henry</strong>
-                    <p class="text-muted text-small" style="margin: 0;">Driving BERDL data resources and curation</p>
-                </div>
-            </div>
-            <div class="card team-card">
-                <div style="position: relative;">
-                    <img src="https://www.kbase.us/wp-content/uploads/sites/6/2024/02/mahmud-gazi.jpg"
-                         alt="Headshot of Gazi Mahmud" class="team-avatar"
-                         onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
-                    <div class="avatar-initials" style="display:none">GM</div>
-                </div>
-                <div>
-                    <strong>Gazi Mahmud</strong>
-                    <p class="text-muted text-small" style="margin: 0;">BERDL architect</p>
-                </div>
-            </div>
-            <div class="card team-card">
-                <div style="position: relative;">
-                    <img src="https://jgi.doe.gov/sites/default/files/styles/medium/public/2024-12/Kjiersten-Fagnan-JLT.jpg.webp?itok=sdcPmWCR"
-                         alt="Headshot of Kjiersten Fagnan" class="team-avatar"
-                         onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
-                    <div class="avatar-initials" style="display:none">KF</div>
-                </div>
-                <div>
-                    <strong>Kjiersten Fagnan</strong>
-                    <p class="text-muted text-small" style="margin: 0;">BERIL co-PI</p>
-                </div>
-            </div>
-            <div class="card team-card">
-                <div style="position: relative;">
-                    <img src="https://www.pnnl.gov/sites/default/files/styles/portrait/public/media/image/Ratna_Saripalli_PNNL.jpg?h=3dd0356d&itok=E5wMIvuA"
-                         alt="Headshot of Ratna Saripalli" class="team-avatar"
-                         onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
-                    <div class="avatar-initials" style="display:none">RS</div>
-                </div>
-                <div>
-                    <strong>Ratna Saripalli</strong>
-                    <p class="text-muted text-small" style="margin: 0;">BERIL co-PI</p>
-                </div>
-            </div>
-        </div>
-        <p class="text-muted text-small" style="margin-top: var(--space-4);">
-            This acknowledgements list recognizes enabling roles in BERDL/BERIL/KBase; the Research Observatory UI is led and maintained by Paramvir S. Dehal.
-        </p>
-    </details>
 </section>
 
 <!-- Getting Started -->


### PR DESCRIPTION
## Summary

- Move the acknowledgements section up to directly below Research Observatory Team
- Rename from collapsible "Acknowledgements (enabling efforts)" to a full `<h2>` "Partner / Enabling Effort" section
- Both team sections now have equal heading weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)