### PR TITLE
Add data collection attribution and render Data/References sections

### DIFF
--- a/.claude/skills/synthesize/SKILL.md
+++ b/.claude/skills/synthesize/SKILL.md
@@ -167,7 +167,9 @@ Create or update `projects/{project_id}/REPORT.md` with the following sections:
 - **Inline figures**: Place `![description](figures/filename.png)` near the finding each figure supports. The UI rewrites these paths automatically for web rendering. Every figure in the project's `figures/` directory should appear inline at least once.
 - **Notebook provenance**: End each finding subsection with `*(Notebook: filename.ipynb)*` to trace results back to the analysis code.
 - **Data section**: The `## Data` section documents data lineage. `### Sources` lists BERDL collections and tables queried. `### Generated Data` lists output files with row counts.
-- **References**: Always include references, even for well-known data sources. At minimum cite the primary data sources (e.g., Price et al. 2018 for Fitness Browser, Parks et al. 2022 for GTDB r214).
+- **Collection IDs**: Use the exact BERDL collection identifier (e.g., `kescience_fitnessbrowser`, `kbase_ke_pangenome`) in the Sources table. These IDs link to the collection detail pages on the Research Observatory, which include citation and attribution information for data providers.
+- **README update**: Ensure the collection IDs appear somewhere in the README.md text so the UI can auto-detect and display Data Collections links on the project page.
+- **References**: Always include references, even for well-known data sources. At minimum cite the primary data sources (e.g., Price et al. 2018 for Fitness Browser, Arkin et al. 2018 for KBase).
 
 Also update `projects/{project_id}/README.md`:
 - Update `## Status` to reflect completion (e.g., "Complete — see [Report](REPORT.md) for findings")

--- a/ui/app/dataloader.py
+++ b/ui/app/dataloader.py
@@ -368,6 +368,8 @@ class RepositoryParser:
         interpretation = None
         limitations = None
         future_directions = None
+        data_section = None
+        references = None
 
         if has_report:
             report_raw = report_path.read_text()
@@ -376,6 +378,8 @@ class RepositoryParser:
             interpretation = self._extract_section(report_raw, "Interpretation")
             limitations = self._extract_section(report_raw, "Limitations")
             future_directions = self._extract_section(report_raw, "Future Directions")
+            data_section = self._extract_section(report_raw, "Data")
+            references = self._extract_section(report_raw, "References")
         else:
             # Fallback: extract from README (legacy projects)
             findings = self._extract_section(readme_content, "Key Findings")
@@ -452,6 +456,8 @@ class RepositoryParser:
             interpretation=self._rewrite_md_links(interpretation, project_dir.name),
             limitations=self._rewrite_md_links(limitations, project_dir.name),
             future_directions=self._rewrite_md_links(future_directions, project_dir.name),
+            data_section=self._rewrite_md_links(data_section, project_dir.name),
+            references=self._rewrite_md_links(references, project_dir.name),
             revision_history=revision_history,
         )
 
@@ -1157,6 +1163,10 @@ class RepositoryParser:
                 sample_queries=sample_queries,
                 related_collections=coll_data.get("related_collections", []),
                 sub_collections=coll_data.get("sub_collections", []),
+                citation=coll_data.get("citation"),
+                doi=coll_data.get("doi"),
+                website=coll_data.get("website"),
+                provider=coll_data.get("provider"),
             )
             collections.append(collection)
 

--- a/ui/app/main.py
+++ b/ui/app/main.py
@@ -208,6 +208,11 @@ async def project_detail(request: Request, project_id: str):
         d for d in repo_data.discoveries if d.project_tag == project_id
     ]
 
+    # Resolve collection IDs to full objects for richer display
+    context["project_collections"] = [
+        c for c in (repo_data.get_collection(cid) for cid in project.related_collections) if c
+    ]
+
     return templates.TemplateResponse("projects/detail.html", context)
 
 

--- a/ui/app/models.py
+++ b/ui/app/models.py
@@ -112,6 +112,10 @@ class Collection:
     sample_queries: list[SampleQuery] = field(default_factory=list)
     related_collections: list[str] = field(default_factory=list)
     sub_collections: list[str] = field(default_factory=list)
+    citation: str | None = None
+    doi: str | None = None
+    website: str | None = None
+    provider: str | None = None
 
 
 @dataclass
@@ -193,6 +197,8 @@ class Project:
     interpretation: str | None = None
     limitations: str | None = None
     future_directions: str | None = None
+    data_section: str | None = None
+    references: str | None = None
     revision_history: str | None = None
 
     @property

--- a/ui/app/templates/collections/detail.html
+++ b/ui/app/templates/collections/detail.html
@@ -207,6 +207,27 @@
 </section>
 {% endif %}
 
+<!-- Citation & Attribution -->
+{% if collection.citation or collection.website or collection.provider %}
+<section class="section">
+    <h2>Citation & Attribution</h2>
+    <div class="card">
+        {% if collection.provider %}
+        <p style="margin-bottom: var(--space-3);"><strong>Provider:</strong> {{ collection.provider }}</p>
+        {% endif %}
+        {% if collection.citation %}
+        <p style="margin-bottom: var(--space-3);"><strong>Cite as:</strong> {{ collection.citation }}</p>
+        {% endif %}
+        {% if collection.doi %}
+        <p style="margin-bottom: var(--space-3);"><strong>DOI:</strong> <a href="https://doi.org/{{ collection.doi }}" target="_blank" rel="noopener">{{ collection.doi }}</a></p>
+        {% endif %}
+        {% if collection.website %}
+        <p style="margin-bottom: 0;"><strong>Website:</strong> <a href="{{ collection.website }}" target="_blank" rel="noopener">{{ collection.website }}</a></p>
+        {% endif %}
+    </div>
+</section>
+{% endif %}
+
 <!-- Scale Stats -->
 {% if collection.scale_stats %}
 <section class="section">

--- a/ui/app/templates/projects/detail.html
+++ b/ui/app/templates/projects/detail.html
@@ -98,6 +98,26 @@
 </section>
 {% endif %}
 
+<!-- Data (from REPORT.md) -->
+{% if project.data_section %}
+<section class="section">
+    <h2>Data</h2>
+    <div class="card markdown-content">
+        {{ project.data_section | markdown }}
+    </div>
+</section>
+{% endif %}
+
+<!-- References (from REPORT.md) -->
+{% if project.references %}
+<section class="section">
+    <h2>References</h2>
+    <div class="card markdown-content">
+        {{ project.references | markdown }}
+    </div>
+</section>
+{% endif %}
+
 <!-- Research Plan (collapsible, secondary for completed projects) -->
 {% if project.hypothesis or project.approach %}
 <section class="section">
@@ -255,7 +275,27 @@
 {% endif %}
 
 <!-- Data Collections -->
-{% if project.related_collections %}
+{% if project_collections %}
+<section class="section">
+    <h2>Data Collections</h2>
+    <div class="grid grid-3">
+        {% for coll in project_collections %}
+        <a href="/collections/{{ coll.id }}" class="card" style="text-decoration: none;">
+            <div class="flex items-center gap-4">
+                <span style="font-size: 1.25rem;">{{ coll.icon | safe }}</span>
+                <div>
+                    <h4 style="margin-bottom: 0; color: var(--text-primary);">{{ coll.name }}</h4>
+                    <p class="text-muted text-small" style="font-family: var(--font-mono); margin-bottom: 0;">{{ coll.id }}</p>
+                </div>
+            </div>
+            {% if coll.provider %}
+            <p class="text-muted text-small" style="margin-top: var(--space-2); margin-bottom: 0;">{{ coll.provider }}</p>
+            {% endif %}
+        </a>
+        {% endfor %}
+    </div>
+</section>
+{% elif project.related_collections %}
 <section class="section">
     <h2>Data Collections</h2>
     <div class="grid grid-3">

--- a/ui/config/collections.yaml
+++ b/ui/config/collections.yaml
@@ -7,6 +7,10 @@ collections:
     name: Pangenome Collection
     category: primary
     icon: "&#129516;"  # DNA emoji
+    provider: "KBase, DOE"
+    citation: "Arkin AP et al. (2018) KBase: The United States Department of Energy Systems Biology Knowledgebase. Nat Biotechnol 36:566-569"
+    doi: "10.1038/nbt.4163"
+    website: "https://www.kbase.us/"
     description: >
       Pangenome data for 293,059 genomes across 27,690 microbial species
       derived from GTDB r214. Includes core/accessory gene classification,
@@ -107,6 +111,10 @@ collections:
     name: Fitness Browser
     category: primary
     icon: "&#128202;"  # Chart emoji
+    provider: "Price Lab, LBNL"
+    citation: "Price MN et al. (2018) Mutant phenotypes for thousands of bacterial genes of unknown function. Nature 557:503-509"
+    doi: "10.1038/s41586-018-0124-0"
+    website: "https://fit.genomics.lbl.gov/"
     description: >
       Gene fitness data from transposon mutant experiments across 40+
       bacterial organisms. Identify essential genes and condition-specific
@@ -163,6 +171,8 @@ collections:
     name: KBase Genomes
     category: primary
     icon: "&#128172;"  # Speech bubble (placeholder)
+    provider: "KBase, DOE"
+    website: "https://www.kbase.us/"
     description: >
       Structural genomics data including contigs, features, and protein
       sequences from the KBase genome repository.
@@ -201,6 +211,8 @@ collections:
     name: ModelSEED Biochemistry
     category: primary
     icon: "&#9879;"  # Alembic emoji
+    provider: "ModelSEED / Henry Lab"
+    website: "https://modelseed.org/"
     description: >
       Biochemistry reference data for metabolic modeling. Reactions,
       compounds, and pathway mappings from ModelSEED.
@@ -303,6 +315,8 @@ collections:
     name: ENIGMA CORAL
     category: domain
     icon: "&#129712;"  # Coral emoji
+    provider: "ENIGMA SFA, LBNL"
+    website: "https://enigma.lbl.gov/"
     description: >
       Environmental microbiology data from the ENIGMA SFA project. Includes
       samples, genomes, communities, and strains for studying microbial
@@ -342,6 +356,8 @@ collections:
     name: NMDC Multi-omics
     category: domain
     icon: "&#128300;"  # Microscope emoji
+    provider: "NMDC"
+    website: "https://microbiomedata.org/"
     description: >
       Multi-omics analysis data from the National Microbiome Data
       Collaborative. Includes functional annotations, embeddings,
@@ -398,6 +414,8 @@ collections:
     name: NMDC BioSamples
     category: domain
     icon: "&#128300;"  # Microscope emoji
+    provider: "NMDC / NCBI"
+    website: "https://microbiomedata.org/"
     description: >
       Harmonized NCBI BioSample metadata from the National Microbiome Data
       Collaborative. Standardized attributes, environmental triads, and


### PR DESCRIPTION
## Summary

- Add citation, DOI, website, provider fields to collection model and YAML config
- Display Citation & Attribution section on collection detail pages (Price et al. for Fitness Browser, Arkin et al. for KBase pangenome, etc.)
- Extract and render `## Data` and `## References` from REPORT.md on project detail pages (previously invisible)
- Enrich Data Collections cards on project pages with collection name, icon, and provider
- Update synthesize skill to emphasize using exact BERDL collection IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)