### PR TITLE
About page: team rename, PI card, add team member, reorder sections

### DIFF
--- a/ui/app/templates/about/about.html
+++ b/ui/app/templates/about/about.html
@@ -11,33 +11,6 @@
     </p>
 </div>
 
-<!-- Project Lead -->
-<section class="section">
-    <div class="card pi-card" style="border-left: 4px solid var(--accent-primary);">
-        <div style="position: relative;">
-            <img src="https://www.kbase.us/wp-content/uploads/sites/6/2020/06/dehal-paramvir_rev@2x.png"
-                 alt="Headshot of Paramvir S. Dehal"
-                 class="pi-avatar"
-                 onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
-            <div class="avatar-initials pi-avatar-initials" style="display:none">PD</div>
-        </div>
-        <div>
-            <h3 style="margin: 0 0 var(--space-1) 0;">Paramvir S. Dehal</h3>
-            <p class="text-muted" style="margin-bottom: var(--space-2);">
-                Project lead &amp; primary contact
-            </p>
-            <p class="text-small" style="margin-bottom: var(--space-2);">
-                PI, BERIL &bull; Scientific lead, primary developer, and maintainer of the Microbial Discovery Forge
-            </p>
-            <p class="text-small" style="margin-bottom: 0;">
-                <a href="mailto:psdehal@lbl.gov">psdehal@lbl.gov</a>
-                &bull;
-                <a href="https://orcid.org/0000-0001-5810-2497" target="_blank" rel="noopener">ORCID</a>
-            </p>
-        </div>
-    </div>
-</section>
-
 <!-- Two Experiences -->
 <section class="section">
     <h2>Two Experiences</h2>
@@ -61,52 +34,34 @@
     </div>
 </section>
 
-<!-- Contributing Projects and Resources -->
+<!-- Microbial Discovery Forge Team -->
 <section class="section">
-    <h2>Contributing Projects and Resources</h2>
-    <div class="grid grid-3">
-        <div class="card">
-            <h4 style="margin-top: 0;">BERIL</h4>
-            <p class="text-small">
-                The <strong>BER Intelligent Layer</strong> is the broader program providing AI integration
-                capabilities for DOE BER data resources. The Research Observatory is developed under the
-                BERIL project umbrella.
-            </p>
+    <h2>Microbial Discovery Forge Team</h2>
+
+    <!-- PI lead card -->
+    <div class="card pi-card" style="border-left: 4px solid var(--accent-primary); margin-bottom: var(--space-6);">
+        <div style="position: relative;">
+            <img src="https://www.kbase.us/wp-content/uploads/sites/6/2020/06/dehal-paramvir_rev@2x.png"
+                 alt="Headshot of Paramvir S. Dehal"
+                 class="pi-avatar"
+                 onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
+            <div class="avatar-initials pi-avatar-initials" style="display:none">PD</div>
         </div>
-        <div class="card">
-            <h4 style="margin-top: 0;">KBase</h4>
-            <p class="text-small">
-                The <strong>Department of Energy Systems Biology Knowledgebase</strong> provides the platform
-                ecosystem, community infrastructure, and the AI/ML team that supports this work.
+        <div>
+            <h3 style="margin: 0 0 var(--space-2) 0;">Paramvir S. Dehal</h3>
+            <p class="text-small" style="margin-bottom: var(--space-2);">
+                Project lead &amp; primary contact; PI BERIL and AI/ML Team Lead KBase; Scientific lead, primary developer of Microbial Discovery Forge
             </p>
-        </div>
-        <div class="card">
-            <h4 style="margin-top: 0;">BERDL</h4>
-            <p class="text-small">
-                The <strong>BER Data Lakehouse</strong> is the underlying data resource hosting 35+ databases
-                across 9 tenants of curated scientific datasets. Developed by the KBase team, BERDL provides
-                the data foundation for all Observatory analyses.
+            <p class="text-small" style="margin-bottom: 0;">
+                <a href="mailto:psdehal@lbl.gov">psdehal@lbl.gov</a>
+                &bull;
+                <a href="https://orcid.org/0000-0001-5810-2497" target="_blank" rel="noopener">ORCID</a>
             </p>
         </div>
     </div>
-</section>
 
-<!-- Research Observatory Team -->
-<section class="section">
-    <h2>Research Observatory Team</h2>
+    <!-- Team grid -->
     <div class="team-grid">
-        <div class="card team-card">
-            <div style="position: relative;">
-                <img src="https://www.kbase.us/wp-content/uploads/sites/6/2020/06/dehal-paramvir_rev@2x.png"
-                     alt="Headshot of Paramvir S. Dehal" class="team-avatar"
-                     onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
-                <div class="avatar-initials" style="display:none">PD</div>
-            </div>
-            <div>
-                <strong>Paramvir S. Dehal</strong>
-                <p class="text-muted text-small" style="margin: 0;">Project lead; scientific direction; architecture; core implementation &amp; maintenance</p>
-            </div>
-        </div>
         <div class="card team-card">
             <div style="position: relative;">
                 <img src="https://berkeleybop.org/people/chris-mungall/Mungall-headshot.jpeg"
@@ -167,10 +122,19 @@
                 <p class="text-muted text-small" style="margin: 0;">Project management support</p>
             </div>
         </div>
+        <div class="card team-card">
+            <div style="position: relative;">
+                <img src="https://www.kbase.us/wp-content/uploads/sites/6/2023/10/cashman-mikaela-scaled.jpg"
+                     alt="Headshot of Mikaela Cashman" class="team-avatar"
+                     onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
+                <div class="avatar-initials" style="display:none">MC</div>
+            </div>
+            <div>
+                <strong>Mikaela Cashman</strong>
+                <p class="text-muted text-small" style="margin: 0;">Data collections</p>
+            </div>
+        </div>
     </div>
-    <p class="text-muted text-small" style="margin-top: var(--space-4);">
-        Roles reflect contributions to the Research Observatory UI and associated analyses.
-    </p>
 </section>
 
 <!-- Partner / Enabling Effort -->
@@ -238,9 +202,36 @@
             </div>
         </div>
     </div>
-    <p class="text-muted text-small" style="margin-top: var(--space-4);">
-        Recognizes enabling roles in BERDL/BERIL/KBase; the Microbial Discovery Forge is led and maintained by Paramvir S. Dehal.
-    </p>
+</section>
+
+<!-- Contributing Projects and Resources -->
+<section class="section">
+    <h2>Contributing Projects and Resources</h2>
+    <div class="grid grid-3">
+        <div class="card">
+            <h4 style="margin-top: 0;">BERIL</h4>
+            <p class="text-small">
+                The <strong>BER Intelligent Layer</strong> is the broader program providing AI integration
+                capabilities for DOE BER data resources. The Research Observatory is developed under the
+                BERIL project umbrella.
+            </p>
+        </div>
+        <div class="card">
+            <h4 style="margin-top: 0;">KBase</h4>
+            <p class="text-small">
+                The <strong>Department of Energy Systems Biology Knowledgebase</strong> provides the platform
+                ecosystem, community infrastructure, and the AI/ML team that supports this work.
+            </p>
+        </div>
+        <div class="card">
+            <h4 style="margin-top: 0;">BERDL</h4>
+            <p class="text-small">
+                The <strong>BER Data Lakehouse</strong> is the underlying data resource hosting 35+ databases
+                across 9 tenants of curated scientific datasets. Developed by the KBase team, BERDL provides
+                the data foundation for all Observatory analyses.
+            </p>
+        </div>
+    </div>
 </section>
 
 <!-- What is BERDL? -->
@@ -311,7 +302,7 @@
     <h2>How to Cite</h2>
     <div class="card">
         <p class="text-small text-muted" style="margin-bottom: var(--space-3);">
-            If you use the Research Observatory or its findings in your work, please cite:
+            If you use the Microbial Discovery Forge or its findings in your work, please cite:
         </p>
         <pre style="background: var(--surface-overlay); padding: var(--space-4); border-radius: var(--radius-md); font-size: 0.875rem; line-height: 1.6; white-space: pre-wrap;">Paramvir S. Dehal. Microbial Discovery Forge — v0.1, 2026. Built on the KBase BER Data Lakehouse (BERDL).</pre>
     </div>
@@ -333,7 +324,7 @@
         <div class="card">
             <h4>For Contributors</h4>
             <p class="text-small" style="margin-bottom: var(--space-3);">
-                For Observatory contributions, please contact <a href="mailto:psdehal@lbl.gov">psdehal@lbl.gov</a>.
+                For contributions, please contact <a href="mailto:psdehal@lbl.gov">psdehal@lbl.gov</a>.
             </p>
             <ol>
                 <li>Pick a <a href="/knowledge/ideas">research idea</a> or propose your own</li>


### PR DESCRIPTION
## Summary

- Remove standalone PI block below title, integrate into team section as full-width highlighted card
- Rename "Research Observatory Team" to "Microbial Discovery Forge Team"
- Add Mikaela Cashman (Data collections) to team
- Move Contributing Projects and Resources below Partner / Enabling Effort
- Remove disclaimer text from both team sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)