### PR TITLE
Restore Community page to nav with enhanced contributor cards

### DIFF
--- a/ui/app/templates/base.html
+++ b/ui/app/templates/base.html
@@ -37,6 +37,7 @@
                         <li><a href="/projects">Projects</a></li>
                         <li><a href="/collections">Collections</a></li>
                         <li><a href="/knowledge/discoveries">Discoveries</a></li>
+                        <li><a href="/community/contributors">Community</a></li>
                     </ul>
                 </li>
                 <li class="nav-dropdown">

--- a/ui/app/templates/community/contributors.html
+++ b/ui/app/templates/community/contributors.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
-{% block title %}Contributors - {{ app_name }}{% endblock %}
+{% block title %}Community - {{ app_name }}{% endblock %}
 
 {% block content %}
 <div class="page-header">
-    <h1 class="page-title">Community Contributors</h1>
+    <h1 class="page-title">Community</h1>
     <p class="page-description">
-        Researchers and analysts contributing to BERDL exploration projects.
+        Researchers and analysts contributing to Microbial Discovery Forge projects.
     </p>
 </div>
 
@@ -19,6 +19,10 @@
     <div class="community-stat">
         <div class="stat-value">{{ project_count }}</div>
         <div class="stat-label">projects</div>
+    </div>
+    <div class="community-stat">
+        <div class="stat-value">{{ total_collections_used }}</div>
+        <div class="stat-label">collections used</div>
     </div>
     <div class="community-stat">
         <div class="stat-value">{{ total_orcids }}</div>
@@ -35,6 +39,7 @@
             {% if contributor.affiliation %}
             <span class="contributor-affiliation">({{ contributor.affiliation }})</span>
             {% endif %}
+            <span class="text-muted text-small" style="margin-left: var(--space-2);">{{ contributor.project_ids|length }} project{% if contributor.project_ids|length != 1 %}s{% endif %}</span>
         </div>
 
         {% if contributor.orcid %}
@@ -50,11 +55,21 @@
         <p class="text-muted text-small" style="margin-bottom: var(--space-3);">{{ contributor.roles | join(', ') }}</p>
         {% endif %}
 
-        <div class="contributor-projects">
+        <div class="contributor-projects" style="margin-bottom: var(--space-3);">
+            <p class="text-muted text-small" style="margin-bottom: var(--space-1);">Projects</p>
             {% for pid in contributor.project_ids %}
             <a href="/projects/{{ pid }}" class="badge badge-project">{{ pid | replace('_', ' ') | title }}</a>
             {% endfor %}
         </div>
+
+        {% if contributor_collections.get(contributor.name) %}
+        <div class="contributor-collections">
+            <p class="text-muted text-small" style="margin-bottom: var(--space-1);">Collections used</p>
+            {% for coll_id in contributor_collections[contributor.name] %}
+            <a href="/collections/{{ coll_id }}" class="badge" style="background: rgba(57, 212, 230, 0.1); color: #39d4e6; font-size: 0.7rem;">{{ coll_id }}</a>
+            {% endfor %}
+        </div>
+        {% endif %}
     </div>
     {% endfor %}
 </div>


### PR DESCRIPTION
## Summary

- Add Community as last item in Observatory dropdown nav
- Sort contributors by project count (most projects first)
- Show project count, collections used badges, and ORCID links per contributor
- Add "collections used" to top stats bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)