### PR TITLE
Add author line to project pages, fix contributor parsing for plain format

### DIFF
--- a/ui/app/templates/projects/detail.html
+++ b/ui/app/templates/projects/detail.html
@@ -39,6 +39,19 @@
     </div>
 </div>
 
+<!-- Authors -->
+{% if project.contributors %}
+<section class="section" style="margin-bottom: 0; padding-bottom: 0;">
+    <div class="flex items-center gap-4" style="flex-wrap: wrap;">
+        {% for contributor in project.contributors %}
+        <span class="text-small">
+            <strong>{{ contributor.name }}</strong>{% if contributor.orcid %} <a href="{{ contributor.orcid_url }}" target="_blank" rel="noopener" class="orcid-link" style="margin-left: 2px;"><img src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" alt="ORCID" width="12" height="12"></a>{% endif %}{% if not loop.last %} &bull;{% endif %}
+        </span>
+        {% endfor %}
+    </div>
+</section>
+{% endif %}
+
 <!-- Research Question -->
 <section class="section">
     <h2>Research Question</h2>
@@ -168,35 +181,6 @@
 
 {% endif %}
 
-<!-- Authors -->
-{% if project.contributors %}
-<section class="section">
-    <h2>Authors</h2>
-    <div class="contributors-list">
-        {% for contributor in project.contributors %}
-        <div class="contributor-card">
-            <div class="contributor-info">
-                <span class="contributor-name">{{ contributor.name }}</span>
-                {% if contributor.affiliation %}
-                <span class="contributor-affiliation">({{ contributor.affiliation }})</span>
-                {% endif %}
-            </div>
-            <div class="contributor-meta">
-                {% if contributor.orcid %}
-                <a href="{{ contributor.orcid_url }}" target="_blank" rel="noopener" class="orcid-link">
-                    <img src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" alt="ORCID" width="16" height="16">
-                    {{ contributor.orcid }}
-                </a>
-                {% endif %}
-                {% if contributor.roles %}
-                <span class="contributor-roles">{{ contributor.roles | join(', ') }}</span>
-                {% endif %}
-            </div>
-        </div>
-        {% endfor %}
-    </div>
-</section>
-{% endif %}
 
 <!-- Discoveries -->
 {% if project_discoveries %}


### PR DESCRIPTION
## Summary

- Show author names with ORCID links above Research Question on project detail pages
- Add fallback contributor parser for plain format (`- Name, Affiliation`) used in newer projects
- Fix deduplication: normalize middle initials so "Paramvir S. Dehal" and "Paramvir Dehal" merge
- Prefer longer name variant when merging
- Adam Deutschbauer now appears on community page via metal_fitness_atlas

🤖 Generated with [Claude Code](https://claude.com/claude-code)