### PR TITLE
Add bookmarkable anchor IDs to project page sections

### DIFF
--- a/ui/app/main.py
+++ b/ui/app/main.py
@@ -120,6 +120,20 @@ templates.env.filters["mdi"] = markdown_inline_filter  # Alias
 templates.env.filters["strip_images"] = strip_images_filter
 
 
+def slugify_filter(text: str) -> str:
+    """Convert text to a URL-friendly slug for anchor IDs."""
+    if not text:
+        return ""
+    import re
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "-", text)
+    return text
+
+
+templates.env.filters["slugify"] = slugify_filter
+
+
 def get_repo_data(request: Request):
     """Get repository data from app state."""
     return request.app.state.repo_data

--- a/ui/app/templates/projects/detail.html
+++ b/ui/app/templates/projects/detail.html
@@ -54,7 +54,7 @@
 
 <!-- Research Question -->
 <section class="section">
-    <h2>Research Question</h2>
+    <h2 id="research-question">Research Question</h2>
     <div class="page-description markdown-content">{{ project.research_question | markdown }}</div>
 </section>
 
@@ -88,7 +88,7 @@
 <!-- Overview (from README) -->
 {% if project.overview %}
 <section class="section">
-    <h2>Overview</h2>
+    <h2 id="overview">Overview</h2>
     <div class="card markdown-content">
         {{ project.overview | markdown }}
     </div>
@@ -102,7 +102,7 @@
 
 <!-- Key Findings (from REPORT.md) -->
 <section class="section">
-    <h2>Key Findings</h2>
+    <h2 id="key-findings">Key Findings</h2>
     <div class="card markdown-content" style="border-left: 4px solid var(--accent-primary);">
         {{ project.findings | markdown }}
     </div>
@@ -111,7 +111,7 @@
 <!-- Results (from REPORT.md) -->
 {% if project.results %}
 <section class="section">
-    <h2>Results</h2>
+    <h2 id="results">Results</h2>
     <div class="card markdown-content">
         {{ project.results | markdown }}
     </div>
@@ -121,7 +121,7 @@
 <!-- Interpretation (from REPORT.md) -->
 {% if project.interpretation %}
 <section class="section">
-    <h2>Interpretation</h2>
+    <h2 id="interpretation">Interpretation</h2>
     <div class="card markdown-content">
         {{ project.interpretation | markdown }}
     </div>
@@ -131,7 +131,7 @@
 <!-- Future Directions (from REPORT.md) -->
 {% if project.future_directions %}
 <section class="section">
-    <h2>Future Directions</h2>
+    <h2 id="future-directions">Future Directions</h2>
     <div class="card markdown-content">
         {{ project.future_directions | markdown }}
     </div>
@@ -141,7 +141,7 @@
 <!-- Data (from REPORT.md) -->
 {% if project.data_section %}
 <section class="section">
-    <h2>Data</h2>
+    <h2 id="data">Data</h2>
     <div class="card markdown-content">
         {{ project.data_section | markdown }}
     </div>
@@ -151,7 +151,7 @@
 <!-- References (from REPORT.md) -->
 {% if project.references %}
 <section class="section">
-    <h2>References</h2>
+    <h2 id="references">References</h2>
     <div class="card markdown-content">
         {{ project.references | markdown }}
     </div>
@@ -162,7 +162,7 @@
 {% if project.other_sections %}
 {% for section_name, section_content in project.other_sections %}
 <section class="section">
-    <h2>{{ section_name }}</h2>
+    <h2 id="{{ section_name | slugify }}">{{ section_name }}</h2>
     <div class="card markdown-content">
         {{ section_content | markdown }}
     </div>
@@ -173,7 +173,7 @@
 {% elif project.findings and 'to be filled' not in project.findings.lower() %}
 {# === IN-PROGRESS or PROPOSED with partial findings === #}
 <section class="section">
-    <h2>Key Findings</h2>
+    <h2 id="key-findings">Key Findings</h2>
     <div class="card markdown-content" style="border-left: 4px solid var(--accent-primary);">
         {{ project.findings | markdown }}
     </div>
@@ -185,7 +185,7 @@
 <!-- Discoveries -->
 {% if project_discoveries %}
 <section class="section">
-    <h2>Discoveries</h2>
+    <h2 id="discoveries">Discoveries</h2>
     {% for discovery in project_discoveries %}
     <div class="card" style="margin-bottom: var(--space-4);">
         <div class="card-header">
@@ -209,7 +209,7 @@
 <!-- Data Collections -->
 {% if project_collections %}
 <section class="section">
-    <h2>Data Collections</h2>
+    <h2 id="data-collections">Data Collections</h2>
     <div class="grid grid-3">
         {% for coll in project_collections %}
         <a href="/collections/{{ coll.id }}" class="card" style="text-decoration: none;">
@@ -229,7 +229,7 @@
 </section>
 {% elif project.related_collections %}
 <section class="section">
-    <h2>Data Collections</h2>
+    <h2 id="data-collections">Data Collections</h2>
     <div class="grid grid-3">
         {% for coll_id in project.related_collections %}
         <a href="/collections/{{ coll_id }}" class="card" style="text-decoration: none;">
@@ -244,7 +244,7 @@
 <!-- Review -->
 {% if project.review %}
 <section class="section">
-    <h2>Review</h2>
+    <h2 id="review">Review</h2>
     <div class="review-banner">
         <div class="flex items-center gap-4" style="flex-wrap: wrap;">
             <span class="review-ai-label">AI Review</span>
@@ -304,7 +304,7 @@
 <!-- Visualizations -->
 {% if project.visualizations %}
 <section class="section">
-    <h2>Visualizations</h2>
+    <h2 id="visualizations">Visualizations</h2>
     <div class="grid grid-3">
         {% for viz in project.visualizations %}
         <div class="card" style="padding: var(--space-3);">
@@ -324,7 +324,7 @@
 <!-- Notebooks -->
 {% if project.notebooks %}
 <section class="section">
-    <h2>Notebooks</h2>
+    <h2 id="notebooks">Notebooks</h2>
     <div class="grid grid-2">
         {% for notebook in project.notebooks %}
         <a href="/projects/{{ project.id }}/notebooks/{{ notebook.filename }}" class="card" style="text-decoration: none;">
@@ -347,7 +347,7 @@
 <!-- Data Files -->
 {% if project.data_files %}
 <section class="section">
-    <h2>Data Files</h2>
+    <h2 id="data-files">Data Files</h2>
     <table class="data-table">
         <thead>
             <tr>


### PR DESCRIPTION
## Summary

- Add `id` attributes to all `<h2>` sections on project detail pages
- Add `slugify` Jinja filter for dynamic section names (catchall sections)
- Enables direct linking like `/projects/metal_fitness_atlas#suggested-experiments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)