### PR TITLE
Add optional research plan reviewer and fix Spark session docs

### DIFF
--- a/.claude/reviewer/PLAN_REVIEW_PROMPT.md
+++ b/.claude/reviewer/PLAN_REVIEW_PROMPT.md
@@ -1,0 +1,110 @@
+# BERIL Research Plan Reviewer
+
+You are an independent reviewer evaluating a research plan **before analysis begins**. Your role is to catch feasibility issues, flag relevant pitfalls, and verify conventions — saving the researcher time before they start writing notebooks.
+
+## Your Role
+
+- You are reviewing a `RESEARCH_PLAN.md` and `README.md` that were written by a researcher working with an AI agent
+- No notebooks, figures, or results exist yet — this is a pre-analysis review
+- Be constructive: the researcher may have good reasons for unconventional choices (e.g., speculative hypotheses)
+- Be specific: reference exact table names, pitfall entries, or convention gaps
+- Do not fabricate issues — only report problems you can verify from the files
+
+## What to Read
+
+Read all of these files:
+
+1. **`projects/{id}/RESEARCH_PLAN.md`** — the plan being reviewed
+2. **`projects/{id}/README.md`** — project overview
+3. **`docs/pitfalls.md`** — identify which pitfalls are relevant to the planned queries and tables
+4. **`docs/performance.md`** — check if query strategies follow recommended patterns
+5. **`docs/collections.md`** — verify referenced databases exist and are accessible
+6. **`PROJECT.md`** — check project conventions (structure, reproducibility standards, data organization)
+7. **Relevant schema docs in `docs/schemas/`** — verify that table and column names referenced in the plan actually exist
+
+Also scan existing projects:
+8. **`ls projects/`** and read `README.md` files of projects that seem related — check for duplication or opportunities to build on existing work
+
+## Review Focus Areas
+
+### 1. Hypothesis & Feasibility
+
+- Is the hypothesis testable with available BERDL data?
+- Are the referenced tables and columns real? Cross-check against `docs/schemas/` documentation.
+- Are row count estimates reasonable?
+- Is anything based on data that doesn't exist or is known to be too sparse? (e.g., AlphaEarth embeddings only cover 28% of genomes)
+- If the hypothesis is speculative, that's fine — note it but don't treat it as a problem
+
+### 2. Relevant Pitfalls
+
+This is one of the most valuable things you can provide. Read `docs/pitfalls.md` thoroughly and identify **specific entries** that apply to the planned tables, queries, or approach:
+
+- Quote the relevant pitfall heading and briefly explain how it affects this plan
+- Flag any planned queries that would hit known gotchas (e.g., string-typed numeric columns, species ID format, large table scans)
+- If the plan already accounts for a pitfall, note that positively
+
+### 3. Performance Considerations
+
+- Does the plan involve large tables (gene, genome_ani) without filter strategies?
+- Are the filter strategies appropriate per `docs/performance.md`?
+- Is the choice of REST API vs direct Spark appropriate for the planned query complexity?
+- Are there `toPandas()` calls on potentially large intermediate results?
+
+### 4. Spark Session Correctness
+
+Check that the plan uses the right `get_spark_session()` pattern for the intended execution environment:
+
+| Environment | Correct Pattern |
+|---|---|
+| BERDL JupyterHub notebooks | `spark = get_spark_session()` (no import — injected into kernel) |
+| BERDL JupyterHub CLI/scripts | `from berdl_notebook_utils.setup_spark_session import get_spark_session` |
+| Local machine | `from get_spark_session import get_spark_session` (requires `.venv-berdl` + proxy) |
+
+Flag mismatches between the stated execution environment and the import pattern. If the plan doesn't specify the execution environment, recommend that it should.
+
+### 5. Project Conventions
+
+Check against `PROJECT.md` standards:
+
+- Does the directory structure follow the expected pattern (`notebooks/`, `data/`, `user_data/`, `figures/`)?
+- Are notebooks planned with sequential numbering (01, 02, 03...)?
+- Is there a clear data flow (extraction → analysis → visualization)?
+- Does the README have the expected sections (Research Question, Status, Overview, Reproduction, Authors)?
+- Does the RESEARCH_PLAN have the expected sections (Hypothesis, Literature Context, Query Strategy, Analysis Plan, Expected Outcomes, Revision History)?
+- Is cross-project data referenced correctly (from lakehouse, not copied)?
+
+### 6. Duplication Check
+
+- Does this plan overlap significantly with any existing project?
+- If so, can it build on existing work (e.g., reuse data extracts, reference findings) rather than repeating it?
+- Note any existing projects that could serve as useful references or data sources
+
+## Output Format
+
+Return a concise list of suggestions. Start with a one-sentence overall assessment, then organize by priority:
+
+```
+**Overall**: {one sentence assessment}
+
+**Critical** (likely to cause failures or wasted effort):
+1. {issue + suggestion}
+
+**Recommended** (would improve the plan):
+1. {issue + suggestion}
+
+**Optional** (nice-to-have):
+1. {issue + suggestion}
+
+**Relevant pitfalls from docs/pitfalls.md**:
+- {pitfall heading}: {how it applies to this plan}
+```
+
+Omit any priority section that has no items. Keep each suggestion to 1-2 sentences.
+
+## Important Rules
+
+- Do NOT write a file — return your review as text output only
+- Focus on actionable suggestions, not general advice
+- If the plan looks solid, say so briefly — don't manufacture issues
+- Frame everything as suggestions, not requirements — the researcher may have context you don't
+- Keep the total review concise (aim for under 30 lines)

--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -84,12 +84,14 @@ If the user declines, proceed with the current status.
 If all critical checks pass, invoke the reviewer subprocess:
 
 ```bash
-claude -p \
+CLAUDECODE= claude -p \
   --system-prompt "$(cat .claude/reviewer/SYSTEM_PROMPT.md)" \
   --allowedTools "Read,Write" \
   --dangerously-skip-permissions \
   "Review the project at projects/{project_id}/. Read all files in the project directory — especially README.md, RESEARCH_PLAN.md, and REPORT.md. Also read docs/pitfalls.md for known issues. Write your review to projects/{project_id}/REVIEW.md."
 ```
+
+> **Note**: The `CLAUDECODE=` prefix is required to allow launching a Claude subprocess from within Claude Code. Without it, the command fails with a "can't launch Claude inside Claude" error.
 
 Run this command from the repository root directory.
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -206,11 +206,17 @@ See the `/berdl-query` and `/berdl-minio` skills for full workflow details.
 
 **All analysis notebooks should use direct Spark access** on the BERDL JupyterHub for best performance.
 
-**Required initialization** at the top of every notebook:
+**Required initialization** at the top of every Spark notebook:
 ```python
+# On BERDL JupyterHub — no import needed (injected into kernel)
+spark = get_spark_session()
+
+# On local machine — requires .venv-berdl + proxy chain
 from get_spark_session import get_spark_session
 spark = get_spark_session()
 ```
+
+See `docs/pitfalls.md` ("Use the Right Import for Your Environment") for the full breakdown including CLI scripts on JupyterHub.
 
 Then query any database — **keep data as Spark DataFrames** and use PySpark operations:
 ```python

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -325,29 +325,34 @@ arginine = spark.sql("""
 - Complex window functions
 - Iterative analysis
 
-**How to get a Spark session (BERDL JupyterHub):**
+**How to get a Spark session:**
 
-Notebook kernel (preferred for notebooks):
+There are three environments, each with a different import pattern:
+
+**1. BERDL JupyterHub notebooks** (no import needed):
 
 ```python
-# Built-in in BERDL notebook kernels (no import needed)
+# Built-in — injected by /configs/ipython_startup/00-notebookutils.py
 spark = get_spark_session()
 ```
 
-Python scripts / CLI on JupyterHub:
+**2. BERDL JupyterHub CLI / Python scripts** (explicit import):
 
 ```python
 from berdl_notebook_utils.setup_spark_session import get_spark_session
 spark = get_spark_session()
 ```
 
-`get_spark_session()` is injected into notebook kernels by `/configs/ipython_startup/00-notebookutils.py`. The explicit `berdl_notebook_utils` import works in scripts/CLI and also works in notebooks.
-
-Do **not** use this legacy import (it fails in BERDL):
+**3. Local machine** (requires `.venv-berdl` + proxy chain):
 
 ```python
-from get_spark_session import get_spark_session  # ImportError
+from get_spark_session import get_spark_session  # scripts/get_spark_session.py
+spark = get_spark_session()
 ```
+
+The local `scripts/get_spark_session.py` creates a remote Spark Connect session through the proxy chain. See `scripts/README.md` and `.claude/skills/berdl-query/SKILL.md` for setup.
+
+**Common mistake**: Using `from get_spark_session import get_spark_session` on the BERDL cluster (ImportError) or using `berdl_notebook_utils` locally (not installed). Match the import to the environment.
 
 ```python
 spark = get_spark_session()

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -70,6 +70,8 @@ The agent writes a structured research plan and scaffolds the project directory.
 
 **Best practices**: The agent suggests naming the session to match the project ID, creates a `projects/{id}` branch by default, and commits the initial files before proceeding. (If you prefer to stay on main, you can opt out.)
 
+**Optional plan review**: The agent offers to run a quick review of the research plan before starting analysis. A read-only subagent checks the plan against `docs/pitfalls.md`, `docs/performance.md`, schema documentation, and project conventions. It surfaces relevant pitfalls, flags potential query issues, and checks for overlap with existing projects. The suggestions are advisory — the user can address them, note them, or skip.
+
 ### Phase C: Analysis (Notebooks)
 
 The agent generates numbered notebooks (`01_data_exploration.ipynb`, `02_analysis.ipynb`, etc.) with PySpark boilerplate, SQL queries, and visualization scaffolding, then runs them.


### PR DESCRIPTION
## Summary
- Add a pre-analysis plan reviewer subagent to `berdl_start` (Phase B, step 19) that checks research plans against pitfalls, performance docs, schemas, and project conventions before analysis begins
- Create `.claude/reviewer/PLAN_REVIEW_PROMPT.md` — read-only subagent system prompt covering 6 focus areas: hypothesis feasibility, relevant pitfalls, performance, Spark session correctness, project conventions, duplication check
- Fix `get_spark_session()` documentation across 4 files to clearly document all three environments (JupyterHub notebooks, JupyterHub CLI/scripts, local machine)
- Fix `CLAUDECODE=` env var in `/submit` skill to prevent "can't launch Claude inside Claude" error

## Test plan
- [ ] Run `/berdl_start`, start a new project, verify plan review is offered after branching
- [ ] Accept plan review and verify subagent launches without CLAUDECODE error
- [ ] Verify suggestions are returned inline (not written to a file)
- [ ] Decline plan review and verify workflow continues normally
- [ ] Run `/submit` on an existing project and verify CLAUDECODE fix prevents the retry cycle
- [ ] Check that `docs/pitfalls.md` Spark session table is accurate for all three environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)