### PR TITLE
Fix missing figures: include projects/ and docs/ in image build triggers

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'ui/**'
+      - 'projects/**'
+      - 'docs/**'
       - 'Dockerfile'
       - '.github/workflows/build-image.yml'
   pull_request:
@@ -13,6 +15,8 @@ on:
       - main
     paths:
       - 'ui/**'
+      - 'projects/**'
+      - 'docs/**'
       - 'Dockerfile'
       - '.github/workflows/build-image.yml'
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- The `build-image.yml` workflow only triggered on `ui/**`, `Dockerfile`, and workflow file changes
- When new projects with figures were committed to `main`, the data-cache pickle updated (referencing the new figures), but the Docker image was **not rebuilt**
- This caused 404s for figure images on 4 projects: `adp1_triple_essentiality`, `adp1_deletion_phenotypes`, `aromatic_catabolism_network`, `respiratory_chain_wiring`
- Fix: add `projects/**` and `docs/**` to the paths filter so the image rebuilds when project content changes

## Test plan
- [ ] Merge this PR — the workflow file change itself will trigger an image build
- [ ] After deploy, verify figures load on the 4 affected project pages
- [ ] Confirm future project-only commits trigger image rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)