### PR TITLE
Add collapse toggle to Key Findings section

### DIFF
--- a/ui/app/static/css/main.css
+++ b/ui/app/static/css/main.css
@@ -1303,3 +1303,38 @@ pre code {
 .lightbox-trigger {
   cursor: pointer;
 }
+
+/* Collapsible section toggle */
+.collapse-toggle {
+  background: none;
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 2px 6px;
+  line-height: 1;
+  transition: color 0.15s ease, border-color 0.15s ease, transform 0.2s ease;
+}
+
+.collapse-toggle:hover {
+  color: var(--text-primary);
+  border-color: var(--surface-border-light);
+}
+
+.collapse-toggle.collapsed {
+  transform: rotate(180deg);
+}
+
+.collapsible-section.collapsed > *:not(h3):not(h4):not(h5) {
+  display: none;
+}
+
+.collapsible-section.collapsed > h3,
+.collapsible-section.collapsed > h4,
+.collapsible-section.collapsed > h5 {
+  margin-bottom: var(--space-1);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--surface-border);
+  cursor: default;
+}

--- a/ui/app/templates/base.html
+++ b/ui/app/templates/base.html
@@ -153,6 +153,17 @@
             });
         })();
 
+        // Collapsible sections
+        document.querySelectorAll('.collapse-toggle').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                var section = this.closest('.section').querySelector('.collapsible-section');
+                if (section) {
+                    section.classList.toggle('collapsed');
+                    this.classList.toggle('collapsed');
+                }
+            });
+        });
+
         // Anchor links on headings
         document.querySelectorAll('.section h2[id]').forEach(function(h2) {
             h2.addEventListener('click', function() {

--- a/ui/app/templates/projects/detail.html
+++ b/ui/app/templates/projects/detail.html
@@ -102,8 +102,11 @@
 
 <!-- Key Findings (from REPORT.md) -->
 <section class="section">
-    <h2 id="key-findings">Key Findings</h2>
-    <div class="card markdown-content" style="border-left: 4px solid var(--accent-primary);">
+    <div class="flex items-center gap-4">
+        <h2 id="key-findings" style="margin-bottom: 0;">Key Findings</h2>
+        <button class="collapse-toggle" aria-label="Collapse findings" title="Toggle details">&#9650;</button>
+    </div>
+    <div class="card markdown-content collapsible-section" style="border-left: 4px solid var(--accent-primary); margin-top: var(--space-4);">
         {{ project.findings | markdown }}
     </div>
 </section>
@@ -173,8 +176,11 @@
 {% elif project.findings and 'to be filled' not in project.findings.lower() %}
 {# === IN-PROGRESS or PROPOSED with partial findings === #}
 <section class="section">
-    <h2 id="key-findings">Key Findings</h2>
-    <div class="card markdown-content" style="border-left: 4px solid var(--accent-primary);">
+    <div class="flex items-center gap-4">
+        <h2 id="key-findings" style="margin-bottom: 0;">Key Findings</h2>
+        <button class="collapse-toggle" aria-label="Collapse findings" title="Toggle details">&#9650;</button>
+    </div>
+    <div class="card markdown-content collapsible-section" style="border-left: 4px solid var(--accent-primary); margin-top: var(--space-4);">
         {{ project.findings | markdown }}
     </div>
 </section>


### PR DESCRIPTION
## Summary
- Adds a small toggle button next to the "Key Findings" heading on project detail pages
- Default state is expanded (all content visible)
- Clicking the toggle collapses the section to show only sub-headings (h3/h4/h5), hiding paragraphs, images, lists, etc.
- Click again to re-expand

## Test plan
- [ ] Visit any completed project page (e.g. `/projects/conservation_vs_fitness`)
- [ ] Verify the toggle button appears next to "Key Findings"
- [ ] Click it — content collapses to sub-headings only
- [ ] Click again — content re-expands

🤖 Generated with [Claude Code](https://claude.com/claude-code)