### PR TITLE
Fix project sorting and add search to projects page

### DIFF
--- a/.github/workflows/build-data-cache.yml
+++ b/.github/workflows/build-data-cache.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/ui/app/static/css/main.css
+++ b/ui/app/static/css/main.css
@@ -369,6 +369,28 @@ a:hover {
   border-color: var(--accent-primary-muted);
 }
 
+.search-input {
+  margin-left: auto;
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--surface-border);
+  background: var(--surface-raised);
+  color: var(--text-primary);
+  min-width: 200px;
+  transition: border-color 0.15s ease;
+}
+
+.search-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--accent-primary-muted);
+}
+
 /* ============================================
    Cards
    ============================================ */

--- a/ui/app/templates/projects/list.html
+++ b/ui/app/templates/projects/list.html
@@ -16,11 +16,14 @@
     <a href="?sort=recent" class="sort-option {% if current_sort == 'recent' %}active{% endif %}">Recent Activity</a>
     <a href="?sort=status" class="sort-option {% if current_sort == 'status' %}active{% endif %}">Status</a>
     <a href="?sort=alpha" class="sort-option {% if current_sort == 'alpha' %}active{% endif %}">Alphabetical</a>
+    <input type="text" id="project-search" class="search-input" placeholder="Search projects..." aria-label="Search projects">
 </div>
 
-<div class="grid grid-2">
+<p id="no-search-results" class="text-muted" style="display: none;">No projects match your search.</p>
+
+<div class="grid grid-2" id="project-grid">
     {% for project in projects %}
-    <article class="card">
+    <article class="card" data-search-text="{{ project.title | lower }} {{ project.id | replace('_', ' ') }} {{ project.research_question | lower }} {{ (project.findings or '')[:500] | lower }} {{ project.status.value | lower }}">
         <div class="card-header">
             <h3 class="card-title">
                 <a href="/projects/{{ project.id }}">{{ project.title | markdown_inline }}</a>
@@ -85,4 +88,33 @@
     <p class="text-muted">No projects found.</p>
     {% endfor %}
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+(function() {
+    var input = document.getElementById('project-search');
+    var grid = document.getElementById('project-grid');
+    var noResults = document.getElementById('no-search-results');
+    if (!input || !grid) return;
+
+    var cards = grid.querySelectorAll('.card[data-search-text]');
+
+    input.addEventListener('input', function() {
+        var query = this.value.toLowerCase().trim();
+        var visible = 0;
+
+        cards.forEach(function(card) {
+            if (!query || card.getAttribute('data-search-text').indexOf(query) !== -1) {
+                card.style.display = '';
+                visible++;
+            } else {
+                card.style.display = 'none';
+            }
+        });
+
+        noResults.style.display = visible === 0 && query ? '' : 'none';
+    });
+})();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- **Sorting fix**: `build-data-cache.yml` used `fetch-depth: 1` (shallow clone), so `git log` couldn't find history for most projects. They fell back to filesystem timestamps which are all identical in CI, making "Recent Activity" sort order random. Changed to `fetch-depth: 0`.
- **Search**: Added a client-side search input to the projects listing page. Filters cards instantly by title, project ID, research question, findings text, and status. Shows "No projects match" when nothing matches.

## Test plan
- [ ] After merge, verify "Recent Activity" sort shows recently-updated projects first
- [ ] On `/projects`, type "fitness" in search — only fitness-related projects show
- [ ] Type "ADP1" — only ADP1 projects show
- [ ] Clear input — all projects reappear
- [ ] Type nonsense — "No projects match your search" message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)