### PR TITLE
Add auth helpers and GitHub repo sync (PR 3)

### DIFF
--- a/ui/app/auth.py
+++ b/ui/app/auth.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 @dataclass
@@ -28,3 +29,35 @@ def get_current_user(request: Request) -> OrcidUser | None:
         name=request.session.get("orcid_name"),
         access_token=request.session.get("orcid_access_token"),
     )
+
+
+def get_beril_user_id(request: Request) -> str | None:
+    """Return the internal BerilUser UUID from the session, or None."""
+    return request.session.get("beril_user_id")
+
+
+async def get_current_user_or_token(
+    request: Request, db: AsyncSession
+) -> "BerilUser | None":
+    """Authenticate via session cookie or Authorization: Bearer token.
+
+    Tries the session first (cheaper, no DB hit). Falls back to the Bearer
+    token in the Authorization header, which requires a DB lookup.
+    Returns the BerilUser ORM object, or None if neither method succeeds.
+    """
+    from app.db.crud import get_user_by_api_token, get_user_by_orcid
+
+    # Session path — only trust it if the orcid_id still resolves in the DB
+    orcid_id = request.session.get("orcid_id")
+    if orcid_id:
+        user = await get_user_by_orcid(db, orcid_id)
+        if user is not None:
+            return user
+
+    # Bearer token path — scheme is case-insensitive per HTTP spec
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        raw_token = auth_header[len("bearer "):]
+        return await get_user_by_api_token(db, raw_token)
+
+    return None

--- a/ui/app/db/crud.py
+++ b/ui/app/db/crud.py
@@ -91,6 +91,7 @@ async def create_project_file(
     title: str | None = None,
     description: str | None = None,
     is_public: bool = False,
+    source: str = "upload",
 ) -> ProjectFile:
     f = ProjectFile(
         project_id=project_id,
@@ -102,6 +103,7 @@ async def create_project_file(
         title=title,
         description=description,
         is_public=is_public,
+        source=source,
     )
     db.add(f)
     await db.commit()
@@ -112,6 +114,19 @@ async def create_project_file(
 async def get_files_for_project(db: AsyncSession, project_id: str) -> list[ProjectFile]:
     result = await db.execute(
         select(ProjectFile).where(ProjectFile.project_id == project_id)
+    )
+    return list(result.scalars().all())
+
+
+async def get_github_files_for_project(
+    db: AsyncSession, project_id: str
+) -> list[ProjectFile]:
+    """Return only files synced from GitHub (source='github') for the given project."""
+    result = await db.execute(
+        select(ProjectFile).where(
+            ProjectFile.project_id == project_id,
+            ProjectFile.source == "github",
+        )
     )
     return list(result.scalars().all())
 

--- a/ui/app/db/models.py
+++ b/ui/app/db/models.py
@@ -131,6 +131,12 @@ class ProjectFile(Base):
     title: Mapped[str | None] = mapped_column(Text, nullable=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_public: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    # "upload" for manually uploaded files, "github" for files synced from a repo
+    source: Mapped[str] = mapped_column(
+        Enum("upload", "github", name="file_source"),
+        default="upload",
+        nullable=False,
+    )
     uploaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now, onupdate=_now)
 

--- a/ui/app/github_sync.py
+++ b/ui/app/github_sync.py
@@ -1,0 +1,217 @@
+"""GitHub repository sync for user projects.
+
+Pulls files from a linked GitHub repo into local project storage and upserts
+ProjectFile records in the database.
+"""
+
+import logging
+import mimetypes
+import shutil
+import subprocess
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.crud import create_project_file, delete_project_file, get_github_files_for_project
+from app.db.models import ProjectFile, UserProject
+from app.git_data_sync import _git_clone, _git_lock, _git_pull
+from app.storage import LocalFileStorage
+
+logger = logging.getLogger(__name__)
+
+# Files and directories to skip when syncing from a repo
+_SKIP_NAMES = {".git", ".github", "__pycache__", ".DS_Store"}
+
+# stderr substrings that indicate a missing branch (as opposed to a transient error)
+_BRANCH_NOT_FOUND_HINTS = (
+    "couldn't find remote ref",
+    "remote ref does not exist",
+    "pathspec",
+    "invalid reference",
+    "error: branch",
+)
+
+
+def _is_branch_error(exc: BaseException) -> bool:
+    """Return True if *exc* looks like a 'branch not found' git error."""
+    if not isinstance(exc, subprocess.CalledProcessError):
+        return False
+    stderr = (exc.stderr or b"").decode().lower()
+    return any(hint in stderr for hint in _BRANCH_NOT_FOUND_HINTS)
+
+
+# Only these two branches have an automatic fallback; any other branch name
+# must fail explicitly so the caller is not silently served the wrong content.
+_FALLBACK_PAIRS: dict[str, str] = {"main": "master", "master": "main"}
+
+
+def _fallback_branch(branch: str) -> str | None:
+    """Return the fallback branch for *branch*, or None if no fallback applies."""
+    return _FALLBACK_PAIRS.get(branch)
+
+
+async def sync_github_repo(
+    repo_url: str,
+    project: UserProject,
+    storage: LocalFileStorage,
+    db: AsyncSession,
+    branch: str = "main",
+) -> list[ProjectFile]:
+    """Pull files from a GitHub repo into project storage and sync DB records.
+
+    Shallow-clones or pulls `repo_url` into a cache directory under the
+    project's storage path, then copies non-hidden files into the project
+    storage area and upserts `ProjectFile` records.
+
+    Args:
+        repo_url: HTTPS or SSH GitHub repo URL.
+        project: The owning UserProject (needs owner_id and slug).
+        storage: LocalFileStorage rooted at user_projects_root.
+        db: Async database session.
+        branch: Branch to sync. Tries "main", falls back to "master" if clone fails.
+
+    Returns:
+        List of upserted ProjectFile records.
+    """
+    owner_id, slug = project.filesystem_path_parts
+    cache_rel = f"{owner_id}/{slug}/.git_cache"
+    cache_path = storage.root / cache_rel
+
+    # Clone or pull into the cache directory
+    await _ensure_repo(repo_url, branch, cache_path)
+
+    # Only consider files previously synced from GitHub; manually uploaded files
+    # are untouched even if they share the same project.
+    existing = {f.filename: f for f in await get_github_files_for_project(db, project.id)}
+    repo_filenames: set[str] = set()
+
+    synced: list[ProjectFile] = []
+    for src in _iter_files(cache_path):
+        # Preserve subdirectory structure relative to the repo root.
+        # e.g. notebooks/analysis.ipynb → filename "notebooks/analysis.ipynb"
+        rel_path = src.relative_to(cache_path)
+        filename = str(rel_path)  # used as the stable key in DB
+        repo_filenames.add(filename)
+        # Store under a "github/" namespace so GitHub blobs never collide with
+        # manually uploaded files in the same project storage area.
+        dest_rel = f"{owner_id}/{slug}/github/{filename}"
+
+        data = src.read_bytes()
+        size = await storage.save(data, dest_rel)
+
+        content_type, _ = mimetypes.guess_type(src.name)
+        file_type = _infer_file_type(src.name)
+
+        if filename in existing:
+            record = existing[filename]
+            record.storage_path = dest_rel
+            record.size_bytes = size
+            record.content_type = content_type
+            await db.commit()
+            await db.refresh(record)
+        else:
+            record = await create_project_file(
+                db,
+                project_id=project.id,
+                file_type=file_type,
+                filename=filename,
+                storage_path=dest_rel,
+                size_bytes=size,
+                content_type=content_type,
+                source="github",
+            )
+
+        synced.append(record)
+        logger.debug("Synced %s → %s", filename, dest_rel)
+
+    # Remove DB records and storage blobs for files deleted from the repo
+    for filename, record in existing.items():
+        if filename not in repo_filenames:
+            await storage.delete(record.storage_path)
+            await delete_project_file(db, record.id)
+            logger.debug("Removed deleted file %s", filename)
+
+    logger.info("Synced %d file(s) from %s for project %s", len(synced), repo_url, project.id)
+    return synced
+
+
+async def _ensure_repo(repo_url: str, branch: str, local_path: Path) -> None:
+    """Clone the repo if it doesn't exist, otherwise pull. Falls back main→master.
+
+    Holds _git_lock for the duration to prevent concurrent operations on the
+    same cache directory.
+    """
+    async with _git_lock:
+        if local_path.exists() and (local_path / ".git").exists():
+            try:
+                await _git_pull(local_path, branch)
+                return
+            except Exception as exc:
+                if not _is_branch_error(exc):
+                    # Transient error (network, auth, disk) — do not silently switch
+                    # branches; re-raise so the caller can handle or retry.
+                    raise
+                fallback = _fallback_branch(branch)
+                if fallback is None:
+                    # Non-main/master branch with no automatic fallback — re-raise.
+                    raise
+                # The branch is missing from the single-branch cache; delete and
+                # reclone on the fallback branch.
+                logger.warning(
+                    "Pull on branch %r failed (branch not found), recloning on %r",
+                    branch,
+                    fallback,
+                )
+                shutil.rmtree(local_path)
+                await _git_clone(repo_url, fallback, local_path)
+                return
+
+        # Clean up any stale/partial directory before cloning
+        if local_path.exists():
+            shutil.rmtree(local_path)
+
+        try:
+            await _git_clone(repo_url, branch, local_path)
+        except Exception as exc:
+            # Only fall back if the branch genuinely doesn't exist; re-raise
+            # for transient errors so the caller sees the real failure.
+            if not _is_branch_error(exc):
+                raise
+            fallback = _fallback_branch(branch)
+            if fallback is None:
+                # Non-main/master branch — no automatic fallback, re-raise.
+                raise
+            if local_path.exists():
+                shutil.rmtree(local_path)
+            logger.warning("Clone of branch %r failed (branch not found), trying %r", branch, fallback)
+            await _git_clone(repo_url, fallback, local_path)
+
+
+def _iter_files(repo_path: Path):
+    """Yield all non-hidden, non-skipped regular files recursively under repo_path.
+
+    Symlinks are always skipped — a malicious repo could point a symlink at
+    an arbitrary host path (e.g. /etc/passwd), so we never follow them.
+    """
+    for entry in repo_path.iterdir():
+        if entry.name in _SKIP_NAMES or entry.name.startswith("."):
+            continue
+        if entry.is_symlink():
+            logger.warning("Skipping symlink in repo: %s", entry)
+            continue
+        if entry.is_dir():
+            yield from _iter_files(entry)
+        elif entry.is_file():
+            yield entry
+
+
+def _infer_file_type(filename: str) -> str:
+    """Map a filename to a ProjectFile file_type enum value."""
+    ext = Path(filename).suffix.lower()
+    if ext == ".ipynb":
+        return "notebook"
+    if ext in {".md", ".rst", ".txt"} and "readme" in filename.lower():
+        return "readme"
+    if ext in {".html", ".png", ".jpg", ".jpeg", ".svg", ".pdf"}:
+        return "visualization"
+    return "data"

--- a/ui/tests/test_auth.py
+++ b/ui/tests/test_auth.py
@@ -340,3 +340,141 @@ class TestCallbackDbIntegration:
 
         user = await get_user_by_orcid(db_session, "0000-0001-2345-6789")
         assert user is None
+
+
+# ---------------------------------------------------------------------------
+# get_beril_user_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetBerilUserId:
+    def test_returns_none_when_no_session(self):
+        from app.auth import get_beril_user_id
+        request = MagicMock()
+        request.session = {}
+        assert get_beril_user_id(request) is None
+
+    def test_returns_id_from_session(self):
+        from app.auth import get_beril_user_id
+        request = MagicMock()
+        request.session = {"beril_user_id": "abc-123"}
+        assert get_beril_user_id(request) == "abc-123"
+
+
+# ---------------------------------------------------------------------------
+# get_current_user_or_token
+# ---------------------------------------------------------------------------
+
+
+class TestGetCurrentUserOrToken:
+    async def test_returns_none_when_no_auth(self, db_session):
+        from app.auth import get_current_user_or_token
+        request = MagicMock()
+        request.session = {}
+        request.headers = {}
+        result = await get_current_user_or_token(request, db_session)
+        assert result is None
+
+    async def test_returns_user_from_session(self, db_session):
+        from app.auth import get_current_user_or_token
+        from app.db.models import BerilUser
+
+        user = BerilUser(orcid_id="0000-0001-2345-6789")
+        db_session.add(user)
+        await db_session.commit()
+
+        request = MagicMock()
+        request.session = {"orcid_id": "0000-0001-2345-6789"}
+        request.headers = {}
+        result = await get_current_user_or_token(request, db_session)
+        assert result is not None
+        assert result.orcid_id == "0000-0001-2345-6789"
+
+    async def test_returns_user_from_bearer_token(self, db_session):
+        from app.auth import get_current_user_or_token
+        from app.db.crud import get_or_create_api_token
+        from app.db.models import BerilUser
+
+        user = BerilUser(orcid_id="0000-0001-2345-6789")
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        raw_token, _ = await get_or_create_api_token(db_session, user.id)
+
+        request = MagicMock()
+        request.session = {}
+        request.headers = {"Authorization": f"Bearer {raw_token}"}
+        result = await get_current_user_or_token(request, db_session)
+        assert result is not None
+        assert result.id == user.id
+
+    async def test_session_takes_priority_over_bearer(self, db_session):
+        from app.auth import get_current_user_or_token
+        from app.db.crud import get_or_create_api_token
+        from app.db.models import BerilUser
+
+        user_a = BerilUser(orcid_id="0000-0001-0001-0001")
+        user_b = BerilUser(orcid_id="0000-0001-0002-0002")
+        db_session.add_all([user_a, user_b])
+        await db_session.commit()
+        await db_session.refresh(user_a)
+        await db_session.refresh(user_b)
+
+        raw_token, _ = await get_or_create_api_token(db_session, user_b.id)
+
+        request = MagicMock()
+        request.session = {"orcid_id": "0000-0001-0001-0001"}
+        request.headers = {"Authorization": f"Bearer {raw_token}"}
+        result = await get_current_user_or_token(request, db_session)
+        assert result is not None
+        assert result.id == user_a.id
+
+    async def test_bad_bearer_token_returns_none(self, db_session):
+        from app.auth import get_current_user_or_token
+        request = MagicMock()
+        request.session = {}
+        request.headers = {"Authorization": "Bearer not-a-real-token"}
+        result = await get_current_user_or_token(request, db_session)
+        assert result is None
+
+    async def test_bearer_token_case_insensitive(self, db_session):
+        """Authorization: bearer <token> (lowercase) should be accepted."""
+        from app.auth import get_current_user_or_token
+        from app.db.crud import get_or_create_api_token
+        from app.db.models import BerilUser
+
+        user = BerilUser(orcid_id="0000-0001-9999-9999")
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        raw_token, _ = await get_or_create_api_token(db_session, user.id)
+
+        request = MagicMock()
+        request.session = {}
+        request.headers = {"Authorization": f"bearer {raw_token}"}
+        result = await get_current_user_or_token(request, db_session)
+        assert result is not None
+        assert result.id == user.id
+
+    async def test_stale_session_falls_back_to_bearer(self, db_session):
+        """If the session orcid_id no longer resolves, bearer token is still honoured."""
+        from app.auth import get_current_user_or_token
+        from app.db.crud import get_or_create_api_token
+        from app.db.models import BerilUser
+
+        user = BerilUser(orcid_id="0000-0001-2345-6789")
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        raw_token, _ = await get_or_create_api_token(db_session, user.id)
+
+        request = MagicMock()
+        # Session references an orcid_id that does not exist in the DB
+        request.session = {"orcid_id": "0000-0000-0000-0000"}
+        request.headers = {"Authorization": f"Bearer {raw_token}"}
+        result = await get_current_user_or_token(request, db_session)
+        assert result is not None
+        assert result.id == user.id

--- a/ui/tests/test_github_sync.py
+++ b/ui/tests/test_github_sync.py
@@ -1,0 +1,492 @@
+"""Tests for GitHub repo sync (app.github_sync)."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.db.models import BerilUser, UserProject
+from app.github_sync import _infer_file_type, _iter_files, sync_github_repo
+from app.storage import LocalFileStorage
+
+
+def _branch_error(branch: str = "main") -> subprocess.CalledProcessError:
+    """Return a CalledProcessError that looks like 'branch not found'."""
+    stderr = f"error: couldn't find remote ref {branch}".encode()
+    return subprocess.CalledProcessError(128, ["git"], b"", stderr)
+
+
+def _transient_error() -> subprocess.CalledProcessError:
+    """Return a CalledProcessError that looks like a network/auth failure."""
+    stderr = b"fatal: unable to access 'https://github.com/': Could not resolve host"
+    return subprocess.CalledProcessError(128, ["git"], b"", stderr)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def user(db_session):
+    u = BerilUser(orcid_id="0000-0001-2345-6789")
+    db_session.add(u)
+    await db_session.commit()
+    await db_session.refresh(u)
+    return u
+
+
+@pytest.fixture
+async def project(db_session, user):
+    p = UserProject(owner_id=user.id, slug="my-project", title="T", research_question="Q?")
+    db_session.add(p)
+    await db_session.commit()
+    await db_session.refresh(p)
+    return p
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return LocalFileStorage(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _infer_file_type
+# ---------------------------------------------------------------------------
+
+
+class TestInferFileType:
+    def test_notebook(self):
+        assert _infer_file_type("analysis.ipynb") == "notebook"
+
+    def test_readme_md(self):
+        assert _infer_file_type("README.md") == "readme"
+
+    def test_readme_rst(self):
+        assert _infer_file_type("README.rst") == "readme"
+
+    def test_visualization_png(self):
+        assert _infer_file_type("figure.png") == "visualization"
+
+    def test_visualization_html(self):
+        assert _infer_file_type("plot.html") == "visualization"
+
+    def test_default_is_data(self):
+        assert _infer_file_type("data.csv") == "data"
+        assert _infer_file_type("results.tsv") == "data"
+        assert _infer_file_type("unknown.xyz") == "data"
+
+
+# ---------------------------------------------------------------------------
+# _iter_files
+# ---------------------------------------------------------------------------
+
+
+class TestIterFiles:
+    def test_yields_regular_files(self, tmp_path):
+        (tmp_path / "file_a.csv").write_text("a")
+        (tmp_path / "file_b.txt").write_text("b")
+        names = {f.name for f in _iter_files(tmp_path)}
+        assert names == {"file_a.csv", "file_b.txt"}
+
+    def test_skips_git_directory(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "data.csv").write_text("x")
+        names = {f.name for f in _iter_files(tmp_path)}
+        assert ".git" not in names
+        assert "data.csv" in names
+
+    def test_skips_hidden_files(self, tmp_path):
+        (tmp_path / ".hidden").write_text("x")
+        (tmp_path / "visible.csv").write_text("y")
+        names = {f.name for f in _iter_files(tmp_path)}
+        assert ".hidden" not in names
+        assert "visible.csv" in names
+
+    def test_recurses_into_subdirectories(self, tmp_path):
+        (tmp_path / "subdir").mkdir()
+        (tmp_path / "subdir" / "nested.csv").write_text("n")
+        (tmp_path / "top.csv").write_text("t")
+        paths = list(_iter_files(tmp_path))
+        names = {f.name for f in paths}
+        assert "nested.csv" in names
+        assert "top.csv" in names
+
+    def test_skips_hidden_subdirectory(self, tmp_path):
+        (tmp_path / ".hidden_dir").mkdir()
+        (tmp_path / ".hidden_dir" / "secret.csv").write_text("s")
+        (tmp_path / "visible.csv").write_text("v")
+        names = {f.name for f in _iter_files(tmp_path)}
+        assert "secret.csv" not in names
+        assert "visible.csv" in names
+
+    def test_skips_symlinks(self, tmp_path):
+        """Symlinks are never followed to prevent host path traversal."""
+        target = tmp_path / "real_file.txt"
+        target.write_text("real")
+        link = tmp_path / "link.txt"
+        link.symlink_to(target)
+        (tmp_path / "normal.csv").write_text("n")
+        names = {f.name for f in _iter_files(tmp_path)}
+        assert "link.txt" not in names
+        assert "normal.csv" in names
+
+    def test_empty_repo(self, tmp_path):
+        assert list(_iter_files(tmp_path)) == []
+
+
+# ---------------------------------------------------------------------------
+# sync_github_repo
+# ---------------------------------------------------------------------------
+
+
+class TestSyncGithubRepo:
+    def _fake_repo(self, path: Path, files: dict[str, bytes]) -> None:
+        """Write files into a fake cloned repo directory.
+
+        Keys in *files* may include subdirectory components, e.g.
+        ``"notebooks/analysis.ipynb"``.
+        """
+        path.mkdir(parents=True, exist_ok=True)
+        (path / ".git").mkdir(exist_ok=True)
+        for name, data in files.items():
+            dest = path / name
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(data)
+
+    async def test_sync_creates_project_files(self, db_session, project, storage, tmp_path):
+        cache_path = storage.root / project.owner_id / project.slug / ".git_cache"
+        self._fake_repo(cache_path, {"data.csv": b"a,b\n1,2", "notebook.ipynb": b"{}"})
+
+        with patch("app.github_sync._ensure_repo", new_callable=AsyncMock):
+            synced = await sync_github_repo(
+                "https://github.com/org/repo", project, storage, db_session
+            )
+
+        assert len(synced) == 2
+        filenames = {f.filename for f in synced}
+        assert "data.csv" in filenames
+        assert "notebook.ipynb" in filenames
+
+    async def test_sync_writes_files_to_storage(self, db_session, project, storage):
+        cache_path = storage.root / project.owner_id / project.slug / ".git_cache"
+        self._fake_repo(cache_path, {"results.csv": b"x,y\n1,2"})
+
+        with patch("app.github_sync._ensure_repo", new_callable=AsyncMock):
+            await sync_github_repo(
+                "https://github.com/org/repo", project, storage, db_session
+            )
+
+        dest = f"{project.owner_id}/{project.slug}/github/results.csv"
+        assert storage.exists(dest)
+        assert await storage.load(dest) == b"x,y\n1,2"
+
+    async def test_sync_upserts_existing_file(self, db_session, project, storage):
+        from app.db.crud import create_project_file, get_file_by_id
+
+        # Pre-create a GitHub-synced ProjectFile record for the same filename
+        existing = await create_project_file(
+            db_session,
+            project_id=project.id,
+            file_type="data",
+            filename="data.csv",
+            storage_path=f"{project.owner_id}/{project.slug}/github/data.csv",
+            size_bytes=0,
+            source="github",
+        )
+
+        cache_path = storage.root / project.owner_id / project.slug / ".git_cache"
+        self._fake_repo(cache_path, {"data.csv": b"new,content\n"})
+
+        with patch("app.github_sync._ensure_repo", new_callable=AsyncMock):
+            synced = await sync_github_repo(
+                "https://github.com/org/repo", project, storage, db_session
+            )
+
+        assert len(synced) == 1
+        assert synced[0].id == existing.id
+        refreshed = await get_file_by_id(db_session, existing.id)
+        assert refreshed.size_bytes == len(b"new,content\n")
+
+    async def test_sync_infers_file_type(self, db_session, project, storage):
+        cache_path = storage.root / project.owner_id / project.slug / ".git_cache"
+        self._fake_repo(cache_path, {"analysis.ipynb": b"{}"})
+
+        with patch("app.github_sync._ensure_repo", new_callable=AsyncMock):
+            synced = await sync_github_repo(
+                "https://github.com/org/repo", project, storage, db_session
+            )
+
+        assert synced[0].file_type == "notebook"
+
+    async def test_sync_marks_files_as_github_source(self, db_session, project, storage):
+        cache_path = storage.root / project.owner_id / project.slug / ".git_cache"
+        self._fake_repo(cache_path, {"data.csv": b"a,b"})
+
+        with patch("app.github_sync._ensure_repo", new_callable=AsyncMock):
+            synced = await sync_github_repo(
+                "https://github.com/org/repo", project, storage, db_session
+            )
+
+        assert synced[0].source == "github"
+
+    async def test_sync_empty_repo_returns_empty(self, db_session, project, storage):
+        cache_path = storage.root / project.owner_id / project.slug / ".git_cache"
+        self._fake_repo(cache_path, {})
+
+        with patch("app.github_sync._ensure_repo", new_callable=AsyncMock):
+            synced = await sync_github_repo(
+                "https://github.com/org/repo", project, storage, db_session
+            )
+
+        assert synced == []
+
+    async def test_sync_recurses_into_subdirectories(self, db_session, project, storage):
+        """Files in subdirectories are synced with their relative path as filename."""
+        cache_path = storage.root / project.owner_id / project.slug / ".git_cache"
+        self._fake_repo(
+            cache_path,
+            {
+                "root.csv": b"root",
+                "notebooks/analysis.ipynb": b"{}",
+                "data/raw/results.csv": b"a,b",
+            },
+        )
+
+        with patch("app.github_sync._ensure_repo", new_callable=AsyncMock):
+            synced = await sync_github_repo(
+                "https://github.com/org/repo", project, storage, db_session
+            )
+
+        assert len(synced) == 3
+        filenames = {f.filename for f in synced}
+        assert "root.csv" in filenames
+        assert "notebooks/analysis.ipynb" in filenames
+        assert "data/raw/results.csv" in filenames
+
+        # Storage paths should mirror the relative structure under the github/ namespace
+        nb_dest = f"{project.owner_id}/{project.slug}/github/notebooks/analysis.ipynb"
+        assert storage.exists(nb_dest)
+
+    async def test_sync_deletes_removed_files(self, db_session, project, storage):
+        """GitHub-synced files removed from the repo should be deleted from DB and storage."""
+        from app.db.crud import create_project_file, get_file_by_id
+
+        # Pre-create a github-sourced file that no longer exists in the repo
+        old_path = f"{project.owner_id}/{project.slug}/github/old.csv"
+        await storage.save(b"old data", old_path)
+        old_record = await create_project_file(
+            db_session,
+            project_id=project.id,
+            file_type="data",
+            filename="old.csv",
+            storage_path=old_path,
+            source="github",
+        )
+
+        # Repo now only has new.csv
+        cache_path = storage.root / project.owner_id / project.slug / ".git_cache"
+        self._fake_repo(cache_path, {"new.csv": b"new,data"})
+
+        with patch("app.github_sync._ensure_repo", new_callable=AsyncMock):
+            synced = await sync_github_repo(
+                "https://github.com/org/repo", project, storage, db_session
+            )
+
+        # Only new.csv should be returned
+        assert len(synced) == 1
+        assert synced[0].filename == "new.csv"
+        # old.csv should be gone from DB and storage
+        assert await get_file_by_id(db_session, old_record.id) is None
+        assert not storage.exists(old_path)
+
+    async def test_sync_preserves_manually_uploaded_files(self, db_session, project, storage):
+        """Manually uploaded files (source='upload') must not be deleted during GitHub sync."""
+        from app.db.crud import create_project_file, get_file_by_id
+
+        # Pre-create a manually uploaded file (not from GitHub)
+        upload_path = f"{project.owner_id}/{project.slug}/manual.csv"
+        await storage.save(b"user data", upload_path)
+        upload_record = await create_project_file(
+            db_session,
+            project_id=project.id,
+            file_type="data",
+            filename="manual.csv",
+            storage_path=upload_path,
+            source="upload",  # manually uploaded, not from GitHub
+        )
+
+        # GitHub repo has only repo.csv — manual.csv is absent
+        cache_path = storage.root / project.owner_id / project.slug / ".git_cache"
+        self._fake_repo(cache_path, {"repo.csv": b"repo,data"})
+
+        with patch("app.github_sync._ensure_repo", new_callable=AsyncMock):
+            synced = await sync_github_repo(
+                "https://github.com/org/repo", project, storage, db_session
+            )
+
+        # Only repo.csv should be in the sync result
+        assert len(synced) == 1
+        assert synced[0].filename == "repo.csv"
+        # manual.csv must still exist in DB and storage
+        assert await get_file_by_id(db_session, upload_record.id) is not None
+        assert storage.exists(upload_path)
+
+
+# ---------------------------------------------------------------------------
+# _ensure_repo branch fallback
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureRepo:
+    async def test_clones_on_main_branch(self, tmp_path):
+        from app.github_sync import _ensure_repo
+
+        with patch("app.github_sync._git_clone", new_callable=AsyncMock) as mock_clone:
+            await _ensure_repo("https://github.com/org/repo", "main", tmp_path / "cache")
+        mock_clone.assert_called_once_with(
+            "https://github.com/org/repo", "main", tmp_path / "cache"
+        )
+
+    async def test_falls_back_to_master_on_clone_failure(self, tmp_path):
+        from app.github_sync import _ensure_repo
+
+        calls = []
+        cache = tmp_path / "cache"
+
+        async def clone_side_effect(url, branch, path):
+            calls.append(branch)
+            if branch == "main":
+                # Simulate git clone leaving a partial directory behind
+                path.mkdir(parents=True, exist_ok=True)
+                raise _branch_error("main")
+
+        with patch("app.github_sync._git_clone", side_effect=clone_side_effect):
+            await _ensure_repo("https://github.com/org/repo", "main", cache)
+
+        assert calls == ["main", "master"]
+        # The partial directory must have been cleaned up before the retry
+        # (if it still existed, the second clone would have failed too)
+
+    async def test_clone_transient_error_is_not_silently_retried(self, tmp_path):
+        """A network/auth failure during clone must propagate, not trigger branch fallback."""
+        from app.github_sync import _ensure_repo
+
+        cache = tmp_path / "cache"
+
+        async def clone_side_effect(url, branch, path):
+            raise _transient_error()
+
+        with patch("app.github_sync._git_clone", side_effect=clone_side_effect):
+            with pytest.raises(subprocess.CalledProcessError):
+                await _ensure_repo("https://github.com/org/repo", "main", cache)
+
+    async def test_non_default_branch_does_not_fall_back(self, tmp_path):
+        """Branches other than main/master must not silently fall back to another branch."""
+        from app.github_sync import _ensure_repo
+
+        cache = tmp_path / "cache"
+
+        async def clone_side_effect(url, branch, path):
+            raise _branch_error(branch)
+
+        with patch("app.github_sync._git_clone", side_effect=clone_side_effect):
+            with pytest.raises(subprocess.CalledProcessError):
+                # 'develop' has no automatic fallback pair
+                await _ensure_repo("https://github.com/org/repo", "develop", cache)
+
+    async def test_stale_clone_dir_cleaned_before_fallback(self, tmp_path):
+        from app.github_sync import _ensure_repo
+
+        cache = tmp_path / "cache"
+
+        async def clone_side_effect(url, branch, path):
+            if branch == "main":
+                path.mkdir(parents=True, exist_ok=True)
+                (path / "stale_file").write_text("leftover")
+                raise _branch_error("main")
+            # fallback succeeds — verify the stale dir was removed first
+            assert not path.exists() or not (path / "stale_file").exists()
+
+        with patch("app.github_sync._git_clone", side_effect=clone_side_effect):
+            await _ensure_repo("https://github.com/org/repo", "main", cache)
+
+    async def test_stale_dir_without_git_is_cleaned_before_clone(self, tmp_path):
+        """A partial dir with no .git should be removed and the same branch retried."""
+        from app.github_sync import _ensure_repo
+
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        (cache / "leftover").write_text("stale")
+
+        calls = []
+
+        async def clone_side_effect(url, branch, path):
+            calls.append(branch)
+            # verify dir was cleaned before this call
+            assert not path.exists()
+
+        with patch("app.github_sync._git_clone", side_effect=clone_side_effect):
+            await _ensure_repo("https://github.com/org/repo", "main", cache)
+
+        assert calls == ["main"]  # no fallback needed — same branch retried cleanly
+
+    async def test_pulls_when_repo_exists(self, tmp_path):
+        from app.github_sync import _ensure_repo
+
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        (cache / ".git").mkdir()
+
+        with patch("app.github_sync._git_pull", new_callable=AsyncMock) as mock_pull:
+            await _ensure_repo("https://github.com/org/repo", "main", cache)
+
+        mock_pull.assert_called_once_with(cache, "main")
+
+    async def test_reclones_on_fallback_branch_when_pull_fails(self, tmp_path):
+        """When pull fails with branch-not-found on an existing cache, delete the cache
+        and reclone on the fallback branch.
+
+        A single-branch clone only has the original branch; pulling a different
+        branch would fail.  The fix is to wipe the cache and reclone fresh.
+        """
+        from app.github_sync import _ensure_repo
+
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        (cache / ".git").mkdir()
+        (cache / "old_file").write_text("stale")
+
+        clone_calls = []
+
+        async def pull_side_effect(path, branch):
+            raise _branch_error(branch)
+
+        async def clone_side_effect(url, branch, path):
+            clone_calls.append(branch)
+            # The stale cache must have been removed before this call
+            assert not (path / "old_file").exists()
+
+        with (
+            patch("app.github_sync._git_pull", side_effect=pull_side_effect),
+            patch("app.github_sync._git_clone", side_effect=clone_side_effect),
+        ):
+            await _ensure_repo("https://github.com/org/repo", "main", cache)
+
+        assert clone_calls == ["master"]  # recloned on the fallback branch
+
+    async def test_pull_transient_error_is_not_silently_retried(self, tmp_path):
+        """A network/auth failure during pull on an existing cache must propagate."""
+        from app.github_sync import _ensure_repo
+
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        (cache / ".git").mkdir()
+
+        async def pull_side_effect(path, branch):
+            raise _transient_error()
+
+        with patch("app.github_sync._git_pull", side_effect=pull_side_effect):
+            with pytest.raises(subprocess.CalledProcessError):
+                await _ensure_repo("https://github.com/org/repo", "main", cache)


### PR DESCRIPTION
## Summary

- **Auth helpers** (app/auth.py): get_beril_user_id(request) reads the internal user UUID from session; get_current_user_or_token(request, db) authenticates via session cookie or Authorization: Bearer token. Case-insensitive header parsing; stale session falls back to Bearer token.
- **GitHub sync** (app/github_sync.py): sync_github_repo() shallow-clones or pulls a linked repo, copies files into a github/ storage namespace, upserts ProjectFile records tagged source=github, and deletes DB rows for files removed from the repo while leaving manually uploaded files untouched.
- **Branch fallback** restricted to main-master only; other branch names fail explicitly. Transient git errors are re-raised rather than silently retried.
- **Symlink rejection** in _iter_files() prevents host path traversal from malicious repos.
- **ProjectFile.source** column (upload or github) scopes the sync deletion loop to only its own files. No migration needed -- DB is rebuilt from create_all().
- **CRUD**: create_project_file() accepts source= kwarg; get_github_files_for_project() added.

## Notes for PR 4

- filename for nested repo files stores the repo-relative path (e.g. notebooks/analysis.ipynb). The existing notebook route uses a single path segment and will 404 for these -- PR 4 will need to handle this.
- GitHub files stored under {owner_id}/{slug}/github/{rel_path}; manual uploads will use {owner_id}/{slug}/uploads/{filename}.
- The source column requires a DB rebuild on existing deployments (intentional -- no Alembic used).

## Test plan

- [ ] cd ui && uv run pytest tests/test_github_sync.py tests/test_auth.py tests/db/ -v -- 185 tests pass locally
- [ ] Log in via ORCiD -- verify session and Bearer auth work
- [ ] Verify sync_github_repo() with a real GitHub repo (main and master branch repos)
- [ ] Verify manually uploaded files survive a GitHub sync on the same project

Generated with [Claude Code](https://claude.com/claude-code)