### PR TITLE
chore: gitignore .claude/projects/ and scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 # Claude Code local settings
 .claude/settings.local.json
 .claude/plans/
+.claude/projects/
+.claude/scheduled_tasks.lock
 .serena/
 
 # Large data files


### PR DESCRIPTION
## Summary

Two per-user Claude Code session-state paths were accumulating as untracked files on everyone's working tree:

- \`.claude/projects/\` — Claude Code's per-project local state (transcripts, memory cache, etc.)
- \`.claude/scheduled_tasks.lock\` — lock file from the scheduled-tasks subsystem

Neither should ever be committed. The existing \`.gitignore\` already excludes \`.claude/settings.local.json\` and \`.claude/plans/\`; this adds the two missing entries.

## Test plan

- [x] \`git status\` after the change: clean working tree (the previously untracked \`.claude/projects/\` and \`.claude/scheduled_tasks.lock\` disappear from the list).
- [x] No existing tracked files are ignored (rule only affects untracked paths).