### PR TITLE
Add BERIL-branded Claude Code status line

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,2 +1,6 @@
 {
+  "statusLine": {
+    "type": "command",
+    "command": "bash .claude/statusline.sh"
+  }
 }

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+model = d.get("model", {}).get("display_name", "")
+cwd = d.get("workspace", {}).get("current_dir", "")
+print(f"BERIL | {model} | {cwd}")
+'


### PR DESCRIPTION
## Summary
- Adds a project-scoped `statusLine` to `.claude/settings.json` so Claude Code sessions in this repo show `BERIL | <model> | <cwd>` at the bottom of the terminal.
- Implementation lives in `.claude/statusline.sh` (a small Python script) so it has no dependency on `jq`, which isn't available in the BERDL JupyterHub environment.

Example output:
```
BERIL | Opus 4.7 (1M context) | /home/cmungall/repos/BERIL-research-observatory
```

## Test plan
- [ ] Open a Claude Code session in this repo and confirm the status line reads `BERIL | <model> | <cwd>`.
- [ ] Open a Claude Code session in an unrelated repo and confirm the status line is unaffected (project-scoped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)