### PR TITLE
Add two pitfalls from obi_ontology_coverage

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -303,6 +303,49 @@ Observed in `[nmdc_community_metabolic_ecology]` NB03 cell-9 when checking `scor
 
 ---
 
+### Parquet `fixed_size_binary[16]` Causes Spark UUID Error
+
+**[obi_ontology_coverage]** Parquet files containing `fixed_size_binary[16]` columns (e.g. MD5 hashes stored as raw 16 bytes) cause Spark 4.x to fail with:
+
+```
+AnalysisException: [PARQUET_TYPE_ILLEGAL] Illegal Parquet type: FIXED_LEN_BYTE_ARRAY (UUID)
+```
+
+Spark interprets 16-byte fixed binary as a UUID logical type and rejects it.
+
+**Symptom**: `spark.read.parquet()` fails on a file that pandas/PyArrow reads fine.
+
+**Solution**: Pre-screen with PyArrow and convert to strings before uploading to bronze:
+
+```python
+import pyarrow.parquet as pq
+schema = pq.read_schema("file.parquet")
+for field in schema:
+    if "fixed_size_binary" in str(field.type):
+        # Re-export with pandas, casting bytes to hex strings
+        df[col] = df[col].apply(lambda x: x.hex() if isinstance(x, bytes) else x)
+```
+
+**Root cause**: DuckDB Parquet export stores hash columns as `fixed_size_binary` rather than `VARCHAR`. Fix upstream or handle during ingest schema detection.
+
+---
+
+### `/berdl-ingest` Skill Does Not Support On-Cluster Execution
+
+**[obi_ontology_coverage]** The `/berdl-ingest` skill and `scripts/ingest_lib.py` assume off-cluster execution. Running on the JupyterHub notebook server, `initialize()` fails immediately checking for SSH tunnels on ports 1337/1338.
+
+**Symptom**: `RuntimeError: SSH tunnel(s) not detected on port(s): [1337, 1338]` when running on the notebook server itself.
+
+**Workaround**: Bypass `ingest_lib` entirely. On-cluster, use:
+
+- `berdl_notebook_utils.setup_spark_session.get_spark_session()` for Spark
+- `minio.Minio()` with env vars (`MINIO_ENDPOINT_URL`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`) for MinIO
+- Direct `spark.read.parquet()` / `sdf.write.format("delta")` for ingest
+
+**Fix needed**: `initialize()` should detect on-cluster via `os.environ.get("SPARK_CONNECT_MODE_ENABLED")` and use the native utilities instead of the proxy chain. See `projects/obi_ontology_coverage/INGEST_SESSION_REPORT.md` for full details.
+
+---
+
 ## Pangenome (`kbase_ke_pangenome`) Pitfalls
 
 ### Taxonomy Join: Use `genome_id`, NOT `gtdb_taxonomy_id`

--- a/projects/obi_ontology_coverage/INGEST_HANDOFF.md
+++ b/projects/obi_ontology_coverage/INGEST_HANDOFF.md
@@ -1,0 +1,88 @@
+# BERDL Ingest Handoff: NMDC Workflow Collections
+
+**Date:** 2026-04-03
+**Source:** NUC (`mark@nuc`), repo `~/gitrepos/external-metadata-awareness/`
+**Target namespace:** `nmdc_flattened_biosamples` (existing)
+**For:** OBI ontology coverage meeting, Monday 2026-04-07
+
+## What's being ingested
+
+Four new parquet files extending the existing `nmdc_flattened_biosamples` namespace with the NMDC provenance chain:
+
+| File | Rows | Size | Description |
+|------|------|------|-------------|
+| `flattened_data_generation.parquet` | 10,423 | 363K | Sequencing events (NucleotideSequencing, MassSpectrometry) |
+| `flattened_workflow_execution.parquet` | 24,698 | 5.5M | Computational pipelines (MagsAnalysis, MetagenomeAnnotation, etc.) |
+| `flattened_workflow_execution_mags.parquet` | 40,580 | 49M | Extracted MAG bins with completeness, contamination, GTDB taxonomy |
+| `flattened_data_object.parquet` | 226,864 | 7.6M | Output files (FASTA, GFF, stats, raw data) |
+
+All files use embedded Parquet schemas -- no `.sql` schema file needed.
+
+## Key field: `nmdc_type`
+
+The `nmdc_type` column in `flattened_workflow_execution` is the primary field for the OBI meeting. It contains NMDC's internal type system:
+
+```
+4220  nmdc:MetagenomeAnnotation
+4026  nmdc:ReadQcAnalysis
+3933  nmdc:MetagenomeAssembly
+3647  nmdc:ReadBasedTaxonomyAnalysis
+3258  nmdc:MagsAnalysis
+2658  nmdc:MetabolomicsAnalysis
+2583  nmdc:NomAnalysis
+ 166  nmdc:MetaproteomicsAnalysis
+  69  nmdc:MetatranscriptomeAssembly
+  69  nmdc:MetatranscriptomeExpressionAnalysis
+  69  nmdc:MetatranscriptomeAnnotation
+```
+
+The OBI story: these 11 types have no OBI equivalents. OBI has `OBI:0200000` (data transformation) but no subtypes for metagenome assembly, genome binning, or taxonomic classification.
+
+## Provenance chain
+
+```
+data_generation (sequencing)
+  --> workflow_execution (pipelines, via was_informed_by)
+    --> data_object (output files, via was_generated_by)
+```
+
+`flattened_workflow_execution_mags` is a child table of `flattened_workflow_execution` -- linked by `workflow_execution_id`.
+
+## Ingest instructions
+
+Use `/berdl-ingest` skill. Point it at this directory:
+
+```
+/home/mamillerpa/BERIL-research-observatory/data/nmdc_flattened_biosamples/
+```
+
+- **Tenant:** use existing tenant for `nmdc_flattened_biosamples`
+- **Dataset:** `nmdc_flattened_biosamples` (same namespace -- these are additional tables)
+- **Write mode:** The 4 new tables don't conflict with existing tables (flattened_biosample, flattened_study, etc.). Use overwrite for the new tables only.
+- **Parquet format:** schema auto-detected, no chunking needed (largest file is 49M)
+
+## Verification query after ingest
+
+```sql
+SELECT nmdc_type, COUNT(*) as cnt
+FROM nmdc_flattened_biosamples.flattened_workflow_execution
+GROUP BY nmdc_type
+ORDER BY cnt DESC
+```
+
+Should return 11 rows totaling 24,698.
+
+## How these were produced
+
+`flatten_nmdc_collections.py` in `external-metadata-awareness` was extended to process three additional MongoDB collections (`data_generation_set`, `workflow_execution_set`, `data_object_set`). The `type` field -- normally skipped during flattening -- is preserved as `nmdc_type` because it carries semantic meaning (the workflow type). `mags_list` arrays were extracted into a separate child table following the existing `extract_associated_dois` pattern.
+
+Pipeline: MongoDB --> flatten_nmdc_collections.py --> DuckDB --> Parquet (ZSTD compression).
+
+## Also in this namespace (already loaded)
+
+- `flattened_biosample` (14,938 rows)
+- `flattened_biosample_chem_administration` (90 rows)
+- `flattened_biosample_field_counts` (281 rows)
+- `flattened_study` (48 rows)
+- `flattened_study_associated_dois` (71 rows)
+- `flattened_study_has_credit_associations` (470 rows)

--- a/projects/obi_ontology_coverage/INGEST_SESSION_REPORT.md
+++ b/projects/obi_ontology_coverage/INGEST_SESSION_REPORT.md
@@ -1,0 +1,160 @@
+# BERDL Ingest Session Report: On-Cluster Execution
+
+**Date:** 2026-04-03
+**Operator:** Mark Andrew Miller (mamillerpa)
+**Environment:** `jupyter-mamillerpa` on BERDL notebook server (hub.berdl.kbase.us)
+**Namespace:** `nmdc_flattened_biosamples` (existing, 6 tables -> 10 tables)
+
+## Summary
+
+Four new Parquet tables were ingested into the existing `nmdc_flattened_biosamples`
+Delta Lake namespace to support OBI ontology coverage analysis. The `/berdl-ingest`
+skill was designed for off-cluster use and required manual adaptation to run
+on the notebook server directly.
+
+## What was ingested
+
+| Table | Rows | Source size |
+|-------|------|-------------|
+| `flattened_data_generation` | 10,423 | 363 KB |
+| `flattened_data_object` | 226,864 | 7.6 MB |
+| `flattened_workflow_execution` | 24,698 | 5.5 MB |
+| `flattened_workflow_execution_mags` | 40,580 | 49 MB |
+
+All row counts verified against source and via the handoff verification query
+(11 `nmdc_type` values totaling 24,698 rows in `flattened_workflow_execution`).
+
+## On-cluster vs. off-cluster: what we changed
+
+### 1. Skipped the entire proxy/tunnel chain
+
+The `/berdl-ingest` skill and its `ingest_lib.py` `initialize()` function assume
+off-cluster execution with:
+
+- SSH SOCKS tunnels on ports 1337 and 1338
+- pproxy on port 8123 bridging SOCKS to HTTP
+- `spark_connect_remote` library for authenticated Spark Connect over the proxy
+- `berdl-remote login/spawn` to start the JupyterHub server remotely
+- MinIO access via `~/.mc/config.json` credentials routed through pproxy
+
+**On-cluster, none of this is needed.** The notebook server has:
+
+- `SPARK_CONNECT_URL` env var pointing directly at the sidecar (`sc://jupyter-mamillerpa.jupyterhub-prod:15002`)
+- `MINIO_ENDPOINT_URL`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` in the environment
+- `berdl_notebook_utils.setup_spark_session.get_spark_session()` handling Spark auth natively
+- Direct HTTPS access to MinIO at `minio.berdl.kbase.us`
+
+### 2. Used `berdl_notebook_utils` instead of `spark_connect_remote`
+
+Off-cluster, the skill uses `scripts/get_spark_session.py` which imports
+`spark_connect_remote.create_spark_session()`. This package is not installed
+on the notebook server (and doesn't need to be).
+
+On-cluster, `berdl_notebook_utils.setup_spark_session.get_spark_session()` is
+pre-installed and handles KBase token authentication via gRPC headers automatically.
+
+### 3. Built MinIO client from environment variables
+
+Off-cluster, the skill reads `~/.mc/config.json` (alias `berdl-minio`) and routes
+through the pproxy. On-cluster, we constructed the `minio.Minio` client directly
+from environment variables:
+
+```python
+from minio import Minio
+client = Minio(
+    endpoint=os.environ["MINIO_ENDPOINT_URL"].replace("https://", ""),
+    access_key=os.environ["MINIO_ACCESS_KEY"],
+    secret_key=os.environ["MINIO_SECRET_KEY"],
+    secure=True,
+)
+```
+
+No proxy manager needed. We did also run `mc alias set berdl-minio` using these
+env vars, but that was only necessary for `mc` CLI usage, not the Python ingest.
+
+### 4. Did not use the notebook template
+
+The reference notebook (`ingest.ipynb`) imports `ingest_lib.initialize()` which
+calls `_check_ssh_tunnels()` and fails immediately on-cluster. Rather than patching
+the template, we ran the ingest as a direct Python script:
+
+1. Upload Parquet files to MinIO bronze via `minio.fput_object()`
+2. `spark.read.parquet()` from bronze path
+3. `sdf.write.format("delta").mode("overwrite").save()` to silver path
+4. `CREATE TABLE IF NOT EXISTS ... USING DELTA LOCATION` to register in catalog
+5. `REFRESH TABLE` and `SELECT COUNT(*)` to verify
+
+## Data issue: Parquet UUID type incompatibility
+
+`flattened_data_object.parquet` contained an `md5_checksum` column stored as
+`fixed_size_binary[16]`. Spark's Parquet reader interprets 16-byte fixed binary
+as a UUID logical type and raises:
+
+```
+AnalysisException: [PARQUET_TYPE_ILLEGAL] Illegal Parquet type: FIXED_LEN_BYTE_ARRAY (UUID)
+```
+
+**Fix:** Re-exported the file via pandas, converting the raw bytes to hex strings:
+
+```python
+df["md5_checksum"] = df["md5_checksum"].apply(
+    lambda x: x.hex() if isinstance(x, bytes) else str(x) if x is not None else None
+)
+```
+
+**Root cause:** The upstream `flatten_nmdc_collections.py` pipeline (DuckDB -> Parquet
+with ZSTD) stores MD5 hashes as `fixed_size_binary[16]`, which is semantically correct
+but incompatible with Spark 4.x Parquet reader. The upstream script should cast these
+to `VARCHAR` before Parquet export, or the ingest skill should detect and handle this
+type during the schema inspection step.
+
+## Recommendations for repo maintainers
+
+### 1. Add on-cluster mode to `ingest_lib.py`
+
+`initialize()` should detect when it's running on the notebook server (e.g. check for
+`SPARK_CONNECT_URL` or `MINIO_ACCESS_KEY` in the environment) and skip the tunnel/proxy
+chain. Suggested approach:
+
+```python
+def initialize():
+    if os.environ.get("SPARK_CONNECT_MODE_ENABLED"):
+        # On-cluster path
+        from berdl_notebook_utils.setup_spark_session import get_spark_session
+        spark = get_spark_session()
+        minio_client = _build_minio_client_from_env()
+    else:
+        # Off-cluster path (existing code)
+        _check_ssh_tunnels()
+        _start_pproxy_if_needed()
+        ...
+```
+
+### 2. Add `fixed_size_binary` handling to the Parquet ingest path
+
+The notebook template's Parquet path reads files directly with `spark.read.parquet()`.
+When Spark encounters `fixed_size_binary` columns it fails. The skill should either:
+
+- Pre-screen Parquet schemas with PyArrow before uploading to bronze
+- Convert incompatible types (fixed binary -> string) during the detect/schema step
+- Document this as a known limitation with a workaround
+
+### 3. `_build_minio_client()` should support env var credentials
+
+Currently it only reads from `~/.mc/config.json`. On-cluster, credentials are in
+`MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` / `MINIO_ENDPOINT_URL`. A fallback to
+env vars would make the library work in both contexts without configuration.
+
+### 4. The `already_ingested/` convention is undocumented
+
+The source directory had a subdirectory `already_ingested/` containing 6 Parquet files
+from a prior ingest. This convention (separating already-loaded files) is not part of
+the skill's workflow. Consider either documenting it or having the skill track ingested
+files via the progress log so users don't need to manually segregate them.
+
+## Paths
+
+- **Bronze:** `s3a://cdm-lake/tenant-general-warehouse/nmdc/datasets/nmdc_flattened_biosamples/`
+- **Silver:** `s3a://cdm-lake/tenant-sql-warehouse/nmdc/nmdc_flattened_biosamples.db/`
+- **Source handoff:** `projects/obi_ontology_coverage/INGEST_HANDOFF.md`
+- **Flattening instructions:** `projects/obi_ontology_coverage/flatten-nmdc-workflow-collections-instructions-2026-04-03.md`

--- a/projects/obi_ontology_coverage/Untitled.ipynb
+++ b/projects/obi_ontology_coverage/Untitled.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "79e03bf6-1212-49bc-8f7a-1fa87605f1c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+--------------------+--------------------+-----------+\n",
+      "|           namespace|           tableName|isTemporary|\n",
+      "+--------------------+--------------------+-----------+\n",
+      "|nmdc_flattened_bi...| flattened_biosample|      false|\n",
+      "|nmdc_flattened_bi...|flattened_biosamp...|      false|\n",
+      "|nmdc_flattened_bi...|flattened_study_a...|      false|\n",
+      "|nmdc_flattened_bi...|flattened_biosamp...|      false|\n",
+      "|nmdc_flattened_bi...|flattened_study_h...|      false|\n",
+      "|nmdc_flattened_bi...|     flattened_study|      false|\n",
+      "|nmdc_flattened_bi...|flattened_data_ge...|      false|\n",
+      "|nmdc_flattened_bi...|flattened_data_ob...|      false|\n",
+      "|nmdc_flattened_bi...|flattened_workflo...|      false|\n",
+      "|nmdc_flattened_bi...|flattened_workflo...|      false|\n",
+      "+--------------------+--------------------+-----------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from berdl_notebook_utils.setup_spark_session import get_spark_session \n",
+    "spark = get_spark_session()\n",
+    "spark.sql(\"SHOW TABLES IN nmdc_flattened_biosamples\").show() "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7dac1b0b-021d-44b9-9a25-9ff501c076c6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/projects/obi_ontology_coverage/flatten-nmdc-workflow-collections-instructions-2026-04-03.md
+++ b/projects/obi_ontology_coverage/flatten-nmdc-workflow-collections-instructions-2026-04-03.md
@@ -1,0 +1,231 @@
+# Instructions: Flatten NMDC Workflow Collections for BERDL Ingestion
+
+## Goal
+
+Extend `flatten_nmdc_collections.py` in `~/gitrepos/external-metadata-awareness/` to flatten
+three additional NMDC MongoDB collections: `data_generation_set`, `workflow_execution_set`,
+and `data_object_set`. These contain the provenance chain that shows *how* NMDC data was
+produced — exactly where OBI terms should be used but currently aren't.
+
+This is for the OBI meeting on Monday 2026-04-07. The flattened tables will be ingested into
+the BERDL lakehouse to demonstrate the gap between NMDC's internal type system and OBI.
+
+## Why These Collections
+
+Study and biosample metadata is already in the lakehouse. The missing layer is:
+
+```
+data_generation_set (sequencing events)
+  → workflow_execution_set (computational pipelines, via was_informed_by)
+    → data_object_set (output files, via was_generated_by)
+```
+
+These documents have fields like `type: nmdc:MagsAnalysis` and `processing_institution: JGI`
+where OBI terms could add cross-project interoperability.
+
+## Document Structures (from API, 2026-04-03)
+
+### data_generation_set
+
+```json
+{
+  "id": "nmdc:dgns-11-3ajjfh90",
+  "type": "nmdc:NucleotideSequencing",
+  "name": "Populus rhizosphere ... - Rhizosphere MetaG P. deltoides SRZDD2",
+  "analyte_category": "metagenome",
+  "associated_studies": ["nmdc:sty-11-1t150432"],
+  "has_input": ["nmdc:bsm-11-7v0s5h20"],
+  "instrument_used": ["nmdc:inst-14-nn4b6k72"],
+  "processing_institution": "JGI",
+  "gold_sequencing_project_identifiers": ["gold:Gp0116341"],
+  "insdc_bioproject_identifiers": ["bioproject:PRJNA375667"],
+  "ncbi_project_name": "...",
+  "principal_investigator": {
+    "email": "pelletierda@ornl.gov",
+    "has_raw_value": "Dale Pelletier",
+    "name": "Dale Pelletier",
+    "type": "nmdc:PersonValue"
+  },
+  "provenance_metadata": {
+    "type": "nmdc:ProvenanceMetadata",
+    "add_date": "2015-06-23T00:00:00Z",
+    "mod_date": "2025-05-05T00:00:00Z"
+  }
+}
+```
+
+**Flattening notes:**
+- `associated_studies`, `has_input`, `instrument_used`, `gold_sequencing_project_identifiers`,
+  `insdc_bioproject_identifiers` are arrays → pipe-separate
+- `principal_investigator` is a dict → flatten to `principal_investigator_name`,
+  `principal_investigator_email`, etc. (same pattern as ControlledTermValue)
+- `provenance_metadata` is a dict → flatten to `provenance_metadata_add_date`, etc.
+- `type` should be KEPT (not skipped) for this collection — it's the workflow type
+  (e.g., `nmdc:NucleotideSequencing`) and is the key field for OBI mapping
+
+### workflow_execution_set
+
+```json
+{
+  "id": "nmdc:wfmag-11-002wf438.1",
+  "type": "nmdc:MagsAnalysis",
+  "name": "Metagenome Assembled Genomes Analysis for ...",
+  "has_input": ["nmdc:dobj-11-zdrpgv45", ...],
+  "has_output": ["nmdc:dobj-11-1218k979", ...],
+  "processing_institution": "NMDC",
+  "git_url": "https://github.com/microbiomedata/metaMAGs",
+  "started_at_time": "2025-12-19 15:59:45",
+  "ended_at_time": "2025-12-19 17:27:03",
+  "was_informed_by": ["nmdc:omprc-11-39q8ar32"],
+  "execution_resource": "NERSC-Perlmutter",
+  "version": "v1.3.16",
+  "binned_contig_num": 12040,
+  "input_contig_num": 536294,
+  "mags_list": [{ "bin_name": "bins.25", "completeness": 94.06, ... }, ...]
+}
+```
+
+**Flattening notes:**
+- `has_input`, `has_output`, `was_informed_by` are arrays of IDs → pipe-separate
+- `mags_list` is a complex nested array → either stringify as JSON or extract to a
+  separate `flattened_workflow_execution_mags` collection (preferred, same pattern as
+  `extract_associated_dois`)
+- `type` should be KEPT — it's `nmdc:MagsAnalysis`, `nmdc:MetagenomeAnnotation`, etc.
+- Scalar fields (`git_url`, `version`, `execution_resource`, `started_at_time`, etc.)
+  flatten directly
+- `binned_contig_num`, `input_contig_num` etc. are workflow-type-specific numeric fields —
+  keep as-is
+
+### data_object_set
+
+```json
+{
+  "id": "nmdc:dobj-11-00017y47",
+  "type": "nmdc:DataObject",
+  "name": "nmdc_wfmgan-11-yq9z3n21.1_proteins.faa",
+  "description": "FASTA Amino Acid File for ...",
+  "data_category": "processed_data",
+  "data_object_type": "Annotation Amino Acid FASTA",
+  "file_size_bytes": 85905216,
+  "md5_checksum": "39e6b7faa4e79fd903383771583b7c4b",
+  "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-1enrtv50/...",
+  "was_generated_by": "nmdc:wfmgan-11-yq9z3n21.1"
+}
+```
+
+**Flattening notes:**
+- Almost entirely flat already — no complex nesting
+- `type` is always `nmdc:DataObject` (less interesting than the others)
+- Keep `data_object_type` (e.g., "CheckM Statistics") — this is the field that classifies
+  what kind of output it is
+- `url` contains the download URL
+- `was_generated_by` links to a WorkflowExecution ID
+
+## Implementation Plan
+
+### Option A: Extend flatten_nmdc_collections.py (preferred)
+
+Add to `main()` after the biosample processing block:
+
+1. **Fetch and flatten data_generation_set:**
+   - Keep `type` field (don't skip it — rename to `nmdc_type` to avoid confusion)
+   - Flatten `principal_investigator` dict
+   - Flatten `provenance_metadata` dict
+   - Pipe-separate array fields
+   - No ontology enhancement needed (no env fields)
+
+2. **Fetch and flatten workflow_execution_set:**
+   - Keep `type` field (rename to `nmdc_type`)
+   - Pipe-separate `has_input`, `has_output`, `was_informed_by`
+   - Extract `mags_list` to separate `flattened_workflow_execution_mags` collection
+   - Keep numeric fields as-is
+   - No ontology enhancement needed
+
+3. **Fetch and flatten data_object_set:**
+   - Almost flat already — minimal transformation
+   - Keep all fields
+
+4. **Add to NMDC_FLATTENED_COLLECTIONS list:**
+   ```python
+   NMDC_FLATTENED_COLLECTIONS = \
+       flattened_biosample \
+       ...existing... \
+       flattened_data_generation \
+       flattened_workflow_execution \
+       flattened_workflow_execution_mags \
+       flattened_data_object
+   ```
+
+### Option B: Fetch from API instead of MongoDB
+
+If local MongoDB doesn't have these collections (check first), fetch from the API:
+
+```bash
+# data_generation_set (for one study)
+curl -s "https://api.microbiomedata.org/nmdcschema/data_generation_set?\
+filter=%7B%22associated_studies%22%3A%22nmdc%3Asty-11-1t150432%22%7D&max_page_size=999"
+
+# workflow_execution_set (need to chain from data_generation IDs)
+# Use linked_instances endpoint per biosample, or fetch all and filter
+
+# data_object_set (use the study endpoint)
+curl -s "https://api.microbiomedata.org/data_objects/study/nmdc:sty-11-1t150432"
+```
+
+Note: Option B is study-scoped. Option A from MongoDB gets all studies at once.
+
+### Key Difference from Biosample/Study Flattening
+
+The `type` field matters here. For biosamples and studies, `type` is always the same
+(`nmdc:Biosample`, `nmdc:Study`) so the script skips it. For workflow collections,
+`type` varies and carries semantic meaning:
+
+| Collection | type values |
+|---|---|
+| data_generation_set | `nmdc:NucleotideSequencing`, `nmdc:MassSpectrometry`, etc. |
+| workflow_execution_set | `nmdc:MagsAnalysis`, `nmdc:MetagenomeAnnotation`, `nmdc:ReadQcAnalysis`, `nmdc:MetagenomeAssembly`, `nmdc:ReadBasedTaxonomyAnalysis`, etc. |
+| data_object_set | always `nmdc:DataObject` |
+
+**The `type` field on workflow_execution_set is THE field where OBI terms should go.**
+Currently it uses NMDC's own type system. The OBI meeting story is: "here's what we use
+now, and here's the OBI planned process term that could replace or augment it."
+
+## Testing
+
+1. Check if local MongoDB has these collections:
+   ```bash
+   mongosh mongodb://localhost:27017/nmdc --quiet --eval \
+     "db.getCollectionNames().filter(n => n.match(/data_gen|workflow|data_obj/))"
+   ```
+
+2. If yes, run the extended script locally and verify the flattened collections
+
+3. Export to parquet:
+   ```bash
+   make -f Makefiles/nmdc_metadata.Makefile export-flattened-parquet
+   ```
+
+4. Ingest to BERDL via `/berdl-ingest` on the notebook server
+
+## For the OBI Meeting
+
+Once the flattened `workflow_execution` table is in the lakehouse, you can run a Spark
+query like:
+
+```sql
+SELECT nmdc_type, COUNT(*) as cnt
+FROM nmdc_flattened_workflow_executions.flattened_workflow_execution
+GROUP BY nmdc_type
+ORDER BY cnt DESC
+```
+
+And show: "Here are 24,698 workflow executions using NMDC's own type system. OBI has
+`OBI:0200000` (data transformation) but no subtypes for metagenome assembly, genome
+binning, or taxonomic classification. We're proposing 5-7 lightweight terms to fill
+this gap."
+
+## Scope Warning
+
+Don't try to flatten ALL of workflow_execution_set (24,698 documents) if going through
+the API — it will be slow. For the Monday demo, just the Populus study
+(`nmdc:sty-11-1t150432`, 29 biosamples) is enough. From MongoDB, all studies is fine.


### PR DESCRIPTION
Documents two reproducible issues discovered during `obi_ontology_coverage` work:

1. **Parquet `fixed_size_binary[16]` UUID error** — Spark 4.x rejects 16-byte fixed binary columns (e.g. MD5 hashes) exported by DuckDB. Includes pre-screen + conversion workaround.
2. **`/berdl-ingest` on-cluster failure** — `initialize()` checks for SSH tunnels on ports 1337/1338, which don't exist on JupyterHub. Documents the on-cluster workaround and the fix needed (`SPARK_CONNECT_MODE_ENABLED` detection).