### PR TITLE
ibd_phage_targeting: drop Collaborators block from Authors sections

### DIFF
--- a/projects/ibd_phage_targeting/README.md
+++ b/projects/ibd_phage_targeting/README.md
@@ -174,9 +174,3 @@ Outputs land in `data/`, figures in `figures/`. Verdicts (one per H-hypothesis o
 ## Authors
 
 - Adam Arkin (ORCID: [0000-0002-4999-2931](https://orcid.org/0000-0002-4999-2931)), U.C. Berkeley / Lawrence Berkeley National Laboratory
-
-Collaborators (data providers, named here for attribution; formal authorship TBD):
-- UC Davis CD cohort: Kuehl / Dave lab teams (metadata pending)
-- Engraftment mouse experiments: Dave lab (NRGS)
-- Strain-level reference analyses: Kumbhari et al. 2024
-- BGC meta-analysis: Elmassry et al. 2025

--- a/projects/ibd_phage_targeting/REPORT.md
+++ b/projects/ibd_phage_targeting/REPORT.md
@@ -2001,9 +2001,3 @@ The project's central science question is fully answered within plan v1.9 scope 
 ## Authors
 
 - Adam Arkin (ORCID: [0000-0002-4999-2931](https://orcid.org/0000-0002-4999-2931)), U.C. Berkeley / Lawrence Berkeley National Laboratory
-
-Collaborators (data providers; formal authorship TBD):
-- UC Davis CD cohort: Kuehl / Dave lab teams
-- Engraftment mouse experiments: Dave lab (NRGS)
-- Strain-level reference analyses: Kumbhari et al. 2024
-- BGC meta-analysis: Elmassry et al. 2025

--- a/projects/ibd_phage_targeting/RESEARCH_PLAN.md
+++ b/projects/ibd_phage_targeting/RESEARCH_PLAN.md
@@ -503,9 +503,3 @@ Tagged via `ref_missing_data_codes` sentinel codes. Does not block analysis but 
 ## Authors
 
 - Adam Arkin (ORCID: [0000-0002-4999-2931](https://orcid.org/0000-0002-4999-2931)), U.C. Berkeley / Lawrence Berkeley National Laboratory
-
-Collaborators (data providers, attribution here pending formal authorship):
-- UC Davis CD cohort: Kuehl / Dave lab
-- Engraftment mouse experiments: Dave lab (NRGS)
-- Strain-level reference analyses: Kumbhari et al. 2024 (PMID / source in `dim_studies`)
-- BGC meta-analysis: Elmassry et al. 2025 (Cell Host & Microbe)


### PR DESCRIPTION
## Summary
- README/RESEARCH_PLAN/REPORT each carried a \`Collaborators (data providers; formal authorship TBD)\` sub-list under \`## Authors\` — drift from the BERIL single-ORCID convention used by every other recent project (cf_formulation_design, genotype_to_phenotype_enigma, enigma_sso_asv_ecology, plant_microbiome_ecotypes, phb_granule_ecology).
- Data providers remain attributed via citations (\`references.md\`, \`dim_studies\`); they don't belong in an authorship-adjacent block.

## Test plan
- [x] \`grep -A 6 '## Authors'\` on the three files now ends after the single Arkin/ORCID line
- [x] No other content modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)