### PR TITLE
chat: ChatSession and ChatMessage tables (2/7)

### DIFF
--- a/ui/alembic/versions/20260421_c3d4e5f6a1b2_add_chat_session_and_message.py
+++ b/ui/alembic/versions/20260421_c3d4e5f6a1b2_add_chat_session_and_message.py
@@ -1,0 +1,89 @@
+"""Add chat_session and chat_message tables.
+
+Revision ID: c3d4e5f6a1b2
+Revises: b2c3d4e5f6a1
+Create Date: 2026-04-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "c3d4e5f6a1b2"
+down_revision = "b2c3d4e5f6a1"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(name: str) -> bool:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT EXISTS ("
+            "  SELECT 1 FROM information_schema.tables"
+            "  WHERE table_name = :name"
+            ")"
+        ),
+        {"name": name},
+    )
+    return result.scalar()
+
+
+def upgrade() -> None:
+    if not _table_exists("chat_session"):
+        op.create_table(
+            "chat_session",
+            sa.Column("id", sa.String(36), primary_key=True),
+            sa.Column(
+                "owner_id",
+                sa.String(36),
+                sa.ForeignKey("beril_user.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("sdk_session_id", sa.Text, nullable=True),
+            sa.Column("provider_id", sa.String(64), nullable=False),
+            sa.Column("model", sa.String(128), nullable=False),
+            sa.Column("title", sa.Text, nullable=False, server_default="New chat"),
+            sa.Column(
+                "project_id",
+                sa.String(36),
+                sa.ForeignKey("user_project.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("archived", sa.Boolean, nullable=False, server_default=sa.false()),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("last_active_at", sa.DateTime(timezone=True), nullable=False),
+        )
+        op.create_index("ix_chat_session_owner_id", "chat_session", ["owner_id"])
+
+    if not _table_exists("chat_message"):
+        op.create_table(
+            "chat_message",
+            sa.Column("id", sa.String(36), primary_key=True),
+            sa.Column(
+                "session_id",
+                sa.String(36),
+                sa.ForeignKey("chat_session.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "role",
+                sa.Enum("user", "assistant", "tool", "tool_result", name="chat_message_role"),
+                nullable=False,
+            ),
+            sa.Column("content", postgresql.JSONB, nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        )
+        op.create_index(
+            "ix_chat_message_session_created",
+            "chat_message",
+            ["session_id", "created_at"],
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chat_message_session_created", table_name="chat_message")
+    op.drop_table("chat_message")
+    op.drop_index("ix_chat_session_owner_id", table_name="chat_session")
+    op.drop_table("chat_session")
+    op.execute("DROP TYPE IF EXISTS chat_message_role")

--- a/ui/app/db/models.py
+++ b/ui/app/db/models.py
@@ -2,9 +2,14 @@
 
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, JSON, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+# JSONB on Postgres, JSON fallback elsewhere (used by SQLite-backed tests).
+JSONCol = JSON().with_variant(JSONB(), "postgresql")
 
 
 def _now() -> datetime:
@@ -40,6 +45,9 @@ class BerilUser(Base):
     )
     roles: Mapped[list["UserRole"]] = relationship(
         "UserRole", back_populates="user", cascade="all, delete-orphan"
+    )
+    chat_sessions: Mapped[list["ChatSession"]] = relationship(
+        "ChatSession", back_populates="owner", cascade="all, delete-orphan"
     )
 
 
@@ -127,6 +135,9 @@ class UserProject(Base):
     )
     import_record: Mapped["ProjectImportRecord | None"] = relationship(
         "ProjectImportRecord", back_populates="project", uselist=False
+    )
+    chat_sessions: Mapped[list["ChatSession"]] = relationship(
+        "ChatSession", back_populates="project"
     )
 
     @property
@@ -269,3 +280,69 @@ class ProjectImportRecord(Base):
     project: Mapped["UserProject | None"] = relationship(
         "UserProject", back_populates="import_record"
     )
+
+
+class ChatSession(Base):
+    """A persistent LLM chat session owned by a BERIL user.
+
+    ``provider_id`` is a free-form string matched against the chat provider
+    registry at request time (not an enum). Adding a new provider is a config +
+    code change, not a migration.
+
+    ``sdk_session_id`` is null until the first turn completes; subsequent turns
+    pass it as the resume handle so the underlying agent rehydrates context.
+    """
+
+    __tablename__ = "chat_session"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    owner_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("beril_user.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    sdk_session_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    provider_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False, default="New chat")
+    project_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("user_project.id", ondelete="SET NULL"), nullable=True
+    )
+    archived: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
+    last_active_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
+
+    owner: Mapped["BerilUser"] = relationship("BerilUser", back_populates="chat_sessions")
+    project: Mapped["UserProject | None"] = relationship(
+        "UserProject", back_populates="chat_sessions"
+    )
+    messages: Mapped[list["ChatMessage"]] = relationship(
+        "ChatMessage",
+        back_populates="session",
+        cascade="all, delete-orphan",
+        order_by="ChatMessage.created_at",
+    )
+
+
+class ChatMessage(Base):
+    """One finalized message in a chat session.
+
+    ``content`` stores structured payloads (text, tool-call dicts, tool-result
+    dicts) as JSON so we preserve the full turn structure on replay.
+    """
+
+    __tablename__ = "chat_message"
+    __table_args__ = (
+        Index("ix_chat_message_session_created", "session_id", "created_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    session_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("chat_session.id", ondelete="CASCADE"), nullable=False
+    )
+    role: Mapped[str] = mapped_column(
+        Enum("user", "assistant", "tool", "tool_result", name="chat_message_role"),
+        nullable=False,
+    )
+    content: Mapped[Any] = mapped_column(JSONCol, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
+
+    session: Mapped["ChatSession"] = relationship("ChatSession", back_populates="messages")

--- a/ui/tests/db/test_chat_models.py
+++ b/ui/tests/db/test_chat_models.py
@@ -1,0 +1,221 @@
+"""Tests for ChatSession and ChatMessage ORM models."""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
+
+from app.db.models import BerilUser, ChatMessage, ChatSession, UserProject
+
+
+async def _make_user(db_session, orcid="0000-0001-1111-0001"):
+    user = BerilUser(orcid_id=orcid, display_name="Test User")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+async def _make_project(db_session, owner, slug="p"):
+    project = UserProject(owner_id=owner.id, slug=slug, title="Test Project")
+    db_session.add(project)
+    await db_session.commit()
+    await db_session.refresh(project)
+    return project
+
+
+class TestChatSessionBasic:
+    async def test_create_minimal(self, db_session):
+        user = await _make_user(db_session)
+        session = ChatSession(
+            owner_id=user.id,
+            provider_id="anthropic",
+            model="claude-opus-4-7",
+        )
+        db_session.add(session)
+        await db_session.commit()
+        await db_session.refresh(session)
+
+        assert session.id is not None
+        assert len(session.id) == 36
+        assert session.provider_id == "anthropic"
+        assert session.model == "claude-opus-4-7"
+        assert session.title == "New chat"
+        assert session.archived is False
+        assert session.sdk_session_id is None
+        assert session.project_id is None
+        assert session.created_at is not None
+        assert session.last_active_at is not None
+
+    async def test_create_with_full_fields(self, db_session):
+        user = await _make_user(db_session)
+        project = await _make_project(db_session, user)
+        session = ChatSession(
+            owner_id=user.id,
+            provider_id="cborg",
+            model="anthropic/claude-opus",
+            title="Investigating gene clusters",
+            sdk_session_id="sdk-abc-123",
+            project_id=project.id,
+            archived=False,
+        )
+        db_session.add(session)
+        await db_session.commit()
+        await db_session.refresh(session)
+
+        assert session.title == "Investigating gene clusters"
+        assert session.sdk_session_id == "sdk-abc-123"
+        assert session.project_id == project.id
+
+    async def test_provider_id_is_free_form_string(self, db_session):
+        """Adding a new provider shouldn't require a migration."""
+        user = await _make_user(db_session)
+        session = ChatSession(
+            owner_id=user.id,
+            provider_id="a-provider-that-doesnt-exist-yet",
+            model="some-model",
+        )
+        db_session.add(session)
+        await db_session.commit()  # no enum constraint; accepted
+
+    async def test_owner_required(self, db_session):
+        session = ChatSession(
+            provider_id="anthropic",
+            model="claude-opus-4-7",
+        )
+        db_session.add(session)
+        with pytest.raises(IntegrityError):
+            await db_session.commit()
+
+
+class TestChatSessionRelations:
+    async def test_owner_relationship(self, db_session):
+        user = await _make_user(db_session)
+        session = ChatSession(
+            owner_id=user.id, provider_id="anthropic", model="claude-opus-4-7"
+        )
+        db_session.add(session)
+        await db_session.commit()
+
+        result = await db_session.execute(
+            select(BerilUser).options(selectinload(BerilUser.chat_sessions)).where(BerilUser.id == user.id)
+        )
+        loaded = result.scalar_one()
+        assert len(loaded.chat_sessions) == 1
+        assert loaded.chat_sessions[0].id == session.id
+
+    async def test_cascade_delete_user_removes_sessions(self, db_session):
+        user = await _make_user(db_session)
+        session = ChatSession(
+            owner_id=user.id, provider_id="anthropic", model="claude-opus-4-7"
+        )
+        db_session.add(session)
+        await db_session.commit()
+        session_id = session.id
+
+        await db_session.delete(user)
+        await db_session.commit()
+
+        result = await db_session.execute(select(ChatSession).where(ChatSession.id == session_id))
+        assert result.scalar_one_or_none() is None
+
+    async def test_project_delete_sets_null(self, db_session):
+        user = await _make_user(db_session)
+        project = await _make_project(db_session, user)
+        session = ChatSession(
+            owner_id=user.id,
+            provider_id="anthropic",
+            model="claude-opus-4-7",
+            project_id=project.id,
+        )
+        db_session.add(session)
+        await db_session.commit()
+
+        await db_session.delete(project)
+        await db_session.commit()
+        await db_session.refresh(session)
+
+        assert session.project_id is None
+
+
+class TestChatMessage:
+    async def _session(self, db_session):
+        user = await _make_user(db_session)
+        session = ChatSession(
+            owner_id=user.id, provider_id="anthropic", model="claude-opus-4-7"
+        )
+        db_session.add(session)
+        await db_session.commit()
+        await db_session.refresh(session)
+        return session
+
+    async def test_create_user_message(self, db_session):
+        session = await self._session(db_session)
+        msg = ChatMessage(
+            session_id=session.id,
+            role="user",
+            content={"text": "What is the genome size of E. coli?"},
+        )
+        db_session.add(msg)
+        await db_session.commit()
+        await db_session.refresh(msg)
+
+        assert msg.id is not None
+        assert msg.role == "user"
+        assert msg.content == {"text": "What is the genome size of E. coli?"}
+
+    async def test_create_assistant_message_with_structured_content(self, db_session):
+        """Tool calls live inside content as structured JSON."""
+        session = await self._session(db_session)
+        msg = ChatMessage(
+            session_id=session.id,
+            role="assistant",
+            content={
+                "text": "Let me check.",
+                "tool_calls": [{"name": "berdl_query", "input": {"sql": "SELECT 1"}}],
+            },
+        )
+        db_session.add(msg)
+        await db_session.commit()
+        await db_session.refresh(msg)
+
+        assert msg.content["tool_calls"][0]["name"] == "berdl_query"
+
+    async def test_messages_ordered_by_created_at(self, db_session):
+        session = await self._session(db_session)
+        from datetime import datetime, timedelta, timezone
+
+        base = datetime.now(timezone.utc)
+        msgs = [
+            ChatMessage(
+                session_id=session.id,
+                role="user",
+                content={"text": f"msg-{i}"},
+                created_at=base + timedelta(seconds=i),
+            )
+            for i in range(3)
+        ]
+        db_session.add_all(msgs)
+        await db_session.commit()
+
+        result = await db_session.execute(
+            select(ChatSession)
+            .options(selectinload(ChatSession.messages))
+            .where(ChatSession.id == session.id)
+        )
+        loaded = result.scalar_one()
+        texts = [m.content["text"] for m in loaded.messages]
+        assert texts == ["msg-0", "msg-1", "msg-2"]
+
+    async def test_cascade_delete_session_removes_messages(self, db_session):
+        session = await self._session(db_session)
+        msg = ChatMessage(session_id=session.id, role="user", content={"text": "hi"})
+        db_session.add(msg)
+        await db_session.commit()
+        msg_id = msg.id
+
+        await db_session.delete(session)
+        await db_session.commit()
+
+        result = await db_session.execute(select(ChatMessage).where(ChatMessage.id == msg_id))
+        assert result.scalar_one_or_none() is None


### PR DESCRIPTION
Second in a 7-PR series adding an LLM chat interface. Adds the
persistent storage that later PRs use for transcripts and resume
tokens. Stacks on top of #214 (PR #1).

## What this PR adds

- **`ChatSession`**: `owner_id` (FK to `beril_user` with cascade
  delete), `sdk_session_id` (resume handle from the Agent SDK),
  `provider_id` (free string matched against the registry at runtime —
  adding a new provider is config + code, not a migration), `model`,
  `title`, optional `project_id`, `archived` flag, `created_at` /
  `last_active_at`.
- **`ChatMessage`**: `session_id` (cascade delete), role enum
  (`user`/`assistant`/`tool`/`tool_result`), JSONB `content` (text +
  optional `tool_activity` + optional `error`), composite index on
  `(session_id, created_at)` for transcript ordering.
- `JSONCol = JSON().with_variant(JSONB(), "postgresql")` so
  SQLite-backed unit tests work too.
- `chat_sessions` back-relations on `BerilUser` (cascade delete) and
  `UserProject` (SET NULL on project deletion — chats outlive projects).
- Alembic revision `c3d4e5f6a1b2` matches the existing idempotent style.

## Tests

11 new model tests covering creation, relationships, cascade behavior,
free-form `provider_id`, and chronological ordering. Full suite: 572
passing.

## Stack context

This is **2 of 7**. PR #1 (#214) is merged. Subsequent branches
(`chat/3` … `chat/7`) sit on top locally and will be rebased onto each
predecessor's merged form.
