### PR TITLE
chat: provider abstraction + Anthropic-compatible implementation (3/7)

### DIFF
--- a/ui/app/chat/providers/__init__.py
+++ b/ui/app/chat/providers/__init__.py
@@ -1,0 +1,57 @@
+"""Chat provider registry.
+
+The registry maps ``provider_id`` strings (as stored on
+``ChatSession.provider_id``) to concrete provider instances. Membership is
+driven by the chat config YAML: each entry in ``providers`` becomes one
+registry entry, selected by its ``wire_protocol``.
+
+Adding a new wire protocol (e.g. OpenAI, Bedrock) is a code change — add the
+implementation and extend :func:`_build_provider` — but adding a new provider
+that speaks an existing wire protocol is a config edit only.
+"""
+
+from __future__ import annotations
+
+from app.chat.config import ProviderConfig, get_chat_config
+from app.chat.providers.anthropic_compatible import AnthropicCompatibleProvider
+from app.chat.providers.base import ChatProvider
+
+_registry: dict[str, ChatProvider] | None = None
+
+
+def _build_provider(provider_id: str, cfg: ProviderConfig) -> ChatProvider:
+    if cfg.wire_protocol == "anthropic":
+        return AnthropicCompatibleProvider(provider_id=provider_id, config=cfg)
+    # Unreachable: ChatConfig pydantic validation rejects unknown wire_protocols.
+    raise ValueError(f"unknown wire_protocol {cfg.wire_protocol!r}")
+
+
+def get_providers() -> dict[str, ChatProvider]:
+    """Return the cached registry, building it on first access."""
+    global _registry
+    if _registry is None:
+        chat_cfg = get_chat_config()
+        _registry = {pid: _build_provider(pid, pc) for pid, pc in chat_cfg.providers.items()}
+    return _registry
+
+
+def get_provider(provider_id: str) -> ChatProvider:
+    """Look up a provider by id. Raises KeyError if unknown."""
+    reg = get_providers()
+    if provider_id not in reg:
+        raise KeyError(f"unknown chat provider {provider_id!r}")
+    return reg[provider_id]
+
+
+def reset_providers_cache() -> None:
+    """Drop the cached registry. Tests only."""
+    global _registry
+    _registry = None
+
+
+__all__ = [
+    "ChatProvider",
+    "get_provider",
+    "get_providers",
+    "reset_providers_cache",
+]

--- a/ui/app/chat/providers/__init__.py
+++ b/ui/app/chat/providers/__init__.py
@@ -12,7 +12,7 @@ that speaks an existing wire protocol is a config edit only.
 
 from __future__ import annotations
 
-from app.chat.config import ProviderConfig, get_chat_config
+from app.chat.config import ProviderConfig, get_chat_config, reset_chat_config_cache
 from app.chat.providers.anthropic_compatible import AnthropicCompatibleProvider
 from app.chat.providers.base import ChatProvider
 
@@ -44,9 +44,16 @@ def get_provider(provider_id: str) -> ChatProvider:
 
 
 def reset_providers_cache() -> None:
-    """Drop the cached registry. Tests only."""
+    """Drop the cached registry and the underlying chat config cache.
+
+    Tests only. Both layers must be cleared together: the registry holds
+    provider instances built from the cached :class:`ChatConfig`, so dropping
+    only the registry would still rebuild from a stale config when a test has
+    swapped the YAML or patched ``get_settings().chat_config_path``.
+    """
     global _registry
     _registry = None
+    reset_chat_config_cache()
 
 
 __all__ = [

--- a/ui/app/chat/providers/anthropic_compatible.py
+++ b/ui/app/chat/providers/anthropic_compatible.py
@@ -61,33 +61,33 @@ class AnthropicCompatibleProvider:
         cwd: str,
         sdk_session_id: str | None,
     ) -> AsyncIterator[TurnEvent]:
-        api_key = credentials.require(_API_KEY_FIELD)
-
-        # Env is merged on top of os.environ in the SDK subprocess. The
-        # auth_style dictates which env var carries the key:
-        #   * api_key  → ANTHROPIC_API_KEY (sent as x-api-key header;
-        #                direct Anthropic endpoints require this).
-        #   * bearer   → ANTHROPIC_AUTH_TOKEN (sent as Authorization: Bearer;
-        #                OAuth-style proxies like CBORG require this).
-        # The unused var is blanked so any server-level default can't shadow
-        # the user's key with a stale value.
-        turn_env = {"ANTHROPIC_BASE_URL": self.config.base_url}
-        if self.config.auth_style == "bearer":
-            turn_env["ANTHROPIC_AUTH_TOKEN"] = api_key
-            turn_env["ANTHROPIC_API_KEY"] = ""
-        else:
-            turn_env["ANTHROPIC_API_KEY"] = api_key
-            turn_env["ANTHROPIC_AUTH_TOKEN"] = ""
-
-        options = ClaudeAgentOptions(
-            model=model,
-            cwd=cwd,
-            env=turn_env,
-            resume=sdk_session_id,
-            skills="all",
-        )
-
         try:
+            api_key = credentials.require(_API_KEY_FIELD)
+
+            # Env is merged on top of os.environ in the SDK subprocess. The
+            # auth_style dictates which env var carries the key:
+            #   * api_key  → ANTHROPIC_API_KEY (sent as x-api-key header;
+            #                direct Anthropic endpoints require this).
+            #   * bearer   → ANTHROPIC_AUTH_TOKEN (sent as Authorization: Bearer;
+            #                OAuth-style proxies like CBORG require this).
+            # The unused var is blanked so any server-level default can't shadow
+            # the user's key with a stale value.
+            turn_env = {"ANTHROPIC_BASE_URL": self.config.base_url}
+            if self.config.auth_style == "bearer":
+                turn_env["ANTHROPIC_AUTH_TOKEN"] = api_key
+                turn_env["ANTHROPIC_API_KEY"] = ""
+            else:
+                turn_env["ANTHROPIC_API_KEY"] = api_key
+                turn_env["ANTHROPIC_AUTH_TOKEN"] = ""
+
+            options = ClaudeAgentOptions(
+                model=model,
+                cwd=cwd,
+                env=turn_env,
+                resume=sdk_session_id,
+                skills="all",
+            )
+
             async for event in _stream_turn(user_message, options):
                 yield event
         except Exception as exc:  # noqa: BLE001 — top-level stream guard
@@ -125,6 +125,12 @@ def _translate(message: Any) -> list[TurnEvent]:
         return events
 
     if isinstance(message, ResultMessage):
+        if message.is_error:
+            return [
+                ErrorEvent(
+                    message=f"provider reported terminal error: {getattr(message, 'subtype', 'unknown')}"
+                )
+            ]
         return [TurnComplete(result_subtype=getattr(message, "subtype", None))]
 
     # UserMessage (tool_result echoes back through the SDK), partial-message

--- a/ui/app/chat/providers/anthropic_compatible.py
+++ b/ui/app/chat/providers/anthropic_compatible.py
@@ -1,0 +1,188 @@
+"""Provider that talks the Anthropic Messages API.
+
+Covers both Anthropic (``https://api.anthropic.com``) and Anthropic-compatible
+endpoints such as CBORG. The distinction between the two is entirely
+configuration — ``base_url`` and credentials differ; wire format is
+identical — so both are served by this single class.
+
+Per-turn credentials are passed into the spawned SDK subprocess via
+``ClaudeAgentOptions.env`` and are never written to logs, files, or the parent
+process environment.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, AsyncIterator
+
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ResultMessage,
+    SystemMessage,
+    query,
+)
+
+from app.chat.config import ProviderConfig
+from app.chat.providers.base import (
+    Credentials,
+    ErrorEvent,
+    SessionInitialized,
+    TextDelta,
+    ToolCall,
+    ToolResult,
+    TurnComplete,
+    TurnEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+# Credential field id we expect every Anthropic-compatible provider to
+# declare. Config validation doesn't enforce it (providers could evolve to
+# need more fields), but this implementation requires it at minimum.
+_API_KEY_FIELD = "api_key"
+
+
+class AnthropicCompatibleProvider:
+    """Runs a chat turn through the Claude Agent SDK against any
+    Anthropic-format endpoint.
+    """
+
+    def __init__(self, *, provider_id: str, config: ProviderConfig) -> None:
+        self.provider_id = provider_id
+        self.config = config
+
+    async def run_turn(
+        self,
+        *,
+        user_message: str,
+        credentials: Credentials,
+        model: str,
+        cwd: str,
+        sdk_session_id: str | None,
+    ) -> AsyncIterator[TurnEvent]:
+        api_key = credentials.require(_API_KEY_FIELD)
+
+        # Env is merged on top of os.environ in the SDK subprocess. The
+        # auth_style dictates which env var carries the key:
+        #   * api_key  → ANTHROPIC_API_KEY (sent as x-api-key header;
+        #                direct Anthropic endpoints require this).
+        #   * bearer   → ANTHROPIC_AUTH_TOKEN (sent as Authorization: Bearer;
+        #                OAuth-style proxies like CBORG require this).
+        # The unused var is blanked so any server-level default can't shadow
+        # the user's key with a stale value.
+        turn_env = {"ANTHROPIC_BASE_URL": self.config.base_url}
+        if self.config.auth_style == "bearer":
+            turn_env["ANTHROPIC_AUTH_TOKEN"] = api_key
+            turn_env["ANTHROPIC_API_KEY"] = ""
+        else:
+            turn_env["ANTHROPIC_API_KEY"] = api_key
+            turn_env["ANTHROPIC_AUTH_TOKEN"] = ""
+
+        options = ClaudeAgentOptions(
+            model=model,
+            cwd=cwd,
+            env=turn_env,
+            resume=sdk_session_id,
+            skills="all",
+        )
+
+        try:
+            async for event in _stream_turn(user_message, options):
+                yield event
+        except Exception as exc:  # noqa: BLE001 — top-level stream guard
+            logger.exception("chat turn failed for provider=%s", self.provider_id)
+            yield ErrorEvent(message=str(exc))
+
+
+async def _stream_turn(
+    user_message: str, options: ClaudeAgentOptions
+) -> AsyncIterator[TurnEvent]:
+    """Drive the SDK ``query()`` and translate its messages to TurnEvents."""
+    emitted_terminal = False
+    async for message in query(prompt=user_message, options=options):
+        for event in _translate(message):
+            if isinstance(event, (TurnComplete, ErrorEvent)):
+                emitted_terminal = True
+            yield event
+    if not emitted_terminal:
+        yield TurnComplete()
+
+
+def _translate(message: Any) -> list[TurnEvent]:
+    """Map one SDK message to zero or more TurnEvents."""
+    if isinstance(message, SystemMessage):
+        if message.subtype == "init":
+            sid = (message.data or {}).get("session_id")
+            if sid:
+                return [SessionInitialized(sdk_session_id=sid)]
+        return []
+
+    if isinstance(message, AssistantMessage):
+        events: list[TurnEvent] = []
+        for block in message.content or []:
+            events.extend(_translate_block(block))
+        return events
+
+    if isinstance(message, ResultMessage):
+        return [TurnComplete(result_subtype=getattr(message, "subtype", None))]
+
+    # UserMessage (tool_result echoes back through the SDK), partial-message
+    # events, and anything else we don't recognize: ignore.
+    return []
+
+
+def _translate_block(block: Any) -> list[TurnEvent]:
+    """Map one content block inside an AssistantMessage to TurnEvents.
+
+    The SDK's block types are duck-typed in the docs; we match on attributes
+    rather than class names so minor SDK revisions don't break us.
+    """
+    # Text block
+    text = getattr(block, "text", None)
+    if isinstance(text, str) and text:
+        return [TextDelta(text=text)]
+
+    # Tool-use block: has name + input (+ id)
+    tool_name = getattr(block, "name", None)
+    tool_input = getattr(block, "input", None)
+    if tool_name is not None and tool_input is not None:
+        return [
+            ToolCall(
+                name=tool_name,
+                input=_as_dict(tool_input),
+                tool_use_id=getattr(block, "id", None),
+            )
+        ]
+
+    # Tool-result block: has tool_use_id + content, optional is_error
+    tu_id = getattr(block, "tool_use_id", None)
+    tu_content = getattr(block, "content", None)
+    if tu_id is not None and tu_content is not None:
+        return [
+            ToolResult(
+                tool_use_id=tu_id,
+                content=_coerce_tool_result_content(tu_content),
+                is_error=bool(getattr(block, "is_error", False)),
+            )
+        ]
+
+    return []
+
+
+def _as_dict(v: Any) -> dict[str, Any]:
+    if isinstance(v, dict):
+        return v
+    return {"value": v}
+
+
+def _coerce_tool_result_content(v: Any) -> Any:
+    """Tool result content can be a string or a list of content blocks;
+    unwrap the common case to a plain string so persistence is tidier."""
+    if isinstance(v, str):
+        return v
+    if isinstance(v, list) and all(
+        isinstance(item, dict) and item.get("type") == "text" for item in v
+    ):
+        return "".join(item.get("text", "") for item in v)
+    return v

--- a/ui/app/chat/providers/anthropic_compatible.py
+++ b/ui/app/chat/providers/anthropic_compatible.py
@@ -20,6 +20,7 @@ from claude_agent_sdk import (
     ClaudeAgentOptions,
     ResultMessage,
     SystemMessage,
+    UserMessage,
     query,
 )
 
@@ -124,6 +125,18 @@ def _translate(message: Any) -> list[TurnEvent]:
             events.extend(_translate_block(block))
         return events
 
+    if isinstance(message, UserMessage):
+        # The SDK echoes tool-result content back as a UserMessage whose
+        # content is a list of ContentBlocks (per the Anthropic wire protocol,
+        # tool results are user-role). String content is the original user
+        # turn — already known to the caller, so ignore.
+        if not isinstance(message.content, list):
+            return []
+        events = []
+        for block in message.content:
+            events.extend(_translate_block(block))
+        return events
+
     if isinstance(message, ResultMessage):
         if message.is_error:
             return [
@@ -133,8 +146,7 @@ def _translate(message: Any) -> list[TurnEvent]:
             ]
         return [TurnComplete(result_subtype=getattr(message, "subtype", None))]
 
-    # UserMessage (tool_result echoes back through the SDK), partial-message
-    # events, and anything else we don't recognize: ignore.
+    # Partial-message events and anything else we don't recognize: ignore.
     return []
 
 

--- a/ui/app/chat/providers/base.py
+++ b/ui/app/chat/providers/base.py
@@ -1,0 +1,134 @@
+"""Provider abstraction for the chat feature.
+
+Every provider emits a uniform :class:`TurnEvent` stream, regardless of the
+underlying wire protocol or SDK. Route handlers consume this stream, persist
+message rows, and (later) translate it into SSE frames for the browser.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Literal, Protocol, runtime_checkable
+
+from app.chat.config import ProviderConfig
+
+
+# ---------------------------------------------------------------------------
+# Turn events
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SessionInitialized:
+    """Emitted once per turn, early in the stream.
+
+    Carries the provider-assigned ``sdk_session_id`` so the caller can
+    persist it on :class:`ChatSession` for future resumes.
+    """
+
+    kind: Literal["session_initialized"] = "session_initialized"
+    sdk_session_id: str = ""
+
+
+@dataclass
+class TextDelta:
+    """A chunk of assistant text.
+
+    Providers that only deliver complete messages (non-streaming SDKs) emit
+    one :class:`TextDelta` per message; streaming providers emit many.
+    """
+
+    text: str
+    kind: Literal["text_delta"] = "text_delta"
+
+
+@dataclass
+class ToolCall:
+    """The model invoked a tool."""
+
+    name: str
+    input: dict[str, Any] = field(default_factory=dict)
+    tool_use_id: str | None = None
+    kind: Literal["tool_call"] = "tool_call"
+
+
+@dataclass
+class ToolResult:
+    """The result returned by a tool invocation."""
+
+    tool_use_id: str | None
+    content: Any
+    is_error: bool = False
+    kind: Literal["tool_result"] = "tool_result"
+
+
+@dataclass
+class TurnComplete:
+    """Final event of a successful turn."""
+
+    kind: Literal["turn_complete"] = "turn_complete"
+    result_subtype: str | None = None
+
+
+@dataclass
+class ErrorEvent:
+    """Terminal event for a failed turn."""
+
+    message: str
+    kind: Literal["error"] = "error"
+
+
+TurnEvent = (
+    SessionInitialized | TextDelta | ToolCall | ToolResult | TurnComplete | ErrorEvent
+)
+
+
+# ---------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Credentials:
+    """User-supplied credentials for a single turn.
+
+    Keyed by the ``id`` of each :class:`~app.chat.config.CredentialField`
+    declared on the provider. Values never leave per-request scope.
+    """
+
+    values: dict[str, str]
+
+    def require(self, field_id: str) -> str:
+        if field_id not in self.values or not self.values[field_id]:
+            raise ValueError(f"missing credential {field_id!r}")
+        return self.values[field_id]
+
+
+# ---------------------------------------------------------------------------
+# Provider protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ChatProvider(Protocol):
+    """Async generator of :class:`TurnEvent` for one chat turn."""
+
+    provider_id: str
+    config: ProviderConfig
+
+    def run_turn(
+        self,
+        *,
+        user_message: str,
+        credentials: Credentials,
+        model: str,
+        cwd: str,
+        sdk_session_id: str | None,
+    ) -> AsyncIterator[TurnEvent]:
+        """Run a single chat turn and yield events as they happen.
+
+        Implementations must yield a :class:`SessionInitialized` event once
+        the provider reports a session id, and a terminal
+        :class:`TurnComplete` or :class:`ErrorEvent` exactly once.
+        """
+        ...

--- a/ui/tests/test_chat_providers.py
+++ b/ui/tests/test_chat_providers.py
@@ -1,0 +1,433 @@
+"""Tests for the chat provider abstraction and Anthropic-compatible impl."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator
+from unittest.mock import patch
+
+import pytest
+
+from claude_agent_sdk import AssistantMessage, ResultMessage, SystemMessage
+
+from app.chat.config import ProviderConfig
+from app.chat.providers import (
+    get_provider,
+    get_providers,
+    reset_providers_cache,
+)
+from app.chat.providers.anthropic_compatible import AnthropicCompatibleProvider
+from app.chat.providers.base import (
+    ChatProvider,
+    Credentials,
+    ErrorEvent,
+    SessionInitialized,
+    TextDelta,
+    ToolCall,
+    ToolResult,
+    TurnComplete,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: use real SDK message classes so isinstance() checks in the
+# translator match. Blocks remain duck-typed because the translator reads
+# them via getattr().
+# ---------------------------------------------------------------------------
+
+
+def _sys_init(session_id: str) -> SystemMessage:
+    return SystemMessage(subtype="init", data={"session_id": session_id})
+
+
+def _assistant(blocks: list) -> AssistantMessage:
+    return AssistantMessage(content=blocks, model="m1")
+
+
+def _result(subtype: str = "end_turn") -> ResultMessage:
+    return ResultMessage(
+        subtype=subtype,
+        duration_ms=0,
+        duration_api_ms=0,
+        is_error=False,
+        num_turns=1,
+        session_id="s",
+    )
+
+
+class _FakeTextBlock:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class _FakeToolUseBlock:
+    def __init__(self, name: str, input_: dict, id_: str = "tu-1"):
+        self.name = name
+        self.input = input_
+        self.id = id_
+
+
+class _FakeToolResultBlock:
+    def __init__(self, tool_use_id: str, content: Any, is_error: bool = False):
+        self.tool_use_id = tool_use_id
+        self.content = content
+        self.is_error = is_error
+
+
+def _make_provider(auth_style: str = "api_key") -> AnthropicCompatibleProvider:
+    cfg = ProviderConfig(
+        display_name="Test",
+        wire_protocol="anthropic",
+        base_url="https://example.com",
+        auth_style=auth_style,
+        credential_fields=[
+            {"id": "api_key", "display_name": "API Key", "secret": True}
+        ],
+        models=[{"id": "m1", "display_name": "Model One"}],
+    )
+    return AnthropicCompatibleProvider(provider_id="test", config=cfg)
+
+
+def _fake_query(messages: list):
+    """Return a mock query() that yields the given message list."""
+
+    async def _fake(prompt: str, options):  # noqa: ARG001
+        for m in messages:
+            yield m
+
+    return _fake
+
+
+async def _collect(agen: AsyncIterator) -> list:
+    return [e async for e in agen]
+
+
+# ---------------------------------------------------------------------------
+# Translation
+# ---------------------------------------------------------------------------
+
+
+class TestTurnTranslation:
+    async def test_system_init_yields_session_initialized(self):
+        provider = _make_provider()
+        messages = [
+            _sys_init("sdk-session-123"),
+            _result(),
+        ]
+        with patch("app.chat.providers.anthropic_compatible.query", _fake_query(messages)):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="hi",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        kinds = [e.kind for e in events]
+        assert kinds == ["session_initialized", "turn_complete"]
+        assert events[0].sdk_session_id == "sdk-session-123"
+
+    async def test_assistant_text_yields_text_delta(self):
+        provider = _make_provider()
+        messages = [
+            _assistant([_FakeTextBlock("hello ")]),
+            _assistant([_FakeTextBlock("world")]),
+            _result(),
+        ]
+        with patch("app.chat.providers.anthropic_compatible.query", _fake_query(messages)):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="hi",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        text_events = [e for e in events if isinstance(e, TextDelta)]
+        assert [e.text for e in text_events] == ["hello ", "world"]
+
+    async def test_tool_call_translated(self):
+        provider = _make_provider()
+        messages = [
+            _assistant(
+                [_FakeToolUseBlock("berdl_query", {"sql": "SELECT 1"}, "tu-7")]
+            ),
+            _result(),
+        ]
+        with patch("app.chat.providers.anthropic_compatible.query", _fake_query(messages)):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="run a query",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        calls = [e for e in events if isinstance(e, ToolCall)]
+        assert len(calls) == 1
+        assert calls[0].name == "berdl_query"
+        assert calls[0].input == {"sql": "SELECT 1"}
+        assert calls[0].tool_use_id == "tu-7"
+
+    async def test_tool_result_string_content_passes_through(self):
+        provider = _make_provider()
+        messages = [
+            _assistant([_FakeToolResultBlock("tu-7", "3 rows returned")]),
+            _result(),
+        ]
+        with patch("app.chat.providers.anthropic_compatible.query", _fake_query(messages)):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="x",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        results = [e for e in events if isinstance(e, ToolResult)]
+        assert len(results) == 1
+        assert results[0].content == "3 rows returned"
+        assert results[0].is_error is False
+
+    async def test_tool_result_list_of_text_blocks_joined(self):
+        provider = _make_provider()
+        content = [{"type": "text", "text": "part-a "}, {"type": "text", "text": "part-b"}]
+        messages = [
+            _assistant([_FakeToolResultBlock("tu-7", content)]),
+            _result(),
+        ]
+        with patch("app.chat.providers.anthropic_compatible.query", _fake_query(messages)):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="x",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        results = [e for e in events if isinstance(e, ToolResult)]
+        assert results[0].content == "part-a part-b"
+
+    async def test_result_message_yields_turn_complete(self):
+        provider = _make_provider()
+        messages = [_result(subtype="end_turn")]
+        with patch("app.chat.providers.anthropic_compatible.query", _fake_query(messages)):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="x",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        terminal = events[-1]
+        assert isinstance(terminal, TurnComplete)
+        assert terminal.result_subtype == "end_turn"
+
+    async def test_exception_surfaces_as_error_event(self):
+        provider = _make_provider()
+
+        async def _bad_query(prompt, options):  # noqa: ARG001
+            yield _sys_init("sess-x")
+            raise RuntimeError("upstream 500")
+
+        with patch("app.chat.providers.anthropic_compatible.query", _bad_query):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="x",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        assert isinstance(events[-1], ErrorEvent)
+        assert "upstream 500" in events[-1].message
+
+    async def test_turn_complete_synthesized_if_missing(self):
+        """If the SDK stream ends without a ResultMessage, we still emit a
+        terminal event so callers don't hang."""
+        provider = _make_provider()
+        messages = [_assistant([_FakeTextBlock("hi")])]
+        with patch("app.chat.providers.anthropic_compatible.query", _fake_query(messages)):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="x",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        assert isinstance(events[-1], TurnComplete)
+
+
+# ---------------------------------------------------------------------------
+# Options wiring: env, resume, cwd, skills
+# ---------------------------------------------------------------------------
+
+
+class TestOptionsWiring:
+    async def _capture_options(self, provider, **turn_kwargs):
+        captured: dict[str, Any] = {}
+
+        async def _spy_query(prompt, options):
+            captured["prompt"] = prompt
+            captured["options"] = options
+            yield _result()
+
+        with patch("app.chat.providers.anthropic_compatible.query", _spy_query):
+            await _collect(provider.run_turn(**turn_kwargs))
+        return captured
+
+    async def test_api_key_auth_uses_x_api_key_env(self):
+        """auth_style=api_key → key in ANTHROPIC_API_KEY (x-api-key header)."""
+        provider = _make_provider(auth_style="api_key")
+        captured = await self._capture_options(
+            provider,
+            user_message="hi",
+            credentials=Credentials({"api_key": "user-secret"}),
+            model="m1",
+            cwd="/tmp/repo",
+            sdk_session_id=None,
+        )
+        env = captured["options"].env
+        assert env["ANTHROPIC_BASE_URL"] == "https://example.com"
+        assert env["ANTHROPIC_API_KEY"] == "user-secret"
+        # The bearer env var is blanked so a stale server-level default
+        # can't win and produce "invalid bearer token".
+        assert env["ANTHROPIC_AUTH_TOKEN"] == ""
+
+    async def test_bearer_auth_uses_auth_token_env(self):
+        """auth_style=bearer → key in ANTHROPIC_AUTH_TOKEN (Bearer header).
+
+        This is what CBORG and similar OAuth-style proxies need.
+        """
+        provider = _make_provider(auth_style="bearer")
+        captured = await self._capture_options(
+            provider,
+            user_message="hi",
+            credentials=Credentials({"api_key": "user-secret"}),
+            model="m1",
+            cwd="/tmp/repo",
+            sdk_session_id=None,
+        )
+        env = captured["options"].env
+        assert env["ANTHROPIC_AUTH_TOKEN"] == "user-secret"
+        assert env["ANTHROPIC_API_KEY"] == ""
+
+    async def test_default_auth_style_is_api_key(self):
+        """No auth_style in YAML should default to api_key (direct Anthropic)."""
+        cfg = ProviderConfig(
+            display_name="Default",
+            wire_protocol="anthropic",
+            base_url="https://example.com",
+            credential_fields=[{"id": "api_key", "display_name": "K", "secret": True}],
+            models=[{"id": "m1", "display_name": "Model One"}],
+        )
+        assert cfg.auth_style == "api_key"
+
+    async def test_resume_passed_through(self):
+        provider = _make_provider()
+        captured = await self._capture_options(
+            provider,
+            user_message="hi",
+            credentials=Credentials({"api_key": "k"}),
+            model="m1",
+            cwd="/tmp",
+            sdk_session_id="prior-session",
+        )
+        assert captured["options"].resume == "prior-session"
+
+    async def test_resume_none_when_fresh(self):
+        provider = _make_provider()
+        captured = await self._capture_options(
+            provider,
+            user_message="hi",
+            credentials=Credentials({"api_key": "k"}),
+            model="m1",
+            cwd="/tmp",
+            sdk_session_id=None,
+        )
+        assert captured["options"].resume is None
+
+    async def test_model_and_cwd_passed(self):
+        provider = _make_provider()
+        captured = await self._capture_options(
+            provider,
+            user_message="hi",
+            credentials=Credentials({"api_key": "k"}),
+            model="claude-opus-4-7",
+            cwd="/repo",
+            sdk_session_id=None,
+        )
+        assert captured["options"].model == "claude-opus-4-7"
+        assert str(captured["options"].cwd) == "/repo"
+
+    async def test_skills_enabled_all(self):
+        provider = _make_provider()
+        captured = await self._capture_options(
+            provider,
+            user_message="hi",
+            credentials=Credentials({"api_key": "k"}),
+            model="m1",
+            cwd="/tmp",
+            sdk_session_id=None,
+        )
+        assert captured["options"].skills == "all"
+
+    async def test_missing_api_key_raises(self):
+        provider = _make_provider()
+        with pytest.raises(ValueError, match="api_key"):
+            async for _ in provider.run_turn(
+                user_message="hi",
+                credentials=Credentials({}),
+                model="m1",
+                cwd="/tmp",
+                sdk_session_id=None,
+            ):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def setup_method(self):
+        reset_providers_cache()
+
+    def teardown_method(self):
+        reset_providers_cache()
+
+    def test_registry_built_from_shipped_config(self):
+        providers = get_providers()
+        assert set(providers.keys()) == {"anthropic", "cborg"}
+        assert isinstance(providers["anthropic"], ChatProvider)
+        assert isinstance(providers["cborg"], ChatProvider)
+
+    def test_get_provider_returns_same_instance(self):
+        p1 = get_provider("anthropic")
+        p2 = get_provider("anthropic")
+        assert p1 is p2
+
+    def test_get_provider_unknown_raises(self):
+        with pytest.raises(KeyError):
+            get_provider("does-not-exist")
+
+    def test_registry_caches(self):
+        first = get_providers()
+        second = get_providers()
+        assert first is second
+
+    def test_reset_drops_cache(self):
+        first = get_providers()
+        reset_providers_cache()
+        second = get_providers()
+        assert first is not second

--- a/ui/tests/test_chat_providers.py
+++ b/ui/tests/test_chat_providers.py
@@ -7,7 +7,13 @@ from unittest.mock import patch
 
 import pytest
 
-from claude_agent_sdk import AssistantMessage, ResultMessage, SystemMessage
+from claude_agent_sdk import (
+    AssistantMessage,
+    ResultMessage,
+    SystemMessage,
+    ToolResultBlock,
+    UserMessage,
+)
 
 from app.chat.config import ProviderConfig
 from app.chat.providers import (
@@ -191,6 +197,60 @@ class TestTurnTranslation:
         assert len(results) == 1
         assert results[0].content == "3 rows returned"
         assert results[0].is_error is False
+
+    async def test_tool_result_from_user_message_translated(self):
+        """The SDK echoes tool results as UserMessages whose content is a
+        list of real ToolResultBlocks (per Anthropic wire protocol —
+        tool_result is user-role). The provider must translate those into
+        ToolResult events; otherwise tool outputs are silently dropped on
+        every tool-using turn."""
+        provider = _make_provider()
+        tool_result_block = ToolResultBlock(
+            tool_use_id="tu-7",
+            content="3 rows returned",
+            is_error=False,
+        )
+        messages = [
+            _assistant([_FakeToolUseBlock("berdl_query", {"sql": "SELECT 1"}, "tu-7")]),
+            UserMessage(content=[tool_result_block]),
+            _result(),
+        ]
+        with patch("app.chat.providers.anthropic_compatible.query", _fake_query(messages)):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="run a query",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        results = [e for e in events if isinstance(e, ToolResult)]
+        assert len(results) == 1
+        assert results[0].tool_use_id == "tu-7"
+        assert results[0].content == "3 rows returned"
+        assert results[0].is_error is False
+
+    async def test_user_message_string_content_ignored(self):
+        """A UserMessage with plain string content is the user's turn echo —
+        not a tool result. It must not produce any TurnEvent."""
+        provider = _make_provider()
+        messages = [
+            UserMessage(content="hello"),
+            _result(),
+        ]
+        with patch("app.chat.providers.anthropic_compatible.query", _fake_query(messages)):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="hello",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        # Only the terminal TurnComplete should be present.
+        assert [e.kind for e in events] == ["turn_complete"]
 
     async def test_tool_result_list_of_text_blocks_joined(self):
         provider = _make_provider()

--- a/ui/tests/test_chat_providers.py
+++ b/ui/tests/test_chat_providers.py
@@ -229,6 +229,33 @@ class TestTurnTranslation:
         assert isinstance(terminal, TurnComplete)
         assert terminal.result_subtype == "end_turn"
 
+    async def test_result_message_is_error_yields_error_event(self):
+        """A terminal ResultMessage with is_error=True must surface as an
+        ErrorEvent so callers don't persist a partial response as success."""
+        provider = _make_provider()
+        err_result = ResultMessage(
+            subtype="error_max_turns",
+            duration_ms=0,
+            duration_api_ms=0,
+            is_error=True,
+            num_turns=1,
+            session_id="s",
+        )
+        messages = [_assistant([_FakeTextBlock("partial ")]), err_result]
+        with patch("app.chat.providers.anthropic_compatible.query", _fake_query(messages)):
+            events = await _collect(
+                provider.run_turn(
+                    user_message="x",
+                    credentials=Credentials({"api_key": "k"}),
+                    model="m1",
+                    cwd="/tmp",
+                    sdk_session_id=None,
+                )
+            )
+        assert isinstance(events[-1], ErrorEvent)
+        assert "error_max_turns" in events[-1].message
+        assert not any(isinstance(e, TurnComplete) for e in events)
+
     async def test_exception_surfaces_as_error_event(self):
         provider = _make_provider()
 
@@ -381,17 +408,22 @@ class TestOptionsWiring:
         )
         assert captured["options"].skills == "all"
 
-    async def test_missing_api_key_raises(self):
+    async def test_missing_api_key_yields_terminal_error_event(self):
+        """Missing credentials must surface as a terminal ErrorEvent, not
+        an exception. Route handlers consume providers as event streams and
+        rely on a normal terminal event for this user-input failure path."""
         provider = _make_provider()
-        with pytest.raises(ValueError, match="api_key"):
-            async for _ in provider.run_turn(
+        events = await _collect(
+            provider.run_turn(
                 user_message="hi",
                 credentials=Credentials({}),
                 model="m1",
                 cwd="/tmp",
                 sdk_session_id=None,
-            ):
-                pass
+            )
+        )
+        assert isinstance(events[-1], ErrorEvent)
+        assert "api_key" in events[-1].message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Third in a 7-PR series adding an LLM chat interface. Defines the
provider Protocol all later PRs program against, and the one
implementation needed for the shipped catalog (Anthropic + CBORG).
Stacks on top of #215.

## What this PR adds

- **`ChatProvider` Protocol** with a single async `run_turn()` that
  yields a `TurnEvent` stream. Event types: `SessionInitialized`,
  `TextDelta`, `ToolCall`, `ToolResult`, `TurnComplete`, `ErrorEvent`.
  The stream shape is the contract between provider implementations
  and the service layer that lands in PR #4.
- **`Credentials`** dataclass with `require()` — declarative match
  against the provider config's `credential_fields`. Bedrock-style
  multi-field credentials slot in without API changes.
- **`AnthropicCompatibleProvider`**: wraps `claude_agent_sdk.query()`
  and translates `SystemMessage`/`AssistantMessage`/`ResultMessage` and
  blocks into `TurnEvent`s. Per-turn `env`
  (`ANTHROPIC_BASE_URL` plus either `ANTHROPIC_API_KEY` or
  `ANTHROPIC_AUTH_TOKEN` depending on the provider's `auth_style`)
  keeps user keys out of the parent process env. The unused auth env
  var is blanked so a stale server-level default cannot shadow the
  user's token.
- **Lazy registry** built from `get_chat_config()`;
  `get_provider("anthropic")` / `get_provider("cborg")` return cached
  instances.

## Tests

21 tests covering frame translation (each block type), missing
credentials, the `auth_style` branch, registry lookup/caching/reset,
and a synthesized `TurnComplete` when the SDK ends without one. Full
suite: 607 passing.

Note: the SDK is not exercised end-to-end here; the service layer that
calls it (and a real subprocess) lands in PR #4.

## Stack context

This is **3 of 7**. PRs #1 (#214) and #2 (#215) are merged.
