### PR TITLE
Update spin deployment gha commands

### DIFF
--- a/.github/workflows/deploy-spin-dev.yml
+++ b/.github/workflows/deploy-spin-dev.yml
@@ -1,0 +1,34 @@
+name: Deploy to SPIN production environment
+
+on:
+  workflow_dispatch:
+
+env:
+  RANCHER_URL: https://rancher2.spin.nersc.gov/v3
+  RANCHER_CLI_VERSION: v2.13.2
+  RANCHER_NAMESPACE: knowledge-engine
+  DEPLOYMENT_NAME: beril-develop
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Rancher CLI
+        run: |
+          wget -q https://github.com/rancher/cli/releases/download/${{ env.RANCHER_CLI_VERSION }}/rancher-linux-amd64-${{ env.RANCHER_CLI_VERSION }}.tar.gz
+          tar -xzf rancher-linux-amd64-${{ env.RANCHER_CLI_VERSION }}.tar.gz
+          sudo mv rancher-${{ env.RANCHER_CLI_VERSION }}/rancher /usr/local/bin/
+          rancher --version
+
+      - name: Login to SPIN Rancher
+        run: |
+          rancher login --token ${{ secrets.SPIN_RANCHER_API_KEY }} --context ${{ secrets.RANCHER_DEV_PROJECT_ID }} ${{ env.RANCHER_URL }}
+
+      - name: Restart deployment
+        run: |
+          rancher kubectl -n ${{ env.RANCHER_NAMESPACE }} rollout restart deploy/${{ env.DEPLOYMENT_NAME }}
+
+      - name: Verify deployment
+        run: |
+          rancher kubectl -n ${{ env.RANCHER_NAMESPACE }} rollout status deploy/${{ env.DEPLOYMENT_NAME }} --timeout=5m

--- a/.github/workflows/deploy-spin-prod.yml
+++ b/.github/workflows/deploy-spin-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy to SPIN
+name: Deploy to SPIN production environment
 
 on:
   workflow_run:
@@ -12,8 +12,8 @@ on:
 env:
   RANCHER_URL: https://rancher2.spin.nersc.gov/v3
   RANCHER_CLI_VERSION: v2.13.2
-  RANCHER_NAMESPACE: knowledge-engine
-  DEPLOYMENT_NAME: beril-observatory
+  RANCHER_NAMESPACE: beril
+  DEPLOYMENT_NAME: observatory-ui
 
 jobs:
   deploy:
@@ -29,7 +29,7 @@ jobs:
 
       - name: Login to SPIN Rancher
         run: |
-          rancher login --token ${{ secrets.SPIN_RANCHER_API_KEY }} --context ${{ secrets.RANCHER_PROJECT_ID }} ${{ env.RANCHER_URL }}
+          rancher login --token ${{ secrets.SPIN_RANCHER_API_KEY }} --context ${{ secrets.RANCHER_PROD_PROJECT_ID }} ${{ env.RANCHER_URL }}
 
       - name: Restart deployment
         run: |


### PR DESCRIPTION
1. Updates the prod deploy script to deploy to the production SPIN deployment instead of the development one.
2. Adds a new development deploy script that works on request - PRs are coming fast and furious right now so having just the latest PR go up might just be confusing.