### PR TITLE
chat: non-streaming turn endpoint with concurrency control (4/7)

### DIFF
--- a/ui/app/chat/concurrency.py
+++ b/ui/app/chat/concurrency.py
@@ -1,0 +1,110 @@
+"""Per-session and per-user concurrency control for chat turns.
+
+Two guarantees:
+
+1. **One active turn per session.** The underlying Agent SDK session is
+   stateful; two concurrent turns would race on the same ``sdk_session_id``
+   and corrupt the conversation. Enforced with a per-session :class:`asyncio.Lock`.
+
+2. **Bounded parallelism per user.** A user running many tabs can still run
+   turns in parallel across their sessions, but not unbounded. Enforced with
+   a per-user :class:`asyncio.Semaphore` sized from
+   ``settings.chat_max_concurrent_turns_per_user``.
+
+The manager is process-local. If this app ever runs multi-worker, these
+guarantees collapse to per-worker; upgrade to a Redis lock or move turns
+onto a single background worker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from app.config import get_settings
+
+
+class UserCapExceeded(Exception):
+    """Raised when the per-user concurrent-turn cap would be exceeded."""
+
+
+class ChatConcurrencyManager:
+    def __init__(self, *, per_user_cap: int) -> None:
+        if per_user_cap < 1:
+            raise ValueError("per_user_cap must be >= 1")
+        self._per_user_cap = per_user_cap
+        self._session_locks: dict[str, asyncio.Lock] = {}
+        # user_id -> current count of active turns. Incremented atomically
+        # under _registry_lock; decremented after the turn finishes. Using a
+        # plain counter (rather than asyncio.Semaphore) lets us fail fast
+        # when the cap is exceeded instead of queueing the caller.
+        self._user_active: dict[str, int] = {}
+        self._registry_lock = asyncio.Lock()
+
+    async def _get_session_lock(self, session_id: str) -> asyncio.Lock:
+        async with self._registry_lock:
+            lock = self._session_locks.get(session_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._session_locks[session_id] = lock
+            return lock
+
+    async def _try_reserve_user_slot(self, user_id: str) -> bool:
+        async with self._registry_lock:
+            active = self._user_active.get(user_id, 0)
+            if active >= self._per_user_cap:
+                return False
+            self._user_active[user_id] = active + 1
+            return True
+
+    async def _release_user_slot(self, user_id: str) -> None:
+        async with self._registry_lock:
+            active = self._user_active.get(user_id, 0)
+            if active <= 1:
+                self._user_active.pop(user_id, None)
+            else:
+                self._user_active[user_id] = active - 1
+
+    def active_turns_for(self, user_id: str) -> int:
+        """Introspection for tests and debugging."""
+        return self._user_active.get(user_id, 0)
+
+    @asynccontextmanager
+    async def acquire(self, *, session_id: str, user_id: str) -> AsyncIterator[None]:
+        """Acquire both the user-cap and session-lock for one turn.
+
+        Non-blocking on the user cap: if the cap is already exhausted,
+        raises :class:`UserCapExceeded` immediately rather than queueing the
+        caller. This lets the route return 429 to the browser quickly.
+
+        Blocks on the session lock. Two turns in the same chat will serialize.
+        """
+        reserved = await self._try_reserve_user_slot(user_id)
+        if not reserved:
+            raise UserCapExceeded(
+                f"user {user_id!r} has reached the concurrent-turn cap"
+            )
+        try:
+            lock = await self._get_session_lock(session_id)
+            async with lock:
+                yield
+        finally:
+            await self._release_user_slot(user_id)
+
+
+_manager: ChatConcurrencyManager | None = None
+
+
+def get_concurrency_manager() -> ChatConcurrencyManager:
+    global _manager
+    if _manager is None:
+        cap = get_settings().chat_max_concurrent_turns_per_user
+        _manager = ChatConcurrencyManager(per_user_cap=cap)
+    return _manager
+
+
+def reset_concurrency_manager() -> None:
+    """Tests only."""
+    global _manager
+    _manager = None

--- a/ui/app/chat/concurrency.py
+++ b/ui/app/chat/concurrency.py
@@ -80,17 +80,17 @@ class ChatConcurrencyManager:
 
         Blocks on the session lock. Two turns in the same chat will serialize.
         """
-        reserved = await self._try_reserve_user_slot(user_id)
-        if not reserved:
-            raise UserChatConcurrencyExceeded(
-                f"user {user_id!r} has reached the concurrent-turn cap"
-            )
-        try:
-            lock = await self._get_session_lock(session_id)
-            async with lock:
+        lock = await self._get_session_lock(session_id)
+        async with lock:
+            reserved = await self._try_reserve_user_slot(user_id)
+            if not reserved:
+                raise UserChatConcurrencyExceeded(
+                    f"user {user_id!r} has reached the concurrent-turn cap"
+                )
+            try:
                 yield
-        finally:
-            await self._release_user_slot(user_id)
+            finally:
+                await self._release_user_slot(user_id)
 
 
 _manager: ChatConcurrencyManager | None = None

--- a/ui/app/chat/concurrency.py
+++ b/ui/app/chat/concurrency.py
@@ -25,7 +25,7 @@ from typing import AsyncIterator
 from app.config import get_settings
 
 
-class UserCapExceeded(Exception):
+class UserChatConcurrencyExceeded(Exception):
     """Raised when the per-user concurrent-turn cap would be exceeded."""
 
 
@@ -75,14 +75,14 @@ class ChatConcurrencyManager:
         """Acquire both the user-cap and session-lock for one turn.
 
         Non-blocking on the user cap: if the cap is already exhausted,
-        raises :class:`UserCapExceeded` immediately rather than queueing the
+        raises :class:`UserChatConcurrencyExceeded` immediately rather than queueing the
         caller. This lets the route return 429 to the browser quickly.
 
         Blocks on the session lock. Two turns in the same chat will serialize.
         """
         reserved = await self._try_reserve_user_slot(user_id)
         if not reserved:
-            raise UserCapExceeded(
+            raise UserChatConcurrencyExceeded(
                 f"user {user_id!r} has reached the concurrent-turn cap"
             )
         try:
@@ -105,6 +105,6 @@ def get_concurrency_manager() -> ChatConcurrencyManager:
 
 
 def reset_concurrency_manager() -> None:
-    """Tests only."""
+    """Used for tests only."""
     global _manager
     _manager = None

--- a/ui/app/chat/crud.py
+++ b/ui/app/chat/crud.py
@@ -1,0 +1,29 @@
+"""Database access helpers for chat sessions and messages.
+
+Mirrors the style of :mod:`app.db.crud` but scoped to the chat feature.
+Route handlers import from here; the service layer talks to models directly
+because it's tightly coupled to the turn lifecycle.
+
+Currently this file holds only the read helper the service layer needs to
+reconstruct prior context when an SDK transcript file goes missing. The
+session CRUD helpers used by the management UI land in a later PR.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import ChatMessage
+
+
+async def list_messages_for_session(
+    db: AsyncSession, session_id: str
+) -> list[ChatMessage]:
+    """Return all messages for ``session_id`` in chronological order."""
+    result = await db.execute(
+        select(ChatMessage)
+        .where(ChatMessage.session_id == session_id)
+        .order_by(ChatMessage.created_at.asc())
+    )
+    return list(result.scalars())

--- a/ui/app/chat/crud.py
+++ b/ui/app/chat/crud.py
@@ -9,8 +9,6 @@ reconstruct prior context when an SDK transcript file goes missing. The
 session CRUD helpers used by the management UI land in a later PR.
 """
 
-from __future__ import annotations
-
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/ui/app/chat/sdk_sessions.py
+++ b/ui/app/chat/sdk_sessions.py
@@ -1,0 +1,74 @@
+"""Bridge between our chat persistence and the Claude Agent SDK's on-disk
+session store.
+
+The SDK writes a JSONL transcript per session under
+``$HOME/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`` and reads it
+back when ``resume=<session-id>`` is passed. Our DB stores the
+``sdk_session_id`` as a resume handle plus its own transcript in
+``ChatMessage`` rows. When the two diverge — file missing but DB still
+holds the ID — resume fails with "No conversation found". This module
+handles the divergence: detect it, and synthesize a DB-backed preamble so
+a cold-started session starts with the prior context intact.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Iterable
+
+from app.db.models import ChatMessage
+
+# Mirrors claude_agent_sdk._internal.sessions._SANITIZE_RE. The rule is
+# stable across SDK versions; if it ever changes, the existence check will
+# start missing and we'll cold-start more aggressively — which is the safe
+# failure mode.
+_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9]")
+
+
+def _claude_projects_dir() -> Path:
+    """Mirrors the SDK's directory-resolution rule."""
+    override = os.environ.get("CLAUDE_CONFIG_DIR")
+    if override:
+        return Path(override) / "projects"
+    return Path.home() / ".claude" / "projects"
+
+
+def session_file_path(cwd: str, session_id: str) -> Path:
+    """Return the path the SDK would write/read for this session."""
+    sanitized = _SANITIZE_RE.sub("-", cwd)
+    return _claude_projects_dir() / sanitized / f"{session_id}.jsonl"
+
+
+def session_file_exists(cwd: str, session_id: str | None) -> bool:
+    if not session_id:
+        return False
+    return session_file_path(cwd, session_id).is_file()
+
+
+def build_resume_preamble(messages: Iterable[ChatMessage]) -> str:
+    """Render prior messages as a plain-text preamble for cold-start.
+
+    Called when the SDK transcript is missing but we still have our own DB
+    history. We replay the conversation as context in the next user prompt
+    so the model isn't starting blind. This is a pragmatic reconstruction
+    — not byte-identical to the SDK's format, so prompt-cache hits are
+    forfeit for this turn, but subsequent turns resume normally from the
+    newly-written SDK transcript.
+    """
+    lines: list[str] = []
+    for msg in messages:
+        content = msg.content or {}
+        text = content.get("text") if isinstance(content, dict) else None
+        if not text:
+            continue
+        label = "User" if msg.role == "user" else "Assistant"
+        lines.append(f"{label}: {text}")
+    if not lines:
+        return ""
+    return (
+        "[Previous conversation, reconstructed from stored history]\n"
+        + "\n\n".join(lines)
+        + "\n\n[End of previous conversation]\n\n"
+    )

--- a/ui/app/chat/sdk_sessions.py
+++ b/ui/app/chat/sdk_sessions.py
@@ -11,8 +11,6 @@ handles the divergence: detect it, and synthesize a DB-backed preamble so
 a cold-started session starts with the prior context intact.
 """
 
-from __future__ import annotations
-
 import os
 import re
 from pathlib import Path

--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -13,8 +13,6 @@ Responsibilities:
 This layer is provider-agnostic and streaming-agnostic.
 """
 
-from __future__ import annotations
-
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone

--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -103,7 +103,9 @@ async def run_turn(
     The session row is expected to be owned by the caller; auth happens at
     the route layer. This function does not validate ownership.
     """
-    await persist_user_message(db, session=session, user_message=user_message)
+    user_row = await persist_user_message(
+        db, session=session, user_message=user_message
+    )
 
     result = TurnResult()
     text_parts: list[str] = []
@@ -113,6 +115,7 @@ async def run_turn(
         session=session,
         user_message=user_message,
         credentials=credentials,
+        skip_message_id=user_row.id,
     ):
         fold_event(event, text_parts, result)
 
@@ -127,6 +130,7 @@ async def run_provider_turn(
     session: ChatSession,
     user_message: str,
     credentials: Credentials,
+    skip_message_id: str | None = None,
 ) -> AsyncIterator[TurnEvent]:
     """Resolve the provider and stream its events. No persistence.
 
@@ -152,7 +156,7 @@ async def run_provider_turn(
         prior = await list_messages_for_session(db, session.id)
         # Drop the just-persisted user message — it's already in
         # ``user_message`` and will be sent as the live prompt.
-        preamble_sources = [m for m in prior if m.content != {"text": user_message}]
+        preamble_sources = [m for m in prior if m.id != skip_message_id]
         preamble = build_resume_preamble(preamble_sources)
         outbound_message = preamble + user_message
         resume_id = None

--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -1,0 +1,202 @@
+"""Chat turn service: drives one turn end-to-end.
+
+Responsibilities:
+  * Persist the user's message before calling the provider (so it survives a
+    crash mid-turn and is visible in the transcript on resume).
+  * Run the provider and collect events.
+  * Persist a single assistant message (aggregating text deltas + tool calls)
+    when the turn finishes.
+  * Record the ``sdk_session_id`` on first completion so subsequent turns
+    resume correctly.
+  * Update ``last_active_at`` so the session list can sort by recency.
+
+This layer is provider-agnostic and streaming-agnostic.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, AsyncIterator
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.chat.crud import list_messages_for_session
+from app.chat.providers import get_provider
+from app.chat.providers.base import (
+    Credentials,
+    ErrorEvent,
+    SessionInitialized,
+    TextDelta,
+    ToolCall,
+    ToolResult,
+    TurnComplete,
+    TurnEvent,
+)
+from app.chat.sdk_sessions import build_resume_preamble, session_file_exists
+from app.config import get_settings
+from app.db.models import ChatMessage, ChatSession
+
+logger = logging.getLogger(__name__)
+
+
+async def persist_user_message(
+    db: AsyncSession, *, session: ChatSession, user_message: str
+) -> ChatMessage:
+    """Write the user's message and commit. Called before provider dispatch."""
+    row = ChatMessage(
+        session_id=session.id, role="user", content={"text": user_message}
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def persist_assistant_message(
+    db: AsyncSession,
+    *,
+    session: ChatSession,
+    result: "TurnResult",
+) -> ChatMessage:
+    """Write the assistant's message, update session state, commit."""
+    row = ChatMessage(
+        session_id=session.id,
+        role="assistant",
+        content={
+            "text": result.assistant_text,
+            "tool_activity": result.tool_activity,
+            "error": result.error,
+        },
+    )
+    db.add(row)
+    if result.sdk_session_id and not session.sdk_session_id:
+        session.sdk_session_id = result.sdk_session_id
+    session.last_active_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+@dataclass
+class TurnResult:
+    """Outcome of one completed turn. Callers returning JSON use this."""
+
+    assistant_text: str = ""
+    tool_activity: list[dict[str, Any]] = field(default_factory=list)
+    sdk_session_id: str | None = None
+    error: str | None = None
+
+    @property
+    def is_error(self) -> bool:
+        return self.error is not None
+
+
+async def run_turn(
+    db: AsyncSession,
+    *,
+    session: ChatSession,
+    user_message: str,
+    credentials: Credentials,
+) -> TurnResult:
+    """Run one chat turn to completion and persist messages.
+
+    The session row is expected to be owned by the caller; auth happens at
+    the route layer. This function does not validate ownership.
+    """
+    await persist_user_message(db, session=session, user_message=user_message)
+
+    result = TurnResult()
+    text_parts: list[str] = []
+
+    async for event in run_provider_turn(
+        db=db,
+        session=session,
+        user_message=user_message,
+        credentials=credentials,
+    ):
+        fold_event(event, text_parts, result)
+
+    result.assistant_text = "".join(text_parts)
+    await persist_assistant_message(db, session=session, result=result)
+    return result
+
+
+async def run_provider_turn(
+    *,
+    db: AsyncSession,
+    session: ChatSession,
+    user_message: str,
+    credentials: Credentials,
+) -> AsyncIterator[TurnEvent]:
+    """Resolve the provider and stream its events. No persistence.
+
+    Exposed separately so the streaming endpoint can consume the event
+    stream directly while still sharing provider resolution.
+
+    If ``session.sdk_session_id`` points to a transcript the SDK can no
+    longer find on disk (volume wiped, different replica, etc.), we clear
+    the stale handle and cold-start the SDK with a reconstructed preamble
+    of prior DB-stored messages so the user doesn't lose context.
+    """
+    provider = get_provider(session.provider_id)
+    cwd = str(get_settings().repo_dir)
+
+    resume_id: str | None = session.sdk_session_id
+    outbound_message = user_message
+    if resume_id and not session_file_exists(cwd, resume_id):
+        logger.warning(
+            "SDK transcript missing for session %s (sdk_session_id=%s); cold-starting with DB preamble",
+            session.id,
+            resume_id,
+        )
+        prior = await list_messages_for_session(db, session.id)
+        # Drop the just-persisted user message — it's already in
+        # ``user_message`` and will be sent as the live prompt.
+        preamble_sources = [m for m in prior if m.content != {"text": user_message}]
+        preamble = build_resume_preamble(preamble_sources)
+        outbound_message = preamble + user_message
+        resume_id = None
+        # Clear the stale handle so persist_assistant_message accepts the
+        # new session ID emitted by the cold-started SDK run.
+        session.sdk_session_id = None
+
+    async for event in provider.run_turn(
+        user_message=outbound_message,
+        credentials=credentials,
+        model=session.model,
+        cwd=cwd,
+        sdk_session_id=resume_id,
+    ):
+        yield event
+
+
+def fold_event(event: TurnEvent, text_parts: list[str], result: TurnResult) -> None:
+    """Accumulate a provider event into the in-progress TurnResult."""
+    if isinstance(event, SessionInitialized):
+        result.sdk_session_id = event.sdk_session_id
+    elif isinstance(event, TextDelta):
+        text_parts.append(event.text)
+    elif isinstance(event, ToolCall):
+        result.tool_activity.append(
+            {
+                "type": "tool_call",
+                "name": event.name,
+                "input": event.input,
+                "tool_use_id": event.tool_use_id,
+            }
+        )
+    elif isinstance(event, ToolResult):
+        result.tool_activity.append(
+            {
+                "type": "tool_result",
+                "tool_use_id": event.tool_use_id,
+                "content": event.content,
+                "is_error": event.is_error,
+            }
+        )
+    elif isinstance(event, ErrorEvent):
+        result.error = event.message
+    elif isinstance(event, TurnComplete):
+        pass  # terminal sentinel; nothing to fold

--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -157,6 +157,10 @@ async def run_provider_turn(
         # Drop the just-persisted user message — it's already in
         # ``user_message`` and will be sent as the live prompt.
         preamble_sources = [m for m in prior if m.id != skip_message_id]
+        # Trim trailing user messages left by a previous interrupted turn
+        # (crashed after persist_user_message but before persist_assistant_message).
+        while preamble_sources and preamble_sources[-1].role == "user":
+            preamble_sources.pop()
         preamble = build_resume_preamble(preamble_sources)
         outbound_message = preamble + user_message
         resume_id = None

--- a/ui/app/main.py
+++ b/ui/app/main.py
@@ -28,6 +28,7 @@ from app.filters import (
 
 from .routes.admin import ROUTER_ADMIN
 from .routes.auth import ROUTER_AUTH
+from .routes.chat import ROUTER_CHAT
 from .routes.data import ROUTER_USER_DATA
 from .routes.user import ROUTER_USER
 from .config import get_settings
@@ -86,6 +87,7 @@ def create_app() -> FastAPI:
 
     app.include_router(ROUTER_ADMIN)
     app.include_router(ROUTER_AUTH)
+    app.include_router(ROUTER_CHAT)
     app.include_router(ROUTER_COLLECTIONS)
     app.include_router(ROUTER_USER)
     app.include_router(ROUTER_USER_DATA)

--- a/ui/app/routes/chat.py
+++ b/ui/app/routes/chat.py
@@ -86,6 +86,9 @@ async def chat_turn(
     manager = get_concurrency_manager()
     try:
         async with manager.acquire(session_id=session.id, user_id=user.id):
+            # Refresh after acquiring the lock so we see any sdk_session_id
+            # written by a turn that just finished on this same session.
+            await db.refresh(session)
             turn = await run_turn(
                 db,
                 session=session,

--- a/ui/app/routes/chat.py
+++ b/ui/app/routes/chat.py
@@ -1,0 +1,111 @@
+"""Chat routes.
+
+Exposes non-streaming turn execution. A streaming (SSE) endpoint is
+layered on top in a later PR and shares the same service layer.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user_session_or_token
+from app.chat.concurrency import UserCapExceeded, get_concurrency_manager
+from app.chat.providers import get_provider
+from app.chat.providers.base import Credentials
+from app.chat.service import run_turn
+from app.db.models import ChatSession
+from app.db.session import get_db
+
+logger = logging.getLogger(__name__)
+
+ROUTER_CHAT = APIRouter(prefix="/api/chat", tags=["Chat"])
+
+
+class TurnRequest(BaseModel):
+    """JSON body for POST /api/chat/{session_id}/turn."""
+
+    message: str = Field(min_length=1)
+    # Credentials: {credential_field_id: value}. Keys must match the provider
+    # config's credential_fields[*].id (e.g. "api_key"). Never logged.
+    credentials: dict[str, str] = Field(default_factory=dict)
+
+
+def _validate_credentials(provider_id: str, provided: dict[str, str]) -> Credentials:
+    provider = get_provider(provider_id)
+    missing = [
+        f.id for f in provider.config.credential_fields if not provided.get(f.id)
+    ]
+    if missing:
+        raise ValueError(f"missing credentials: {', '.join(missing)}")
+    return Credentials(values=provided)
+
+
+async def _load_session_for_user(
+    db: AsyncSession, session_id: str, user_id: str
+) -> tuple[ChatSession | None, int | None]:
+    """Return (session, None) on success, or (None, http_status_code) on auth failure."""
+    result = await db.execute(select(ChatSession).where(ChatSession.id == session_id))
+    session = result.scalar_one_or_none()
+    if session is None:
+        return None, 404
+    if session.owner_id != user_id:
+        return None, 403
+    return session, None
+
+
+@ROUTER_CHAT.post("/{session_id}/turn")
+async def chat_turn(
+    session_id: str,
+    body: TurnRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Run one chat turn to completion and return the assistant's response.
+
+    Non-streaming. Returns JSON on both success and provider error. The
+    streaming variant (a later PR) will live at ``.../stream``.
+    """
+    user = await get_current_user_session_or_token(request, db)
+    if user is None:
+        return Response(status_code=401)
+
+    session, err = await _load_session_for_user(db, session_id, user.id)
+    if err is not None:
+        return Response(status_code=err)
+    assert session is not None  # for the type checker
+
+    try:
+        credentials = _validate_credentials(session.provider_id, body.credentials)
+    except (KeyError, ValueError) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+
+    manager = get_concurrency_manager()
+    try:
+        async with manager.acquire(session_id=session.id, user_id=user.id):
+            turn = await run_turn(
+                db,
+                session=session,
+                user_message=body.message,
+                credentials=credentials,
+            )
+    except UserCapExceeded:
+        return JSONResponse(
+            {"error": "concurrent-turn cap exceeded for this user"},
+            status_code=429,
+        )
+
+    payload: dict[str, Any] = {
+        "session_id": session.id,
+        "assistant_text": turn.assistant_text,
+        "tool_activity": turn.tool_activity,
+    }
+    if turn.is_error:
+        payload["error"] = turn.error
+    return JSONResponse(payload)

--- a/ui/app/routes/chat.py
+++ b/ui/app/routes/chat.py
@@ -4,8 +4,6 @@ Exposes non-streaming turn execution. A streaming (SSE) endpoint is
 layered on top in a later PR and shares the same service layer.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 
@@ -16,7 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user_session_or_token
-from app.chat.concurrency import UserCapExceeded, get_concurrency_manager
+from app.chat.concurrency import UserChatConcurrencyExceeded, get_concurrency_manager
 from app.chat.providers import get_provider
 from app.chat.providers.base import Credentials
 from app.chat.service import run_turn
@@ -77,9 +75,8 @@ async def chat_turn(
         return Response(status_code=401)
 
     session, err = await _load_session_for_user(db, session_id, user.id)
-    if err is not None:
+    if err is not None or session is None:
         return Response(status_code=err)
-    assert session is not None  # for the type checker
 
     try:
         credentials = _validate_credentials(session.provider_id, body.credentials)
@@ -95,7 +92,7 @@ async def chat_turn(
                 user_message=body.message,
                 credentials=credentials,
             )
-    except UserCapExceeded:
+    except UserChatConcurrencyExceeded:
         return JSONResponse(
             {"error": "concurrent-turn cap exceeded for this user"},
             status_code=429,

--- a/ui/tests/test_chat_concurrency.py
+++ b/ui/tests/test_chat_concurrency.py
@@ -6,7 +6,7 @@ import asyncio
 
 import pytest
 
-from app.chat.concurrency import ChatConcurrencyManager, UserCapExceeded
+from app.chat.concurrency import ChatConcurrencyManager, UserChatConcurrencyExceeded
 
 
 class TestSessionLock:
@@ -62,7 +62,7 @@ class TestUserCap:
         await asyncio.sleep(0.01)
         assert mgr.active_turns_for("u1") == 2
 
-        with pytest.raises(UserCapExceeded):
+        with pytest.raises(UserChatConcurrencyExceeded):
             async with mgr.acquire(session_id="s3", user_id="u1"):
                 pass
 

--- a/ui/tests/test_chat_concurrency.py
+++ b/ui/tests/test_chat_concurrency.py
@@ -1,0 +1,102 @@
+"""Tests for the ChatConcurrencyManager."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.chat.concurrency import ChatConcurrencyManager, UserCapExceeded
+
+
+class TestSessionLock:
+    async def test_same_session_serializes(self):
+        mgr = ChatConcurrencyManager(per_user_cap=10)
+        order: list[str] = []
+
+        async def turn(tag: str, hold: float) -> None:
+            async with mgr.acquire(session_id="s1", user_id="u1"):
+                order.append(f"enter-{tag}")
+                await asyncio.sleep(hold)
+                order.append(f"exit-{tag}")
+
+        await asyncio.gather(turn("a", 0.02), turn("b", 0.01))
+
+        # Second entry must wait for the first to exit — no interleaving.
+        assert order.index("exit-a") < order.index("enter-b") or order.index(
+            "exit-b"
+        ) < order.index("enter-a")
+
+    async def test_different_sessions_parallel(self):
+        mgr = ChatConcurrencyManager(per_user_cap=10)
+        events: list[str] = []
+
+        async def turn(sess: str) -> None:
+            async with mgr.acquire(session_id=sess, user_id="u1"):
+                events.append(f"enter-{sess}")
+                await asyncio.sleep(0.01)
+                events.append(f"exit-{sess}")
+
+        await asyncio.gather(turn("s1"), turn("s2"))
+
+        # Both should have entered before either exited.
+        entered = [e for e in events if e.startswith("enter-")]
+        assert len(entered) == 2
+        first_exit = next(i for i, e in enumerate(events) if e.startswith("exit-"))
+        assert events[first_exit - 1].startswith("enter-")
+        assert events[first_exit - 2].startswith("enter-")
+
+
+class TestUserCap:
+    async def test_cap_blocks_third_turn(self):
+        mgr = ChatConcurrencyManager(per_user_cap=2)
+        release = asyncio.Event()
+
+        async def held_turn(sess: str) -> None:
+            async with mgr.acquire(session_id=sess, user_id="u1"):
+                await release.wait()
+
+        t1 = asyncio.create_task(held_turn("s1"))
+        t2 = asyncio.create_task(held_turn("s2"))
+        # Give the tasks a moment to acquire.
+        await asyncio.sleep(0.01)
+        assert mgr.active_turns_for("u1") == 2
+
+        with pytest.raises(UserCapExceeded):
+            async with mgr.acquire(session_id="s3", user_id="u1"):
+                pass
+
+        release.set()
+        await asyncio.gather(t1, t2)
+        assert mgr.active_turns_for("u1") == 0
+
+    async def test_slot_released_on_exception(self):
+        mgr = ChatConcurrencyManager(per_user_cap=1)
+        with pytest.raises(RuntimeError):
+            async with mgr.acquire(session_id="s1", user_id="u1"):
+                raise RuntimeError("boom")
+        assert mgr.active_turns_for("u1") == 0
+
+        # Can acquire again immediately afterward.
+        async with mgr.acquire(session_id="s1", user_id="u1"):
+            pass
+
+    async def test_different_users_independent(self):
+        mgr = ChatConcurrencyManager(per_user_cap=1)
+        release = asyncio.Event()
+
+        async def held(user: str) -> None:
+            async with mgr.acquire(session_id="s", user_id=user):
+                await release.wait()
+
+        t1 = asyncio.create_task(held("u1"))
+        t2 = asyncio.create_task(held("u2"))
+        await asyncio.sleep(0.01)
+        assert mgr.active_turns_for("u1") == 1
+        assert mgr.active_turns_for("u2") == 1
+        release.set()
+        await asyncio.gather(t1, t2)
+
+    async def test_invalid_cap_rejected(self):
+        with pytest.raises(ValueError):
+            ChatConcurrencyManager(per_user_cap=0)

--- a/ui/tests/test_chat_concurrency.py
+++ b/ui/tests/test_chat_concurrency.py
@@ -85,12 +85,12 @@ class TestUserCap:
         mgr = ChatConcurrencyManager(per_user_cap=1)
         release = asyncio.Event()
 
-        async def held(user: str) -> None:
-            async with mgr.acquire(session_id="s", user_id=user):
+        async def held(user: str, sess: str) -> None:
+            async with mgr.acquire(session_id=sess, user_id=user):
                 await release.wait()
 
-        t1 = asyncio.create_task(held("u1"))
-        t2 = asyncio.create_task(held("u2"))
+        t1 = asyncio.create_task(held("u1", "s1"))
+        t2 = asyncio.create_task(held("u2", "s2"))
         await asyncio.sleep(0.01)
         assert mgr.active_turns_for("u1") == 1
         assert mgr.active_turns_for("u2") == 1

--- a/ui/tests/test_routes_chat.py
+++ b/ui/tests/test_routes_chat.py
@@ -1,0 +1,394 @@
+"""End-to-end tests for both chat turn endpoints (JSON + SSE)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncGenerator
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.chat.concurrency import reset_concurrency_manager
+from app.chat.providers.base import (
+    ErrorEvent,
+    SessionInitialized,
+    TextDelta,
+    ToolCall,
+    ToolResult,
+    TurnComplete,
+    TurnEvent,
+)
+from app.db.models import BerilUser, ChatMessage, ChatSession
+from app.db.session import get_db
+from app.main import create_app
+
+
+# ---------------------------------------------------------------------------
+# Shared env / fixtures
+# ---------------------------------------------------------------------------
+
+
+_ENV = {
+    "BERIL_TEST_SKIP_LIFESPAN": "True",
+    "BERIL_ORCID_CLIENT_ID": "APP-TESTCLIENTID",
+    "BERIL_ORCID_CLIENT_SECRET": "test-secret",
+    "BERIL_ORCID_BASE_URL": "https://sandbox.orcid.org",
+    "BERIL_SESSION_SECRET_KEY": "test-session-secret",
+}
+
+USER_TOKEN = {
+    "access_token": "fake-access-token",
+    "token_type": "bearer",
+    "orcid": "0000-0001-2345-6789",
+    "name": "Alice Researcher",
+}
+
+OTHER_TOKEN = {
+    "access_token": "other-access-token",
+    "token_type": "bearer",
+    "orcid": "0000-0002-9999-9999",
+    "name": "Mallory",
+}
+
+
+def _make_mock_oauth_client(token: dict):
+    auth_url = (
+        "https://sandbox.orcid.org/oauth/authorize"
+        "?client_id=APP-TESTCLIENTID&scope=%2Fauthenticate"
+        "&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8000"
+        "%2Fauth%2Forcid%2Fcallback&state=mock-state"
+    )
+    mock_instance = MagicMock()
+    mock_instance.create_authorization_url = MagicMock(return_value=(auth_url, "mock-state"))
+    mock_instance.fetch_token = AsyncMock(return_value=token)
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=mock_instance)
+
+
+def _login(client: TestClient, token: dict = USER_TOKEN) -> None:
+    mock_class = _make_mock_oauth_client(token)
+    with patch("app.routes.auth.AsyncOAuth2Client", mock_class):
+        client.get(
+            "/auth/orcid/callback",
+            params={"code": "fake-code"},
+            follow_redirects=False,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _reset_concurrency():
+    reset_concurrency_manager()
+    yield
+    reset_concurrency_manager()
+
+
+@pytest.fixture
+def client(repository_data, app_data_context, db_session):
+    with patch.dict(os.environ, _ENV):
+        import app.config as cfg
+
+        cfg._settings = None
+        app_instance = create_app()
+
+        async def override_get_db() -> AsyncGenerator:
+            yield db_session
+
+        app_instance.dependency_overrides[get_db] = override_get_db
+        with TestClient(app_instance, raise_server_exceptions=True) as c:
+            app_instance.state.repo_data = repository_data
+            app_instance.state.base_context = app_data_context
+            yield c
+        cfg._settings = None
+
+
+@pytest.fixture
+async def user(db_session):
+    """The BerilUser matching USER_TOKEN (must be pre-created for session auth)."""
+    u = BerilUser(orcid_id=USER_TOKEN["orcid"], display_name=USER_TOKEN["name"])
+    db_session.add(u)
+    await db_session.commit()
+    await db_session.refresh(u)
+    return u
+
+
+@pytest.fixture
+async def other_user(db_session):
+    u = BerilUser(orcid_id=OTHER_TOKEN["orcid"], display_name=OTHER_TOKEN["name"])
+    db_session.add(u)
+    await db_session.commit()
+    await db_session.refresh(u)
+    return u
+
+
+@pytest.fixture
+async def session_row(db_session, user):
+    s = ChatSession(
+        owner_id=user.id, provider_id="anthropic", model="claude-opus-4-7"
+    )
+    db_session.add(s)
+    await db_session.commit()
+    await db_session.refresh(s)
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Provider-turn fakes
+# ---------------------------------------------------------------------------
+
+
+def _events_ok() -> list[TurnEvent]:
+    return [
+        SessionInitialized(sdk_session_id="sdk-abc"),
+        TextDelta(text="Hello "),
+        TextDelta(text="world"),
+        ToolCall(name="berdl_query", input={"sql": "SELECT 1"}, tool_use_id="tu-1"),
+        ToolResult(tool_use_id="tu-1", content="3 rows"),
+        TurnComplete(),
+    ]
+
+
+def _patched_provider(events: list[TurnEvent]):
+    async def _fake(
+        *, db, session, user_message, credentials
+    ) -> AsyncIterator[TurnEvent]:
+        for e in events:
+            yield e
+
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    def test_unauthenticated_returns_401(self, client, session_row):
+        resp = client.post(
+            f"/api/chat/{session_row.id}/turn",
+            json={"message": "hi", "credentials": {"api_key": "k"}},
+        )
+        assert resp.status_code == 401
+
+    def test_other_user_gets_403(self, client, session_row, other_user):
+        _login(client, OTHER_TOKEN)
+        resp = client.post(
+            f"/api/chat/{session_row.id}/turn",
+            json={"message": "hi", "credentials": {"api_key": "k"}},
+        )
+        assert resp.status_code == 403
+
+    def test_unknown_session_returns_404(self, client, user):
+        _login(client)
+        resp = client.post(
+            "/api/chat/does-not-exist/turn",
+            json={"message": "hi", "credentials": {"api_key": "k"}},
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_empty_message_rejected(self, client, session_row, user):
+        _login(client)
+        resp = client.post(
+            f"/api/chat/{session_row.id}/turn",
+            json={"message": "", "credentials": {"api_key": "k"}},
+        )
+        assert resp.status_code == 422
+
+    def test_missing_credential_returns_400(self, client, session_row, user):
+        _login(client)
+        resp = client.post(
+            f"/api/chat/{session_row.id}/turn",
+            json={"message": "hi", "credentials": {}},
+        )
+        assert resp.status_code == 400
+        assert "api_key" in resp.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessfulTurn:
+    def test_returns_assistant_text(self, client, session_row, user):
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/turn",
+                json={"message": "hi there", "credentials": {"api_key": "k"}},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["assistant_text"] == "Hello world"
+        assert body["session_id"] == session_row.id
+        kinds = [t["type"] for t in body["tool_activity"]]
+        assert kinds == ["tool_call", "tool_result"]
+
+    async def test_persists_user_and_assistant_messages(
+        self, client, session_row, user, db_session
+    ):
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/turn",
+                json={"message": "hi there", "credentials": {"api_key": "k"}},
+            )
+        assert resp.status_code == 200
+
+        result = await db_session.execute(
+            select(ChatMessage).where(ChatMessage.session_id == session_row.id)
+        )
+        msgs = list(result.scalars())
+        roles = [m.role for m in msgs]
+        assert roles == ["user", "assistant"]
+        assert msgs[0].content == {"text": "hi there"}
+        assert msgs[1].content["text"] == "Hello world"
+        assert msgs[1].content["error"] is None
+
+    async def test_sdk_session_id_captured_on_first_turn(
+        self, client, session_row, user, db_session
+    ):
+        assert session_row.sdk_session_id is None
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/turn",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        assert resp.status_code == 200
+        await db_session.refresh(session_row)
+        assert session_row.sdk_session_id == "sdk-abc"
+
+    async def test_subsequent_turn_preserves_original_sdk_session_id(
+        self, client, session_row, user, db_session
+    ):
+        session_row.sdk_session_id = "already-set"
+        await db_session.commit()
+
+        events: list[TurnEvent] = [
+            SessionInitialized(sdk_session_id="different-one"),
+            TextDelta(text="ok"),
+            TurnComplete(),
+        ]
+        _login(client)
+        with patch("app.chat.service.run_provider_turn", _patched_provider(events)):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/turn",
+                json={"message": "follow-up", "credentials": {"api_key": "k"}},
+            )
+        assert resp.status_code == 200
+        await db_session.refresh(session_row)
+        assert session_row.sdk_session_id == "already-set"
+
+    async def test_last_active_at_updated(
+        self, client, session_row, user, db_session
+    ):
+        original = session_row.last_active_at
+        await asyncio.sleep(0.01)
+
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            client.post(
+                f"/api/chat/{session_row.id}/turn",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        await db_session.refresh(session_row)
+        assert session_row.last_active_at > original
+
+
+# ---------------------------------------------------------------------------
+# Error path
+# ---------------------------------------------------------------------------
+
+
+class TestProviderError:
+    def test_error_returned_in_body(self, client, session_row, user):
+        events: list[TurnEvent] = [
+            SessionInitialized(sdk_session_id="sdk-x"),
+            ErrorEvent(message="upstream 500"),
+        ]
+        _login(client)
+        with patch("app.chat.service.run_provider_turn", _patched_provider(events)):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/turn",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"] == "upstream 500"
+        assert body["assistant_text"] == ""
+
+    async def test_assistant_message_records_error(
+        self, client, session_row, user, db_session
+    ):
+        events: list[TurnEvent] = [ErrorEvent(message="timeout")]
+        _login(client)
+        with patch("app.chat.service.run_provider_turn", _patched_provider(events)):
+            client.post(
+                f"/api/chat/{session_row.id}/turn",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+
+        result = await db_session.execute(
+            select(ChatMessage)
+            .where(ChatMessage.session_id == session_row.id)
+            .where(ChatMessage.role == "assistant")
+        )
+        msg = result.scalar_one()
+        assert msg.content["error"] == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    def test_cap_exceeded_returns_429(
+        self, client, session_row, user, db_session
+    ):
+        """With cap=1, two concurrent turns across two sessions → one 429."""
+        # Override the singleton manager with cap=1.
+        from app.chat import concurrency as c
+        from app.chat.concurrency import ChatConcurrencyManager
+
+        c._manager = ChatConcurrencyManager(per_user_cap=1)
+
+        # Pre-reserve the user's single slot by poking the manager directly.
+        # This is equivalent to "a turn is already in flight" without needing
+        # two concurrent sync requests through TestClient.
+        asyncio.get_event_loop().run_until_complete(
+            c._manager._try_reserve_user_slot(user.id)
+        )
+        assert c._manager.active_turns_for(user.id) == 1
+
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/turn",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        assert resp.status_code == 429
+        assert "cap" in resp.json()["error"]

--- a/ui/tests/test_routes_chat.py
+++ b/ui/tests/test_routes_chat.py
@@ -154,7 +154,7 @@ def _events_ok() -> list[TurnEvent]:
 
 def _patched_provider(events: list[TurnEvent]):
     async def _fake(
-        *, db, session, user_message, credentials
+        *, db, session, user_message, credentials, **kwargs
     ) -> AsyncIterator[TurnEvent]:
         for e in events:
             yield e


### PR DESCRIPTION
Fourth in a 7-PR series adding an LLM chat interface. Wires the
provider abstraction into a working JSON endpoint, persists messages
to the DB, and adds the concurrency primitives that protect both
per-session correctness and per-user cost. Stacks on top of #218.

## What this PR adds

- **`ChatConcurrencyManager`**: per-session `asyncio.Lock` (turns
  within one chat are strictly serialized — the underlying SDK session
  is stateful and racing two turns would corrupt `sdk_session_id`),
  plus a per-user active-turn counter that fails fast
  (`UserCapExceeded`) when the cap from
  `settings.chat_max_concurrent_turns_per_user` is hit. The cap is a
  hard ceiling, not a queue, so a runaway user can't pile work on the
  server and the route returns 429 quickly.
- **`service.run_turn` / `run_provider_turn` / `persist_user_message`
  / `persist_assistant_message`**: the turn lifecycle. User row is
  committed before the provider runs (so a crashed turn is still
  visible in the transcript on resume); assistant row is committed
  once at the end with aggregated text + `tool_activity` +
  `sdk_session_id`.
- **`sdk_sessions`**: bridges the SDK's on-disk transcript store
  (under `~/.claude/projects/<cwd-hash>/<session>.jsonl`) with the
  DB-stored `sdk_session_id`. `session_file_exists()` detects the case
  where the resume handle points at a file the SDK can no longer find
  (volume wiped, replica swap), and `build_resume_preamble()`
  reconstructs prior context from DB messages so the user doesn't lose
  history. `run_provider_turn` cold-starts via this preamble when the
  file is gone.
- **`POST /api/chat/{id}/turn`**: auth via session cookie or bearer
  token, ownership check (404 if not yours, no info leak), credential
  validation against the provider's declared `credential_fields` (400
  if missing), then guarded by the concurrency manager (429 if cap
  hit). Returns JSON: `{session_id, assistant_text, tool_activity,
  error?}`.
- `ui/app/chat/crud.py` is a stub holding only
  `list_messages_for_session` — that's what the cold-start preamble
  needs. The session-CRUD helpers used by the management UI land in
  PR #6.

## Tests

19 new tests: 6 concurrency (same-session serialization, parallel
across sessions, cap exceeded, exception cleanup, user isolation,
invalid cap), 13 route (auth/validation/happy-path/error/concurrency).
Full suite: 629 passing.

## What's *not* in this PR

This PR makes the chat endpoint functional but **not user-facing**.
There's no UI yet, no streaming, and no session-listing page; you
have to POST to `/api/chat/{id}/turn` directly. PRs #5 and #6 add the
UX layer.

## Stack context

This is **4 of 7**. PRs #1–#3 (#214, #215, #218) are merged.
