### PR TITLE
add build info to dockerfile and health endpoint

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,6 +26,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  GIT_COMMIT_HASH: ${{ github.sha }}
 
 jobs:
   build-and-push:
@@ -48,6 +49,9 @@ jobs:
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get current datestamp
+        run: echo "BUILD_DATE=$(date -u)" >> $GITHUB_ENV
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -63,5 +67,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ env.BUILD_DATE }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,10 @@ WORKDIR /repo/ui
 
 USER beril
 
+ARG GIT_COMMIT
+ARG BUILD_DATE
+ENV BERIL_GIT_COMMIT=${GIT_COMMIT}
+ENV BERIL_BUILD_DATE=${BUILD_DATE}
+
 # Run the application
 CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:create_app --factory --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips=\"*\""]

--- a/ui/app/config.py
+++ b/ui/app/config.py
@@ -13,6 +13,10 @@ class Settings(BaseSettings):
     # Test-only settings. These should be left False unless running tests.
     test_skip_lifespan: bool = False
 
+    # Image info. Only used for health endpoint when present
+    git_commit: str | None = None
+    build_date: str | None = None
+
     # Paths
     app_dir: Path = Path(__file__).parent
     ui_dir: Path = app_dir.parent

--- a/ui/app/main.py
+++ b/ui/app/main.py
@@ -890,11 +890,14 @@ async def health(
     status = "healthy"
     if db_status["status"] != "ok":
         status = "degraded"
+    settings = get_settings()
     return {
         "status": status,
         "services": {
             "database": db_status
         },
         "session": context,
-        "url_scheme": request.url.scheme
+        "url_scheme": request.url.scheme,
+        "git_commit": settings.git_commit,
+        "build_date": settings.build_date
     }


### PR DESCRIPTION
As the title says. This should add "git_commit" and "build_date" fields to the /health endpoint result.