### PR TITLE
Chat: SSE streaming endpoint

### DIFF
--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -152,8 +152,14 @@ async def stream_turn(
         # failure — to avoid duplicating the assistant row.
         if not persist_started:
             result.assistant_text = "".join(text_parts)
-            if not stream_completed and result.error is None:
-                result.error = "stream interrupted"
+            if not stream_completed:
+                # Don't promote a partial provider session to the resume
+                # handle — the next turn must rebuild from the DB transcript
+                # rather than resume from a conversation we only partially
+                # captured locally.
+                result.sdk_session_id = None
+                if result.error is None:
+                    result.error = "stream interrupted"
             await persist_assistant_message(db, session=session, result=result)
 
 

--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -111,7 +111,9 @@ async def stream_turn(
     """
     from app.chat.sse import event_to_frame, turn_complete_frame
 
-    await persist_user_message(db, session=session, user_message=user_message)
+    user_row = await persist_user_message(
+        db, session=session, user_message=user_message
+    )
 
     result = TurnResult()
     text_parts: list[str] = []
@@ -123,6 +125,7 @@ async def stream_turn(
             session=session,
             user_message=user_message,
             credentials=credentials,
+            skip_message_id=user_row.id,
         ):
             fold_event(event, text_parts, result)
             yield event_to_frame(event)

--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -117,7 +117,7 @@ async def stream_turn(
 
     result = TurnResult()
     text_parts: list[str] = []
-    persisted = False
+    stream_completed = False
 
     try:
         async for event in run_provider_turn(
@@ -129,22 +129,19 @@ async def stream_turn(
         ):
             fold_event(event, text_parts, result)
             yield event_to_frame(event)
-
+        stream_completed = True
+    finally:
+        # Persist exactly once, whether the stream completed normally or
+        # was cancelled mid-flight (browser closed, etc.). On interruption,
+        # tag the partial row with an error so resume sees a coherent state.
         result.assistant_text = "".join(text_parts)
+        if not stream_completed and result.error is None:
+            result.error = "stream interrupted"
         assistant_row = await persist_assistant_message(
             db, session=session, result=result
         )
-        persisted = True
-        yield turn_complete_frame(assistant_message_id=assistant_row.id)
-    finally:
-        # Client disconnected or the generator was cancelled before the
-        # stream naturally ended: still persist whatever we accumulated so
-        # the transcript is coherent on resume.
-        if not persisted:
-            result.assistant_text = "".join(text_parts)
-            if result.error is None:
-                result.error = "stream interrupted"
-            await persist_assistant_message(db, session=session, result=result)
+        if stream_completed:
+            yield turn_complete_frame(assistant_message_id=assistant_row.id)
 
 
 async def run_turn(

--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -91,6 +91,59 @@ class TurnResult:
         return self.error is not None
 
 
+async def stream_turn(
+    db: AsyncSession,
+    *,
+    session: ChatSession,
+    user_message: str,
+    credentials: Credentials,
+) -> AsyncIterator[dict[str, Any]]:
+    """Run one chat turn and yield SSE-ready frames as events arrive.
+
+    Persistence semantics match :func:`run_turn`:
+      * user message saved before the provider is invoked,
+      * assistant message saved exactly once after the provider stream ends
+        (or after a client disconnect — see below).
+
+    If the caller's generator is closed early (e.g. the browser tab closes),
+    whatever assistant content accumulated so far is still persisted so a
+    resumed session doesn't lose partial work.
+    """
+    from app.chat.sse import event_to_frame, turn_complete_frame
+
+    await persist_user_message(db, session=session, user_message=user_message)
+
+    result = TurnResult()
+    text_parts: list[str] = []
+    persisted = False
+
+    try:
+        async for event in run_provider_turn(
+            db=db,
+            session=session,
+            user_message=user_message,
+            credentials=credentials,
+        ):
+            fold_event(event, text_parts, result)
+            yield event_to_frame(event)
+
+        result.assistant_text = "".join(text_parts)
+        assistant_row = await persist_assistant_message(
+            db, session=session, result=result
+        )
+        persisted = True
+        yield turn_complete_frame(assistant_message_id=assistant_row.id)
+    finally:
+        # Client disconnected or the generator was cancelled before the
+        # stream naturally ended: still persist whatever we accumulated so
+        # the transcript is coherent on resume.
+        if not persisted:
+            result.assistant_text = "".join(text_parts)
+            if result.error is None:
+                result.error = "stream interrupted"
+            await persist_assistant_message(db, session=session, result=result)
+
+
 async def run_turn(
     db: AsyncSession,
     *,

--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -119,7 +119,6 @@ async def stream_turn(
     text_parts: list[str] = []
     stream_completed = False
 
-    persist_started = False
     try:
         async for event in run_provider_turn(
             db=db,
@@ -129,38 +128,29 @@ async def stream_turn(
             skip_message_id=user_row.id,
         ):
             fold_event(event, text_parts, result)
-            # Mark complete before yielding the terminal frame: if the
-            # client disconnects while consuming this last frame, the turn
-            # itself still finished, so don't tag the persisted row as
-            # interrupted.
+            # Mark complete on the terminal event so a disconnect during the
+            # final yield doesn't get tagged as interrupted on persist.
             if isinstance(event, (TurnComplete, ErrorEvent)):
                 stream_completed = True
             yield event_to_frame(event)
-
-        # Happy-path persist + terminal frame. Doing this here (rather than
-        # in finally) keeps the generator from yielding during aclose(),
-        # which would raise RuntimeError on a client disconnect.
+    finally:
+        # Persist exactly once. If the DB write itself fails the trace is
+        # lost, but a broken DB connection would also break any retry, so
+        # we accept that and keep the path simple.
         result.assistant_text = "".join(text_parts)
-        persist_started = True
+        if not stream_completed:
+            # Interrupted before a terminal event: don't promote a partial
+            # provider session handle so the next turn rebuilds from the
+            # DB transcript rather than resuming a half-captured turn.
+            result.sdk_session_id = None
+            if result.error is None:
+                result.error = "stream interrupted"
         assistant_row = await persist_assistant_message(
             db, session=session, result=result
         )
+
+    if stream_completed:
         yield turn_complete_frame(assistant_message_id=assistant_row.id)
-    finally:
-        # Cancellation path: only persist if we never started the happy-path
-        # commit. If we did start it, don't write again — even on partial
-        # failure — to avoid duplicating the assistant row.
-        if not persist_started:
-            result.assistant_text = "".join(text_parts)
-            if not stream_completed:
-                # Don't promote a partial provider session to the resume
-                # handle — the next turn must rebuild from the DB transcript
-                # rather than resume from a conversation we only partially
-                # captured locally.
-                result.sdk_session_id = None
-                if result.error is None:
-                    result.error = "stream interrupted"
-            await persist_assistant_message(db, session=session, result=result)
 
 
 async def run_turn(

--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -128,8 +128,13 @@ async def stream_turn(
             skip_message_id=user_row.id,
         ):
             fold_event(event, text_parts, result)
+            # Mark complete before yielding the terminal frame: if the
+            # client disconnects while consuming this last frame, the turn
+            # itself still finished, so don't tag the persisted row as
+            # interrupted.
+            if isinstance(event, (TurnComplete, ErrorEvent)):
+                stream_completed = True
             yield event_to_frame(event)
-        stream_completed = True
     finally:
         # Persist exactly once, whether the stream completed normally or
         # was cancelled mid-flight (browser closed, etc.). On interruption,

--- a/ui/app/chat/service.py
+++ b/ui/app/chat/service.py
@@ -119,6 +119,7 @@ async def stream_turn(
     text_parts: list[str] = []
     stream_completed = False
 
+    persist_started = False
     try:
         async for event in run_provider_turn(
             db=db,
@@ -135,18 +136,25 @@ async def stream_turn(
             if isinstance(event, (TurnComplete, ErrorEvent)):
                 stream_completed = True
             yield event_to_frame(event)
-    finally:
-        # Persist exactly once, whether the stream completed normally or
-        # was cancelled mid-flight (browser closed, etc.). On interruption,
-        # tag the partial row with an error so resume sees a coherent state.
+
+        # Happy-path persist + terminal frame. Doing this here (rather than
+        # in finally) keeps the generator from yielding during aclose(),
+        # which would raise RuntimeError on a client disconnect.
         result.assistant_text = "".join(text_parts)
-        if not stream_completed and result.error is None:
-            result.error = "stream interrupted"
+        persist_started = True
         assistant_row = await persist_assistant_message(
             db, session=session, result=result
         )
-        if stream_completed:
-            yield turn_complete_frame(assistant_message_id=assistant_row.id)
+        yield turn_complete_frame(assistant_message_id=assistant_row.id)
+    finally:
+        # Cancellation path: only persist if we never started the happy-path
+        # commit. If we did start it, don't write again — even on partial
+        # failure — to avoid duplicating the assistant row.
+        if not persist_started:
+            result.assistant_text = "".join(text_parts)
+            if not stream_completed and result.error is None:
+                result.error = "stream interrupted"
+            await persist_assistant_message(db, session=session, result=result)
 
 
 async def run_turn(

--- a/ui/app/chat/sse.py
+++ b/ui/app/chat/sse.py
@@ -1,0 +1,68 @@
+"""SSE wire-format helpers for chat turn streams.
+
+The provider yields :class:`TurnEvent` dataclasses; the browser consumes
+JSON-per-frame SSE. This module is the only place that knows how to map
+between them. Keep it boring — the React component parses these shapes
+directly, so renaming a field here is a breaking change.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Any
+
+from app.chat.providers.base import (
+    ErrorEvent,
+    SessionInitialized,
+    TextDelta,
+    ToolCall,
+    ToolResult,
+    TurnComplete,
+    TurnEvent,
+)
+
+
+def event_to_frame(event: TurnEvent) -> dict[str, str]:
+    """Convert one TurnEvent into the dict shape ``EventSourceResponse`` expects.
+
+    ``event`` → ``{ "event": <kind>, "data": <json payload> }``.
+    """
+    if isinstance(event, SessionInitialized):
+        payload: dict[str, Any] = {"sdk_session_id": event.sdk_session_id}
+    elif isinstance(event, TextDelta):
+        payload = {"text": event.text}
+    elif isinstance(event, ToolCall):
+        payload = {
+            "name": event.name,
+            "input": event.input,
+            "tool_use_id": event.tool_use_id,
+        }
+    elif isinstance(event, ToolResult):
+        payload = {
+            "tool_use_id": event.tool_use_id,
+            "content": event.content,
+            "is_error": event.is_error,
+        }
+    elif isinstance(event, ErrorEvent):
+        payload = {"message": event.message}
+    elif isinstance(event, TurnComplete):
+        payload = {"result_subtype": event.result_subtype}
+    else:  # pragma: no cover — exhaustive union
+        payload = asdict(event)
+
+    return {"event": event.kind, "data": json.dumps(payload)}
+
+
+def turn_complete_frame(*, assistant_message_id: str) -> dict[str, str]:
+    """Emit the final frame with the newly-persisted assistant message id.
+
+    This is distinct from the provider's :class:`TurnComplete` event: that
+    one marks the agent's end of turn; this frame is what the browser
+    listens for to know the server has finished persisting and is closing
+    the stream.
+    """
+    return {
+        "event": "turn_persisted",
+        "data": json.dumps({"assistant_message_id": assistant_message_id}),
+    }

--- a/ui/app/routes/chat.py
+++ b/ui/app/routes/chat.py
@@ -155,6 +155,10 @@ async def chat_stream(
             status_code=429,
         )
 
+    # Refresh after acquiring the lock so we see any sdk_session_id written
+    # by a turn that just finished on this same session.
+    await db.refresh(session)
+
     async def _event_generator():
         try:
             async for frame in stream_turn(

--- a/ui/app/routes/chat.py
+++ b/ui/app/routes/chat.py
@@ -155,9 +155,16 @@ async def chat_stream(
             status_code=429,
         )
 
-    # Refresh after acquiring the lock so we see any sdk_session_id written
-    # by a turn that just finished on this same session.
-    await db.refresh(session)
+    # Anything between acquire and handoff to EventSourceResponse must
+    # release the guard manually; only the generator's finally fires once
+    # streaming starts.
+    try:
+        # Refresh after acquiring the lock so we see any sdk_session_id
+        # written by a turn that just finished on this same session.
+        await db.refresh(session)
+    except BaseException:
+        await turn_guard.__aexit__(None, None, None)
+        raise
 
     async def _event_generator():
         try:

--- a/ui/app/routes/chat.py
+++ b/ui/app/routes/chat.py
@@ -1,7 +1,11 @@
 """Chat routes.
 
-Exposes non-streaming turn execution. A streaming (SSE) endpoint is
-layered on top in a later PR and shares the same service layer.
+Two turn endpoints:
+  * POST /api/chat/{id}/turn   — non-streaming, returns full JSON.
+  * POST /api/chat/{id}/stream — SSE-streamed, frames as the agent works.
+
+Both share auth, ownership, credential, and concurrency guards. Session
+CRUD endpoints and Jinja pages land in a later PR.
 """
 
 import logging
@@ -12,12 +16,13 @@ from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sse_starlette.sse import EventSourceResponse
 
 from app.auth import get_current_user_session_or_token
 from app.chat.concurrency import UserChatConcurrencyExceeded, get_concurrency_manager
 from app.chat.providers import get_provider
 from app.chat.providers.base import Credentials
-from app.chat.service import run_turn
+from app.chat.service import run_turn, stream_turn
 from app.db.models import ChatSession
 from app.db.session import get_db
 
@@ -27,7 +32,7 @@ ROUTER_CHAT = APIRouter(prefix="/api/chat", tags=["Chat"])
 
 
 class TurnRequest(BaseModel):
-    """JSON body for POST /api/chat/{session_id}/turn."""
+    """JSON body for POST /api/chat/{session_id}/turn and .../stream."""
 
     message: str = Field(min_length=1)
     # Credentials: {credential_field_id: value}. Keys must match the provider
@@ -67,8 +72,7 @@ async def chat_turn(
 ) -> Response:
     """Run one chat turn to completion and return the assistant's response.
 
-    Non-streaming. Returns JSON on both success and provider error. The
-    streaming variant (a later PR) will live at ``.../stream``.
+    Non-streaming. Returns JSON on both success and provider error.
     """
     user = await get_current_user_session_or_token(request, db)
     if user is None:
@@ -109,3 +113,58 @@ async def chat_turn(
     if turn.is_error:
         payload["error"] = turn.error
     return JSONResponse(payload)
+
+
+@ROUTER_CHAT.post("/{session_id}/stream")
+async def chat_stream(
+    session_id: str,
+    body: TurnRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Run one chat turn and stream events to the browser as SSE.
+
+    Pre-flight (auth, ownership, credential validation, concurrency cap) runs
+    synchronously and can return a plain JSON error response. Once the SSE
+    stream has started, errors surface as ``error`` events inside the stream.
+    """
+    user = await get_current_user_session_or_token(request, db)
+    if user is None:
+        return Response(status_code=401)
+
+    session, err = await _load_session_for_user(db, session_id, user.id)
+    if err is not None:
+        return Response(status_code=err)
+    assert session is not None
+
+    try:
+        credentials = _validate_credentials(session.provider_id, body.credentials)
+    except (KeyError, ValueError) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+
+    manager = get_concurrency_manager()
+    # Reserve the user slot and session lock BEFORE returning the response,
+    # so a cap-exceeded case surfaces as a plain 429 rather than an opaque
+    # 200 with an embedded error frame.
+    try:
+        turn_guard = manager.acquire(session_id=session.id, user_id=user.id)
+        await turn_guard.__aenter__()
+    except UserChatConcurrencyExceeded:
+        return JSONResponse(
+            {"error": "concurrent-turn cap exceeded for this user"},
+            status_code=429,
+        )
+
+    async def _event_generator():
+        try:
+            async for frame in stream_turn(
+                db,
+                session=session,
+                user_message=body.message,
+                credentials=credentials,
+            ):
+                yield frame
+        finally:
+            await turn_guard.__aexit__(None, None, None)
+
+    return EventSourceResponse(_event_generator())

--- a/ui/tests/test_chat_sse.py
+++ b/ui/tests/test_chat_sse.py
@@ -1,0 +1,73 @@
+"""Unit tests for SSE wire-format helpers."""
+
+from __future__ import annotations
+
+import json
+
+from app.chat.providers.base import (
+    ErrorEvent,
+    SessionInitialized,
+    TextDelta,
+    ToolCall,
+    ToolResult,
+    TurnComplete,
+)
+from app.chat.sse import event_to_frame, turn_complete_frame
+
+
+class TestEventToFrame:
+    def test_session_initialized(self):
+        frame = event_to_frame(SessionInitialized(sdk_session_id="sdk-42"))
+        assert frame["event"] == "session_initialized"
+        assert json.loads(frame["data"]) == {"sdk_session_id": "sdk-42"}
+
+    def test_text_delta(self):
+        frame = event_to_frame(TextDelta(text="hello"))
+        assert frame["event"] == "text_delta"
+        assert json.loads(frame["data"]) == {"text": "hello"}
+
+    def test_tool_call(self):
+        frame = event_to_frame(
+            ToolCall(name="berdl_query", input={"sql": "SELECT 1"}, tool_use_id="tu-7")
+        )
+        assert frame["event"] == "tool_call"
+        data = json.loads(frame["data"])
+        assert data == {
+            "name": "berdl_query",
+            "input": {"sql": "SELECT 1"},
+            "tool_use_id": "tu-7",
+        }
+
+    def test_tool_result_ok(self):
+        frame = event_to_frame(
+            ToolResult(tool_use_id="tu-7", content="3 rows", is_error=False)
+        )
+        assert frame["event"] == "tool_result"
+        assert json.loads(frame["data"]) == {
+            "tool_use_id": "tu-7",
+            "content": "3 rows",
+            "is_error": False,
+        }
+
+    def test_tool_result_error(self):
+        frame = event_to_frame(
+            ToolResult(tool_use_id="tu-9", content="boom", is_error=True)
+        )
+        assert json.loads(frame["data"])["is_error"] is True
+
+    def test_error_event(self):
+        frame = event_to_frame(ErrorEvent(message="upstream 500"))
+        assert frame["event"] == "error"
+        assert json.loads(frame["data"]) == {"message": "upstream 500"}
+
+    def test_turn_complete(self):
+        frame = event_to_frame(TurnComplete(result_subtype="end_turn"))
+        assert frame["event"] == "turn_complete"
+        assert json.loads(frame["data"]) == {"result_subtype": "end_turn"}
+
+
+class TestTurnCompleteFrame:
+    def test_payload(self):
+        frame = turn_complete_frame(assistant_message_id="msg-abc")
+        assert frame["event"] == "turn_persisted"
+        assert json.loads(frame["data"]) == {"assistant_message_id": "msg-abc"}

--- a/ui/tests/test_routes_chat.py
+++ b/ui/tests/test_routes_chat.py
@@ -162,6 +162,35 @@ def _patched_provider(events: list[TurnEvent]):
     return _fake
 
 
+def _parse_sse(raw: str) -> list[dict]:
+    """Parse an SSE response body into a list of ``{event, data}`` dicts."""
+    import json as _json
+
+    frames: list[dict] = []
+    current_event: str | None = None
+    current_data: list[str] = []
+    for line in raw.replace("\r\n", "\n").split("\n"):
+        if line == "":
+            if current_event or current_data:
+                frames.append(
+                    {
+                        "event": current_event,
+                        "data": _json.loads("\n".join(current_data))
+                        if current_data
+                        else None,
+                    }
+                )
+                current_event = None
+                current_data = []
+            continue
+        if line.startswith("event:"):
+            current_event = line[len("event:") :].strip()
+        elif line.startswith("data:"):
+            current_data.append(line[len("data:") :].strip())
+        # other SSE fields (id:, retry:, :comment) ignored
+    return frames
+
+
 # ---------------------------------------------------------------------------
 # Auth
 # ---------------------------------------------------------------------------
@@ -392,3 +421,213 @@ class TestConcurrency:
             )
         assert resp.status_code == 429
         assert "cap" in resp.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Streaming endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestStreamAuth:
+    def test_unauthenticated_returns_401(self, client, session_row):
+        resp = client.post(
+            f"/api/chat/{session_row.id}/stream",
+            json={"message": "hi", "credentials": {"api_key": "k"}},
+        )
+        assert resp.status_code == 401
+
+    def test_other_user_gets_403(self, client, session_row, other_user):
+        _login(client, OTHER_TOKEN)
+        resp = client.post(
+            f"/api/chat/{session_row.id}/stream",
+            json={"message": "hi", "credentials": {"api_key": "k"}},
+        )
+        assert resp.status_code == 403
+
+    def test_unknown_session_returns_404(self, client, user):
+        _login(client)
+        resp = client.post(
+            "/api/chat/does-not-exist/stream",
+            json={"message": "hi", "credentials": {"api_key": "k"}},
+        )
+        assert resp.status_code == 404
+
+
+class TestStreamValidation:
+    def test_missing_credential_returns_400(self, client, session_row, user):
+        _login(client)
+        resp = client.post(
+            f"/api/chat/{session_row.id}/stream",
+            json={"message": "hi", "credentials": {}},
+        )
+        assert resp.status_code == 400
+
+    def test_cap_exceeded_returns_429(self, client, session_row, user):
+        from app.chat import concurrency as c
+        from app.chat.concurrency import ChatConcurrencyManager
+
+        c._manager = ChatConcurrencyManager(per_user_cap=1)
+        asyncio.get_event_loop().run_until_complete(
+            c._manager._try_reserve_user_slot(user.id)
+        )
+
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/stream",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        assert resp.status_code == 429
+
+
+class TestStreamHappyPath:
+    def test_emits_expected_sse_frames(self, client, session_row, user):
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/stream",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+
+        frames = _parse_sse(resp.text)
+        kinds = [f["event"] for f in frames]
+        # Order should be: session_initialized, text_delta, text_delta,
+        # tool_call, tool_result, turn_complete, turn_persisted.
+        assert kinds[0] == "session_initialized"
+        assert kinds.count("text_delta") == 2
+        assert "tool_call" in kinds
+        assert "tool_result" in kinds
+        assert "turn_complete" in kinds
+        assert kinds[-1] == "turn_persisted"
+
+    def test_text_deltas_carry_content(self, client, session_row, user):
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/stream",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        frames = _parse_sse(resp.text)
+        texts = [f["data"]["text"] for f in frames if f["event"] == "text_delta"]
+        assert texts == ["Hello ", "world"]
+
+    async def test_persists_messages(self, client, session_row, user, db_session):
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/stream",
+                json={"message": "streamed hi", "credentials": {"api_key": "k"}},
+            )
+        assert resp.status_code == 200
+
+        result = await db_session.execute(
+            select(ChatMessage).where(ChatMessage.session_id == session_row.id)
+        )
+        msgs = list(result.scalars())
+        assert [m.role for m in msgs] == ["user", "assistant"]
+        assert msgs[0].content["text"] == "streamed hi"
+        assert msgs[1].content["text"] == "Hello world"
+
+    async def test_sdk_session_id_captured(
+        self, client, session_row, user, db_session
+    ):
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            client.post(
+                f"/api/chat/{session_row.id}/stream",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        await db_session.refresh(session_row)
+        assert session_row.sdk_session_id == "sdk-abc"
+
+    def test_turn_persisted_carries_assistant_message_id(
+        self, client, session_row, user
+    ):
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/stream",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        frames = _parse_sse(resp.text)
+        final = frames[-1]
+        assert final["event"] == "turn_persisted"
+        assert final["data"]["assistant_message_id"]  # non-empty uuid
+
+
+class TestStreamErrorPath:
+    def test_provider_error_surfaces_as_error_frame(self, client, session_row, user):
+        events: list[TurnEvent] = [
+            SessionInitialized(sdk_session_id="sdk-x"),
+            ErrorEvent(message="upstream 500"),
+        ]
+        _login(client)
+        with patch("app.chat.service.run_provider_turn", _patched_provider(events)):
+            resp = client.post(
+                f"/api/chat/{session_row.id}/stream",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        frames = _parse_sse(resp.text)
+        kinds = [f["event"] for f in frames]
+        assert "error" in kinds
+        err_frame = next(f for f in frames if f["event"] == "error")
+        assert err_frame["data"]["message"] == "upstream 500"
+
+    async def test_provider_error_still_persists_assistant_message(
+        self, client, session_row, user, db_session
+    ):
+        events: list[TurnEvent] = [ErrorEvent(message="timeout")]
+        _login(client)
+        with patch("app.chat.service.run_provider_turn", _patched_provider(events)):
+            client.post(
+                f"/api/chat/{session_row.id}/stream",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+        result = await db_session.execute(
+            select(ChatMessage)
+            .where(ChatMessage.session_id == session_row.id)
+            .where(ChatMessage.role == "assistant")
+        )
+        msg = result.scalar_one()
+        assert msg.content["error"] == "timeout"
+
+
+class TestStreamConcurrency:
+    def test_stream_releases_user_slot(self, client, session_row, user):
+        """After a stream finishes, the user's slot is free for the next turn."""
+        from app.chat.concurrency import get_concurrency_manager
+
+        mgr = get_concurrency_manager()
+        assert mgr.active_turns_for(user.id) == 0
+
+        _login(client)
+        with patch(
+            "app.chat.service.run_provider_turn", _patched_provider(_events_ok())
+        ):
+            resp1 = client.post(
+                f"/api/chat/{session_row.id}/stream",
+                json={"message": "hi", "credentials": {"api_key": "k"}},
+            )
+            assert resp1.status_code == 200
+            # Slot freed.
+            assert mgr.active_turns_for(user.id) == 0
+
+            resp2 = client.post(
+                f"/api/chat/{session_row.id}/stream",
+                json={"message": "again", "credentials": {"api_key": "k"}},
+            )
+            assert resp2.status_code == 200


### PR DESCRIPTION
Fifth in the chat-feature PR series. Adds POST /api/chat/{id}/stream returning Server-Sent Events so the frontend can render assistant responses as they're generated rather than waiting for the full reply.

- ui/app/chat/sse.py: event_to_frame() maps each TurnEvent to the {event, data} dict EventSourceResponse expects. turn_complete_frame() emits a final ``turn_persisted`` frame carrying the newly-committed assistant message id, so the client can reconcile the in-flight optimistic message with the server-canonical one.
- service.stream_turn(): async generator that runs the turn, persists the user message before dispatch, yields SSE frames as provider events arrive, and persists the assistant message exactly once at the end. If the client disconnects mid-stream, the finally branch still persists whatever was accumulated (marked error="stream interrupted") so a reload doesn't lose partial work.
- routes.chat_stream(): pre-flight (auth, ownership, credentials, cap) runs synchronously and returns plain JSON errors (401/403/404/400/429) before the SSE response starts - so the React client can handle failures with the same machinery as the non-streaming endpoint rather than parsing in-band error frames. The concurrency slot is reserved before the response is returned and released in the generator's finally.
- 21 new tests: 8 SSE frame mapping unit tests, 13 streaming route e2e tests (auth, validation, cap, happy-path frame sequence, persistence, sdk_session_id capture, provider error paths, slot release after stream end).

Note: this PR makes streaming work over the wire but there's still no UI consuming it - the frontend will be in PR #7 after the session-management pages in PR #6.