### PR TITLE
chat: session management API and pages (6/7)

### DIFF
--- a/ui/app/chat/crud.py
+++ b/ui/app/chat/crud.py
@@ -3,16 +3,39 @@
 Mirrors the style of :mod:`app.db.crud` but scoped to the chat feature.
 Route handlers import from here; the service layer talks to models directly
 because it's tightly coupled to the turn lifecycle.
-
-Currently this file holds only the read helper the service layer needs to
-reconstruct prior context when an SDK transcript file goes missing. The
-session CRUD helpers used by the management UI land in a later PR.
 """
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
-from app.db.models import ChatMessage
+from app.db.models import ChatMessage, ChatSession
+
+
+async def get_session_for_user(
+    db: AsyncSession, session_id: str, user_id: str
+) -> ChatSession | None:
+    """Return the session iff it exists AND belongs to the given user."""
+    result = await db.execute(select(ChatSession).where(ChatSession.id == session_id))
+    session = result.scalar_one_or_none()
+    if session is None or session.owner_id != user_id:
+        return None
+    return session
+
+
+async def list_sessions_for_user(
+    db: AsyncSession, user_id: str, *, include_archived: bool = False
+) -> list[ChatSession]:
+    """Return all sessions owned by ``user_id``, newest first."""
+    stmt = (
+        select(ChatSession)
+        .where(ChatSession.owner_id == user_id)
+        .order_by(ChatSession.last_active_at.desc())
+    )
+    if not include_archived:
+        stmt = stmt.where(ChatSession.archived.is_(False))
+    result = await db.execute(stmt)
+    return list(result.scalars())
 
 
 async def list_messages_for_session(
@@ -25,3 +48,56 @@ async def list_messages_for_session(
         .order_by(ChatMessage.created_at.asc())
     )
     return list(result.scalars())
+
+
+async def create_session(
+    db: AsyncSession,
+    *,
+    owner_id: str,
+    provider_id: str,
+    model: str,
+    title: str = "New chat",
+) -> ChatSession:
+    session = ChatSession(
+        owner_id=owner_id,
+        provider_id=provider_id,
+        model=model,
+        title=title,
+    )
+    db.add(session)
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def update_session(
+    db: AsyncSession,
+    session: ChatSession,
+    *,
+    title: str | None = None,
+    archived: bool | None = None,
+) -> ChatSession:
+    if title is not None:
+        session.title = title
+    if archived is not None:
+        session.archived = archived
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def delete_session(db: AsyncSession, session: ChatSession) -> None:
+    await db.delete(session)
+    await db.commit()
+
+
+async def get_session_with_messages(
+    db: AsyncSession, session_id: str
+) -> ChatSession | None:
+    """Fetch session + eager-load its messages. Used by the session page."""
+    result = await db.execute(
+        select(ChatSession)
+        .options(selectinload(ChatSession.messages))
+        .where(ChatSession.id == session_id)
+    )
+    return result.scalar_one_or_none()

--- a/ui/app/main.py
+++ b/ui/app/main.py
@@ -41,7 +41,7 @@ from app.atlas_graph import (
 
 from .routes.admin import ROUTER_ADMIN
 from .routes.auth import ROUTER_AUTH
-from .routes.chat import ROUTER_CHAT
+from .routes.chat import ROUTER_CHAT, ROUTER_CHAT_PAGES
 from .routes.data import ROUTER_USER_DATA
 from .routes.user import ROUTER_USER
 from .config import get_settings
@@ -117,6 +117,7 @@ def create_app() -> FastAPI:
     app.include_router(ROUTER_ADMIN)
     app.include_router(ROUTER_AUTH)
     app.include_router(ROUTER_CHAT)
+    app.include_router(ROUTER_CHAT_PAGES)
     app.include_router(ROUTER_COLLECTIONS)
     app.include_router(ROUTER_USER)
     app.include_router(ROUTER_USER_DATA)

--- a/ui/app/routes/chat.py
+++ b/ui/app/routes/chat.py
@@ -1,18 +1,16 @@
 """Chat routes.
 
-Two turn endpoints:
-  * POST /api/chat/{id}/turn   — non-streaming, returns full JSON.
-  * POST /api/chat/{id}/stream — SSE-streamed, frames as the agent works.
-
-Both share auth, ownership, credential, and concurrency guards. Session
-CRUD endpoints and Jinja pages land in a later PR.
+Exposes non-streaming turn execution. Streaming (SSE) is layered on top in
+step 5; at that point this module grows a second endpoint that shares the
+same service layer.
 """
 
 import logging
 from typing import Any
 
+import app.context as ctx
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,19 +18,122 @@ from sse_starlette.sse import EventSourceResponse
 
 from app.auth import get_current_user_session_or_token
 from app.chat.concurrency import UserChatConcurrencyExceeded, get_concurrency_manager
+from app.chat.config import get_chat_config
+from app.chat.crud import (
+    create_session,
+    delete_session,
+    get_session_for_user,
+    get_session_with_messages,
+    list_sessions_for_user,
+    update_session,
+)
 from app.chat.providers import get_provider
 from app.chat.providers.base import Credentials
 from app.chat.service import run_turn, stream_turn
+from app.context import get_base_context
 from app.db.models import ChatSession
 from app.db.session import get_db
 
 logger = logging.getLogger(__name__)
 
 ROUTER_CHAT = APIRouter(prefix="/api/chat", tags=["Chat"])
+ROUTER_CHAT_PAGES = APIRouter(tags=["Chat"])
+
+
+# ---------------------------------------------------------------------------
+# HTML pages
+# ---------------------------------------------------------------------------
+
+
+def _provider_catalog_for_template() -> list[dict]:
+    """Serialize the chat config into a list the Jinja template can render.
+
+    Structured so the React component gets the same shape via a JSON island
+    later (step 7).
+    """
+    cfg = get_chat_config()
+    return [
+        {
+            "id": provider_id,
+            "display_name": p.display_name,
+            "credential_fields": [
+                {"id": f.id, "display_name": f.display_name, "secret": f.secret}
+                for f in p.credential_fields
+            ],
+            "models": [{"id": m.id, "display_name": m.display_name} for m in p.models],
+        }
+        for provider_id, p in cfg.providers.items()
+    ]
+
+
+@ROUTER_CHAT_PAGES.get("/chat", response_class=HTMLResponse)
+async def chat_list_page(
+    request: Request,
+    context: dict = Depends(get_base_context),
+    db: AsyncSession = Depends(get_db),
+):
+    """List the user's chat sessions."""
+    user = context.get("current_user")
+    if user is None:
+        return RedirectResponse(url="/auth/login?next=/chat", status_code=302)
+
+    beril_user = await get_current_user_session_or_token(request, db)
+    if beril_user is None:
+        return RedirectResponse(url="/auth/login?next=/chat", status_code=302)
+
+    context["active_sessions"] = await list_sessions_for_user(
+        db, beril_user.id, include_archived=False
+    )
+    context["archived_sessions"] = [
+        s
+        for s in await list_sessions_for_user(
+            db, beril_user.id, include_archived=True
+        )
+        if s.archived
+    ]
+    context["providers"] = _provider_catalog_for_template()
+    return ctx.templates.TemplateResponse(request, "chat/list.html", context)
+
+
+@ROUTER_CHAT_PAGES.get("/chat/{session_id}", response_class=HTMLResponse)
+async def chat_session_page(
+    session_id: str,
+    request: Request,
+    context: dict = Depends(get_base_context),
+    db: AsyncSession = Depends(get_db),
+):
+    """Render a single chat session with its transcript."""
+    user = context.get("current_user")
+    if user is None:
+        return RedirectResponse(url=f"/auth/login?next=/chat/{session_id}", status_code=302)
+
+    beril_user = await get_current_user_session_or_token(request, db)
+    if beril_user is None:
+        return RedirectResponse(url=f"/auth/login?next=/chat/{session_id}", status_code=302)
+
+    session = await get_session_with_messages(db, session_id)
+    if session is None or session.owner_id != beril_user.id:
+        return ctx.templates.TemplateResponse(
+            request, "error.html", {**context, "status_code": 404}, status_code=404
+        )
+
+    context["session"] = session
+    context["messages"] = session.messages
+    context["messages_json"] = [
+        {
+            "id": m.id,
+            "role": m.role,
+            "content": m.content or {},
+            "created_at": m.created_at.isoformat() if m.created_at else None,
+        }
+        for m in session.messages
+    ]
+    context["providers"] = _provider_catalog_for_template()
+    return ctx.templates.TemplateResponse(request, "chat/session.html", context)
 
 
 class TurnRequest(BaseModel):
-    """JSON body for POST /api/chat/{session_id}/turn and .../stream."""
+    """JSON body for POST /api/chat/{session_id}/turn."""
 
     message: str = Field(min_length=1)
     # Credentials: {credential_field_id: value}. Keys must match the provider
@@ -72,7 +173,8 @@ async def chat_turn(
 ) -> Response:
     """Run one chat turn to completion and return the assistant's response.
 
-    Non-streaming. Returns JSON on both success and provider error.
+    Non-streaming. Returns JSON on both success and provider error. The
+    streaming variant lives at ``.../stream``.
     """
     user = await get_current_user_session_or_token(request, db)
     if user is None:
@@ -179,3 +281,104 @@ async def chat_stream(
             await turn_guard.__aexit__(None, None, None)
 
     return EventSourceResponse(_event_generator())
+
+
+# ---------------------------------------------------------------------------
+# Session CRUD
+# ---------------------------------------------------------------------------
+
+
+class CreateSessionRequest(BaseModel):
+    provider_id: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    title: str | None = Field(default=None, max_length=500)
+
+
+class UpdateSessionRequest(BaseModel):
+    title: str | None = Field(default=None, max_length=500)
+    archived: bool | None = None
+
+
+def _validate_provider_and_model(provider_id: str, model: str) -> str | None:
+    """Return an error message if the provider or model isn't configured."""
+    try:
+        provider = get_provider(provider_id)
+    except KeyError:
+        return f"unknown provider {provider_id!r}"
+    if not any(m.id == model for m in provider.config.models):
+        return f"unknown model {model!r} for provider {provider_id!r}"
+    return None
+
+
+@ROUTER_CHAT.post("")
+async def chat_create_session(
+    body: CreateSessionRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Create a new chat session. Returns ``{session_id}`` for client redirect."""
+    user = await get_current_user_session_or_token(request, db)
+    if user is None:
+        return Response(status_code=401)
+
+    err = _validate_provider_and_model(body.provider_id, body.model)
+    if err:
+        return JSONResponse({"error": err}, status_code=400)
+
+    session = await create_session(
+        db,
+        owner_id=user.id,
+        provider_id=body.provider_id,
+        model=body.model,
+        title=body.title or "New chat",
+    )
+    return JSONResponse({"session_id": session.id})
+
+
+@ROUTER_CHAT.patch("/{session_id}")
+async def chat_update_session(
+    session_id: str,
+    body: UpdateSessionRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Rename, archive, or unarchive a chat session."""
+    user = await get_current_user_session_or_token(request, db)
+    if user is None:
+        return Response(status_code=401)
+
+    session = await get_session_for_user(db, session_id, user.id)
+    if session is None:
+        # Don't leak the difference between "doesn't exist" and "not yours".
+        return Response(status_code=404)
+
+    if body.title is None and body.archived is None:
+        return JSONResponse({"error": "no fields to update"}, status_code=400)
+
+    await update_session(db, session, title=body.title, archived=body.archived)
+    return JSONResponse(
+        {
+            "session_id": session.id,
+            "title": session.title,
+            "archived": session.archived,
+        }
+    )
+
+
+@ROUTER_CHAT.delete("/{session_id}")
+async def chat_delete_session(
+    session_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Hard-delete a chat session and its messages."""
+    user = await get_current_user_session_or_token(request, db)
+    if user is None:
+        return Response(status_code=401)
+
+    session = await get_session_for_user(db, session_id, user.id)
+    if session is None:
+        return Response(status_code=404)
+
+    await delete_session(db, session)
+    return Response(status_code=204)

--- a/ui/app/templates/chat/list.html
+++ b/ui/app/templates/chat/list.html
@@ -1,0 +1,157 @@
+{% extends "base.html" %}
+
+{% block title %}My Chats — {{ app_name }}{% endblock %}
+
+{% block content %}
+<div class="page-header" style="display: flex; align-items: flex-start; justify-content: space-between; flex-wrap: wrap; gap: var(--space-4);">
+  <div>
+    <h1 class="page-title">My Chats</h1>
+    <p class="text-muted">Persistent conversations with a research co-scientist, backed by your chosen LLM.</p>
+  </div>
+  <button id="chat-new-btn" type="button" class="btn btn-primary" style="white-space: nowrap;">+ New chat</button>
+</div>
+
+{% if active_sessions %}
+  <div style="display: flex; flex-direction: column; gap: var(--space-4);">
+    {% for session in active_sessions %}
+      <div class="card" style="display: flex; align-items: center; justify-content: space-between; gap: var(--space-4); flex-wrap: wrap;">
+        <div style="flex: 1; min-width: 0;">
+          <div style="display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; margin-bottom: var(--space-1);">
+            <span style="font-weight: 600; font-size: 1.05rem;">{{ session.title }}</span>
+            <span class="badge" style="background: rgba(57,212,230,0.1); color: #39d4e6; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em;">{{ session.provider_id }}</span>
+            <span class="badge" style="background: rgba(255,255,255,0.06); color: var(--color-text-muted); font-size: 0.7rem;">{{ session.model }}</span>
+          </div>
+          <p class="text-muted text-small" style="margin: 0;">Last active {{ session.last_active_at.strftime('%Y-%m-%d %H:%M') }}</p>
+        </div>
+        <a href="/chat/{{ session.id }}" class="btn btn-outline btn-sm" style="white-space: nowrap; flex-shrink: 0;">Open</a>
+      </div>
+    {% endfor %}
+  </div>
+{% else %}
+  <div class="card" style="text-align: center; padding: var(--space-10) var(--space-6);">
+    <p class="text-muted" style="margin-bottom: var(--space-4);">You have no chats yet.</p>
+    <button id="chat-empty-new-btn" type="button" class="btn btn-primary">Start your first chat</button>
+  </div>
+{% endif %}
+
+{% if archived_sessions %}
+  <details style="margin-top: var(--space-8);">
+    <summary class="text-muted" style="cursor: pointer;">Archived ({{ archived_sessions|length }})</summary>
+    <div style="display: flex; flex-direction: column; gap: var(--space-3); margin-top: var(--space-4);">
+      {% for session in archived_sessions %}
+        <div class="card" style="opacity: 0.7; display: flex; align-items: center; justify-content: space-between; gap: var(--space-4);">
+          <span>{{ session.title }}</span>
+          <a href="/chat/{{ session.id }}" class="btn btn-outline btn-sm">Open</a>
+        </div>
+      {% endfor %}
+    </div>
+  </details>
+{% endif %}
+
+{# Provider catalog embedded as JSON so the new-chat modal can populate its dropdowns. #}
+<script type="application/json" id="chat-providers-data">{{ providers | tojson }}</script>
+
+<dialog id="chat-new-dialog" style="border: 1px solid rgba(255,255,255,0.15); border-radius: var(--radius-lg); background: var(--color-bg-elevated); color: var(--color-text); padding: var(--space-6); max-width: 480px; width: 90%;">
+  <form id="chat-new-form" style="display: flex; flex-direction: column; gap: var(--space-4);">
+    <h2 style="margin: 0;">Start a new chat</h2>
+
+    <label style="display: flex; flex-direction: column; gap: var(--space-1);">
+      <span>Host</span>
+      <select name="provider_id" id="chat-new-provider" required></select>
+    </label>
+
+    <label style="display: flex; flex-direction: column; gap: var(--space-1);">
+      <span>Model</span>
+      <select name="model" id="chat-new-model" required></select>
+    </label>
+
+    <label style="display: flex; flex-direction: column; gap: var(--space-1);">
+      <span>Title (optional)</span>
+      <input type="text" name="title" maxlength="500" placeholder="New chat">
+    </label>
+
+    <div style="display: flex; gap: var(--space-3); justify-content: flex-end;">
+      <button type="button" id="chat-new-cancel" class="btn btn-outline">Cancel</button>
+      <button type="submit" class="btn btn-primary">Create</button>
+    </div>
+
+    <p id="chat-new-error" class="text-muted text-small" style="color: #ff6b6b; display: none; margin: 0;"></p>
+  </form>
+</dialog>
+
+<script>
+  (function () {
+    const dialog = document.getElementById('chat-new-dialog');
+    const providerSelect = document.getElementById('chat-new-provider');
+    const modelSelect = document.getElementById('chat-new-model');
+    const form = document.getElementById('chat-new-form');
+    const errorEl = document.getElementById('chat-new-error');
+
+    const providers = JSON.parse(
+      document.getElementById('chat-providers-data').textContent
+    );
+
+    function populateProviders() {
+      providerSelect.innerHTML = '';
+      for (const p of providers) {
+        const opt = document.createElement('option');
+        opt.value = p.id;
+        opt.textContent = p.display_name;
+        providerSelect.appendChild(opt);
+      }
+      populateModels();
+    }
+
+    function populateModels() {
+      const selected = providers.find(p => p.id === providerSelect.value);
+      modelSelect.innerHTML = '';
+      if (!selected) return;
+      for (const m of selected.models) {
+        const opt = document.createElement('option');
+        opt.value = m.id;
+        opt.textContent = m.display_name;
+        modelSelect.appendChild(opt);
+      }
+    }
+
+    providerSelect.addEventListener('change', populateModels);
+
+    function openDialog() {
+      errorEl.style.display = 'none';
+      populateProviders();
+      dialog.showModal();
+    }
+
+    document.getElementById('chat-new-btn')?.addEventListener('click', openDialog);
+    document.getElementById('chat-empty-new-btn')?.addEventListener('click', openDialog);
+    document.getElementById('chat-new-cancel').addEventListener('click', () => dialog.close());
+
+    form.addEventListener('submit', async (ev) => {
+      ev.preventDefault();
+      errorEl.style.display = 'none';
+      const data = new FormData(form);
+      const payload = {
+        provider_id: data.get('provider_id'),
+        model: data.get('model'),
+        title: data.get('title') || null,
+      };
+      try {
+        const resp = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!resp.ok) {
+          const body = await resp.json().catch(() => ({}));
+          throw new Error(body.error || `create failed (${resp.status})`);
+        }
+        const body = await resp.json();
+        window.location.assign(`/chat/${body.session_id}`);
+      } catch (err) {
+        errorEl.textContent = err.message;
+        errorEl.style.display = 'block';
+      }
+    });
+  })();
+</script>
+{% endblock %}

--- a/ui/app/templates/chat/session.html
+++ b/ui/app/templates/chat/session.html
@@ -1,0 +1,128 @@
+{% extends "base.html" %}
+
+{% block title %}{{ session.title }} — {{ app_name }}{% endblock %}
+
+{% block content %}
+<div class="page-header" style="display: flex; align-items: flex-start; justify-content: space-between; flex-wrap: wrap; gap: var(--space-4);">
+  <div style="flex: 1; min-width: 0;">
+    <a href="/chat" class="text-muted text-small" style="text-decoration: none;">&larr; All chats</a>
+    <h1 class="page-title" style="margin-top: var(--space-2);">{{ session.title }}</h1>
+    <p class="text-muted text-small" style="margin: 0;">
+      {{ session.provider_id }} · {{ session.model }} ·
+      Last active {{ session.last_active_at.strftime('%Y-%m-%d %H:%M') }}
+    </p>
+  </div>
+</div>
+
+{#
+  Transcript renders server-side so refreshes / no-JS show prior messages.
+  The React island will mount underneath and take over new-turn
+  streaming.
+#}
+<section id="chat-transcript" style="display: flex; flex-direction: column; gap: var(--space-4); margin-top: var(--space-6);">
+  {% if messages %}
+    {% for msg in messages %}
+      <article class="card" data-role="{{ msg.role }}" style="padding: var(--space-4);">
+        <header style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: var(--space-2);">
+          <span style="font-weight: 600; text-transform: capitalize;">{{ msg.role }}</span>
+          <span class="text-muted text-small">{{ msg.created_at.strftime('%Y-%m-%d %H:%M') }}</span>
+        </header>
+        {% if msg.content.get('text') %}
+          <p style="margin: 0; white-space: pre-wrap;">{{ msg.content['text'] }}</p>
+        {% endif %}
+        {% if msg.content.get('error') %}
+          <p class="text-small" style="color: #ff6b6b; margin-top: var(--space-2);">
+            Error: {{ msg.content['error'] }}
+          </p>
+        {% endif %}
+        {% if msg.content.get('tool_activity') %}
+          <details style="margin-top: var(--space-2);">
+            <summary class="text-muted text-small" style="cursor: pointer;">
+              Tool activity ({{ msg.content['tool_activity']|length }})
+            </summary>
+            <pre class="text-small" style="overflow-x: auto; margin-top: var(--space-2);">{{ msg.content['tool_activity'] | tojson(indent=2) }}</pre>
+          </details>
+        {% endif %}
+      </article>
+    {% endfor %}
+  {% else %}
+    <div class="card" style="text-align: center; padding: var(--space-8);">
+      <p class="text-muted">No messages yet.</p>
+    </div>
+  {% endif %}
+</section>
+
+{#
+  React chat island. The component itself owns the message list and input;
+  the server-rendered transcript above is the fallback when JS is disabled
+  and is hidden once the component mounts.
+#}
+<div id="chat-island-root"
+     data-session-id="{{ session.id }}"
+     data-provider-id="{{ session.provider_id }}"
+     data-model="{{ session.model }}"
+     style="margin-top: var(--space-6);"></div>
+
+<script type="application/json" id="chat-providers-data">{{ providers | tojson }}</script>
+<script type="application/json" id="chat-initial-messages">{{ messages_json | tojson }}</script>
+
+<script type="module">
+  // Bootstrap: await the bundle so `window.BERILChat` is guaranteed to be
+  // installed before we read it. Using dynamic import (rather than a
+  // separate <script> tag) sequences the module load deterministically.
+  (async function () {
+    const root = document.getElementById('chat-island-root');
+    if (!root) return;
+
+    try {
+      await import('/static/chat/chat.js');
+    } catch (err) {
+      console.error('Failed to load chat component bundle:', err);
+      root.innerHTML =
+        '<p style="color:#ff6b6b;">Chat component failed to load. See console for details.</p>';
+      return;
+    }
+
+    if (!window.BERILChat) {
+      console.error(
+        'Chat bundle loaded but window.BERILChat is undefined — rebuild may be stale.'
+      );
+      return;
+    }
+
+    const providers = JSON.parse(
+      document.getElementById('chat-providers-data').textContent
+    );
+
+    const rawMessages = JSON.parse(
+      document.getElementById('chat-initial-messages').textContent
+    );
+    const initialMessages = rawMessages
+      .filter(m => m && m.id && m.role && m.content)
+      .map(m => ({
+        id: m.id,
+        role: m.role,
+        text: (m.content && m.content.text) || '',
+        tool_activity: (m.content && m.content.tool_activity) || [],
+        error: (m.content && m.content.error) || null,
+        created_at: m.created_at,
+      }));
+
+    const sessionId = root.dataset.sessionId;
+
+    // Hide the SSR transcript once React takes over, but keep it in the DOM
+    // so the no-JS fallback still works on initial paint.
+    const ssrTranscript = document.getElementById('chat-transcript');
+    if (ssrTranscript) ssrTranscript.style.display = 'none';
+
+    window.BERILChat.mount(root, {
+      sessionId,
+      providerCatalog: providers,
+      currentProviderId: root.dataset.providerId,
+      currentModel: root.dataset.model,
+      streamEndpoint: `/api/chat/${sessionId}/stream`,
+      initialMessages,
+    });
+  })();
+</script>
+{% endblock %}

--- a/ui/tests/test_routes_chat_sessions.py
+++ b/ui/tests/test_routes_chat_sessions.py
@@ -1,0 +1,424 @@
+"""Tests for chat session CRUD and list/session pages."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncGenerator
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.db.models import BerilUser, ChatMessage, ChatSession
+from app.db.session import get_db
+from app.main import create_app
+
+
+_ENV = {
+    "BERIL_TEST_SKIP_LIFESPAN": "True",
+    "BERIL_ORCID_CLIENT_ID": "APP-TESTCLIENTID",
+    "BERIL_ORCID_CLIENT_SECRET": "test-secret",
+    "BERIL_ORCID_BASE_URL": "https://sandbox.orcid.org",
+    "BERIL_SESSION_SECRET_KEY": "test-session-secret",
+}
+
+USER_TOKEN = {
+    "access_token": "fake-access-token",
+    "token_type": "bearer",
+    "orcid": "0000-0001-2345-6789",
+    "name": "Alice Researcher",
+}
+
+OTHER_TOKEN = {
+    "access_token": "other-access-token",
+    "token_type": "bearer",
+    "orcid": "0000-0002-9999-9999",
+    "name": "Mallory",
+}
+
+
+def _make_mock_oauth_client(token: dict):
+    auth_url = (
+        "https://sandbox.orcid.org/oauth/authorize"
+        "?client_id=APP-TESTCLIENTID&scope=%2Fauthenticate"
+        "&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8000"
+        "%2Fauth%2Forcid%2Fcallback&state=mock-state"
+    )
+    mock_instance = MagicMock()
+    mock_instance.create_authorization_url = MagicMock(return_value=(auth_url, "mock-state"))
+    mock_instance.fetch_token = AsyncMock(return_value=token)
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=mock_instance)
+
+
+def _login(client: TestClient, token: dict = USER_TOKEN) -> None:
+    mock_class = _make_mock_oauth_client(token)
+    with patch("app.routes.auth.AsyncOAuth2Client", mock_class):
+        client.get(
+            "/auth/orcid/callback",
+            params={"code": "fake-code"},
+            follow_redirects=False,
+        )
+
+
+@pytest.fixture
+def client(repository_data, app_data_context, db_session):
+    with patch.dict(os.environ, _ENV):
+        import app.config as cfg
+
+        cfg._settings = None
+        app_instance = create_app()
+
+        async def override_get_db() -> AsyncGenerator:
+            yield db_session
+
+        app_instance.dependency_overrides[get_db] = override_get_db
+        with TestClient(app_instance, raise_server_exceptions=True) as c:
+            app_instance.state.repo_data = repository_data
+            app_instance.state.base_context = app_data_context
+            yield c
+        cfg._settings = None
+
+
+@pytest.fixture
+async def user(db_session):
+    u = BerilUser(orcid_id=USER_TOKEN["orcid"], display_name=USER_TOKEN["name"])
+    db_session.add(u)
+    await db_session.commit()
+    await db_session.refresh(u)
+    return u
+
+
+@pytest.fixture
+async def other_user(db_session):
+    u = BerilUser(orcid_id=OTHER_TOKEN["orcid"], display_name=OTHER_TOKEN["name"])
+    db_session.add(u)
+    await db_session.commit()
+    await db_session.refresh(u)
+    return u
+
+
+async def _make_session(db, owner, **overrides) -> ChatSession:
+    defaults = dict(
+        owner_id=owner.id,
+        provider_id="anthropic",
+        model="claude-opus-4-7",
+        title="Test chat",
+    )
+    defaults.update(overrides)
+    s = ChatSession(**defaults)
+    db.add(s)
+    await db.commit()
+    await db.refresh(s)
+    return s
+
+
+# ---------------------------------------------------------------------------
+# POST /api/chat — create
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSession:
+    def test_unauthenticated_returns_401(self, client):
+        resp = client.post(
+            "/api/chat",
+            json={"provider_id": "anthropic", "model": "claude-opus-4-7"},
+        )
+        assert resp.status_code == 401
+
+    async def test_happy_path_creates_row(self, client, user, db_session):
+        _login(client)
+        resp = client.post(
+            "/api/chat",
+            json={
+                "provider_id": "anthropic",
+                "model": "claude-opus-4-7",
+                "title": "Gene clusters",
+            },
+        )
+        assert resp.status_code == 200
+        session_id = resp.json()["session_id"]
+
+        result = await db_session.execute(
+            select(ChatSession).where(ChatSession.id == session_id)
+        )
+        row = result.scalar_one()
+        assert row.owner_id == user.id
+        assert row.provider_id == "anthropic"
+        assert row.model == "claude-opus-4-7"
+        assert row.title == "Gene clusters"
+
+    def test_default_title(self, client, user):
+        _login(client)
+        resp = client.post(
+            "/api/chat",
+            json={"provider_id": "anthropic", "model": "claude-opus-4-7"},
+        )
+        assert resp.status_code == 200
+
+    def test_unknown_provider_rejected(self, client, user):
+        _login(client)
+        resp = client.post(
+            "/api/chat",
+            json={"provider_id": "bogus", "model": "claude-opus-4-7"},
+        )
+        assert resp.status_code == 400
+        assert "bogus" in resp.json()["error"]
+
+    def test_unknown_model_rejected(self, client, user):
+        _login(client)
+        resp = client.post(
+            "/api/chat",
+            json={"provider_id": "anthropic", "model": "not-a-real-model"},
+        )
+        assert resp.status_code == 400
+        assert "not-a-real-model" in resp.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/chat/{id} — update (rename, archive)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSession:
+    def test_unauthenticated_returns_401(self, client):
+        resp = client.patch("/api/chat/anything", json={"title": "x"})
+        assert resp.status_code == 401
+
+    async def test_missing_session_returns_404(self, client, user):
+        _login(client)
+        resp = client.patch("/api/chat/does-not-exist", json={"title": "x"})
+        assert resp.status_code == 404
+
+    async def test_other_users_session_returns_404(
+        self, client, user, other_user, db_session
+    ):
+        """No information leak: other-user and missing both return 404."""
+        foreign = await _make_session(db_session, other_user)
+        _login(client)
+        resp = client.patch(f"/api/chat/{foreign.id}", json={"title": "x"})
+        assert resp.status_code == 404
+
+    async def test_rename(self, client, user, db_session):
+        session = await _make_session(db_session, user, title="old")
+        _login(client)
+        resp = client.patch(f"/api/chat/{session.id}", json={"title": "new title"})
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "new title"
+
+        await db_session.refresh(session)
+        assert session.title == "new title"
+
+    async def test_archive(self, client, user, db_session):
+        session = await _make_session(db_session, user)
+        _login(client)
+        resp = client.patch(f"/api/chat/{session.id}", json={"archived": True})
+        assert resp.status_code == 200
+        assert resp.json()["archived"] is True
+
+        await db_session.refresh(session)
+        assert session.archived is True
+
+    async def test_unarchive(self, client, user, db_session):
+        session = await _make_session(db_session, user, archived=True)
+        _login(client)
+        resp = client.patch(f"/api/chat/{session.id}", json={"archived": False})
+        assert resp.status_code == 200
+        await db_session.refresh(session)
+        assert session.archived is False
+
+    async def test_empty_patch_rejected(self, client, user, db_session):
+        session = await _make_session(db_session, user)
+        _login(client)
+        resp = client.patch(f"/api/chat/{session.id}", json={})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/chat/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteSession:
+    def test_unauthenticated_returns_401(self, client):
+        resp = client.delete("/api/chat/anything")
+        assert resp.status_code == 401
+
+    async def test_missing_session_returns_404(self, client, user):
+        _login(client)
+        resp = client.delete("/api/chat/does-not-exist")
+        assert resp.status_code == 404
+
+    async def test_other_users_session_returns_404(
+        self, client, user, other_user, db_session
+    ):
+        foreign = await _make_session(db_session, other_user)
+        _login(client)
+        resp = client.delete(f"/api/chat/{foreign.id}")
+        assert resp.status_code == 404
+
+    async def test_delete_removes_row_and_messages(self, client, user, db_session):
+        session = await _make_session(db_session, user)
+        msg = ChatMessage(session_id=session.id, role="user", content={"text": "hi"})
+        db_session.add(msg)
+        await db_session.commit()
+
+        _login(client)
+        resp = client.delete(f"/api/chat/{session.id}")
+        assert resp.status_code == 204
+
+        result = await db_session.execute(
+            select(ChatSession).where(ChatSession.id == session.id)
+        )
+        assert result.scalar_one_or_none() is None
+
+        result = await db_session.execute(
+            select(ChatMessage).where(ChatMessage.session_id == session.id)
+        )
+        assert list(result.scalars()) == []
+
+
+# ---------------------------------------------------------------------------
+# GET /chat — list page
+# ---------------------------------------------------------------------------
+
+
+class TestListPage:
+    def test_unauthenticated_redirects(self, client):
+        resp = client.get("/chat", follow_redirects=False)
+        assert resp.status_code == 302
+        assert "/auth/login" in resp.headers["location"]
+
+    async def test_shows_active_sessions(self, client, user, db_session):
+        await _make_session(db_session, user, title="Project planning chat")
+        await _make_session(db_session, user, title="Archived one", archived=True)
+        _login(client)
+
+        resp = client.get("/chat")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Project planning chat" in body
+        # Archived session shouldn't be in the main list, but should appear
+        # in the Archived details section.
+        assert "Archived one" in body
+        assert "Archived" in body  # the <summary> label
+
+    async def test_empty_state(self, client, user):
+        _login(client)
+        resp = client.get("/chat")
+        assert resp.status_code == 200
+        assert "You have no chats yet" in resp.text
+
+    async def test_provider_catalog_embedded(self, client, user):
+        _login(client)
+        resp = client.get("/chat")
+        assert "chat-providers-data" in resp.text
+        # Provider IDs should appear in the JSON island.
+        assert "anthropic" in resp.text
+        assert "cborg" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# GET /chat/{id} — session page
+# ---------------------------------------------------------------------------
+
+
+class TestSessionPage:
+    def test_unauthenticated_redirects(self, client):
+        resp = client.get("/chat/some-id", follow_redirects=False)
+        assert resp.status_code == 302
+
+    async def test_missing_session_returns_404(self, client, user):
+        _login(client)
+        resp = client.get("/chat/does-not-exist")
+        assert resp.status_code == 404
+
+    async def test_other_users_session_returns_404(
+        self, client, user, other_user, db_session
+    ):
+        foreign = await _make_session(db_session, other_user)
+        _login(client)
+        resp = client.get(f"/chat/{foreign.id}")
+        assert resp.status_code == 404
+
+    async def test_renders_transcript(self, client, user, db_session):
+        session = await _make_session(db_session, user, title="Research chat")
+        now = datetime.now(timezone.utc)
+        user_msg = ChatMessage(
+            session_id=session.id,
+            role="user",
+            content={"text": "What genes matter?"},
+            created_at=now,
+        )
+        assistant_msg = ChatMessage(
+            session_id=session.id,
+            role="assistant",
+            content={"text": "Several candidates.", "tool_activity": [], "error": None},
+            created_at=now,
+        )
+        db_session.add_all([user_msg, assistant_msg])
+        await db_session.commit()
+
+        _login(client)
+        resp = client.get(f"/chat/{session.id}")
+        assert resp.status_code == 200
+        assert "Research chat" in resp.text
+        assert "What genes matter?" in resp.text
+        assert "Several candidates." in resp.text
+
+    async def test_island_root_carries_session_metadata(
+        self, client, user, db_session
+    ):
+        session = await _make_session(db_session, user, model="claude-sonnet-4-6")
+        _login(client)
+        resp = client.get(f"/chat/{session.id}")
+        assert f'data-session-id="{session.id}"' in resp.text
+        assert 'data-provider-id="anthropic"' in resp.text
+        assert 'data-model="claude-sonnet-4-6"' in resp.text
+
+    async def test_initial_messages_json_block_is_valid(
+        self, client, user, db_session
+    ):
+        """The React island parses JSON out of <script id='chat-initial-messages'>.
+        If this JSON is malformed, the page silently breaks client-side, so
+        snapshot the structure here."""
+        import json
+        import re
+
+        session = await _make_session(db_session, user)
+        db_session.add_all(
+            [
+                ChatMessage(
+                    session_id=session.id,
+                    role="user",
+                    content={"text": "hi"},
+                ),
+                ChatMessage(
+                    session_id=session.id,
+                    role="assistant",
+                    content={
+                        "text": "hello",
+                        "tool_activity": [],
+                        "error": None,
+                    },
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        _login(client)
+        resp = client.get(f"/chat/{session.id}")
+        m = re.search(
+            r'<script type="application/json" id="chat-initial-messages">(.*?)</script>',
+            resp.text,
+            re.DOTALL,
+        )
+        assert m is not None
+        parsed = json.loads(m.group(1))
+        assert isinstance(parsed, list)
+        assert len(parsed) == 2
+        assert {row["role"] for row in parsed} == {"user", "assistant"}
+        assert all("id" in row and "created_at" in row for row in parsed)


### PR DESCRIPTION
## Summary

Sixth of seven PRs splitting up the chat feature. Adds session-management
CRUD endpoints and the Jinja list/detail pages that wrap the streaming
turn endpoint shipped in #226.

- `POST /api/chat`, `PATCH /api/chat/{id}`, `DELETE /api/chat/{id}` for
  session create/rename/archive/delete.
- `GET /chat` and `GET /chat/{id}` server-side pages, including a
  `messages_json` island the React component (PR #7) will hydrate from.
- Fills out `app/chat/crud.py` with the session helpers (the stub
  `list_messages_for_session` from PR #4 stays).
- Registers a new `ROUTER_CHAT_PAGES` in `main.py`.
- 26 new tests covering CRUD, page rendering, and the JSON-island shape.

The page mount in `session.html` does `await import('/static/chat/chat.js')`,
which fails gracefully until PR #7 puts that bundle on disk.

Stacked on top of #226 (merged). The Dockerfile prereqs from PR #1 are
required for end-to-end testing on the development site.

## Test plan
- [ ] `cd ui && uv run pytest tests/ -q --no-cov` — 712 tests pass.
- [ ] `/chat` renders without 500.
- [ ] `/chat/{id}` renders without 500 (chat.js absent yet — no-JS fallback shown).
- [ ] CRUD endpoints round-trip create → list → rename → archive → delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
