### PR TITLE
docs: refresh BERDL schema docs with missed table ingestions

### DIFF
--- a/.claude/skills/berdl/modules/pangenome.md
+++ b/.claude/skills/berdl/modules/pangenome.md
@@ -13,16 +13,28 @@ Pangenome data for 293,059 genomes across 27,690 microbial species from GTDB.
 | `genome` | 293,059 | Genome metadata and file paths |
 | `pangenome` | 27,690 | Per-species pangenome statistics |
 | `gtdb_species_clade` | 27,690 | Species taxonomy and ANI statistics |
-| `gene_cluster` | varies | Gene family classifications (core/accessory/singleton) |
-| `gene_genecluster_junction` | varies | Gene-to-cluster memberships |
-| `gene` | varies | Individual gene records |
-| `eggnog_mapper_annotations` | varies | Functional annotations (COG, GO, KEGG, EC, PFAM) |
-| `gapmind_pathways` | varies | Metabolic pathway predictions |
-| `genome_ani` | varies | Pairwise ANI values between genomes |
-| `gtdb_metadata` | varies | CheckM quality, assembly stats, GC% |
-| `gtdb_taxonomy_r214v1` | varies | GTDB taxonomy |
-| `sample` | varies | Sample metadata |
-| `ncbi_env` | varies | Environment metadata |
+| `gene_cluster` | 132,531,501 | Gene family classifications (core/accessory/singleton) |
+| `gene_genecluster_junction` | 1,011,650,762 | Gene-to-cluster memberships |
+| `gene` | 1,011,650,903 | Individual gene records |
+| `eggnog_mapper_annotations` | 93,558,330 | Functional annotations (COG, GO, KEGG, EC, PFAM) |
+| `gapmind_pathways` | 305,471,280 | Metabolic pathway predictions |
+| `genome_ani` | 421,218,641 | Pairwise ANI values between genomes |
+| `gtdb_metadata` | 293,059 | CheckM quality, assembly stats, GC% |
+| `gtdb_taxonomy_r214v1` | 293,059 | GTDB taxonomy |
+| `sample` | 293,059 | Sample metadata |
+| `ncbi_env` | 4,124,801 | Environment metadata |
+| `bakta_annotations` | 132,538,155 | Bakta reannotation of cluster representatives (gene names, EC, COG, KEGG, UniRef) |
+| `bakta_db_xrefs` | 572,376,477 | Bakta cross-references to external DBs (UniRef, RefSeq, etc.) |
+| `bakta_pfam_domains` | 18,807,208 | Pfam domain hits from Bakta |
+| `bakta_amr` | 83,008 | AMR gene calls from Bakta |
+| `interproscan_domains` | 833,303,130 | InterProScan domain hits across 18 member databases |
+| `interproscan_go` | 266,317,724 | GO term assignments via InterProScan |
+| `interproscan_pathways` | 287,228,475 | Pathway assignments via InterProScan (KEGG, MetaCyc, Reactome) |
+| `alphaearth_embeddings_all_years` | 83,287 | AlphaEarth satellite-imagery embeddings keyed to genome sample sites |
+| `phylogenetic_tree` | 343 | Per-species phylogenetic trees (Newick format) |
+| `phylogenetic_tree_distance_pairs` | 283,485,747 | Pairwise branch distances from species trees |
+
+For full schemas of the Bakta, InterProScan, AlphaEarth, and phylogenetic tables, see [`docs/schemas/pangenome.md`](../../../../docs/schemas/pangenome.md).
 
 ## Key Table Schemas
 

--- a/docs/schemas/pdb.md
+++ b/docs/schemas/pdb.md
@@ -3,24 +3,29 @@
 Database: `kescience_pdb`
 Location: On-prem Delta Lakehouse (BERDL)
 Tenant: kescience
-Last Updated: 2026-03-14
-Verified: Ingested 2026-03-14 (250,741 entries + 966,977 mappings)
+Last Updated: 2026-05-05
+Verified: Ingested 2026-03-14 (250,741 entries + 966,977 mappings + 5 extended tables)
 
 ## Overview
 
 Experimental structure metadata from the Protein Data Bank. Contains ~250K deposited structures with resolution, R-factors, experimental method, organism, and PDB→UniProt chain mapping from SIFTS. Enables cross-collection queries linking pangenome annotations and AlphaFold predictions to experimental structures.
 
 **Database**: `kescience_pdb`
-**Source**: RCSB PDB GraphQL API + EBI SIFTS
-**Scale**: 250,741 entries, 966,977 chain mappings
+**Source**: RCSB PDB GraphQL API + EBI SIFTS + RCSB CDN sequence clusters
+**Scale**: 8 tables, ~12.9M total rows
 
 ## Tables
 
-| Table | Rows (est.) | Description |
-|-------|-------------|-------------|
+| Table | Rows | Description |
+|-------|------|-------------|
 | `pdb_entries` | 250,741 | One row per PDB entry — core metadata |
 | `pdb_uniprot_mapping` | 966,977 | PDB chain → UniProt accession (from SIFTS) |
-| `pdb_validation` | ~250K | wwPDB validation metrics (clashscore, Ramachandran, rotamers) |
+| `pdb_validation` | 250,741 | wwPDB validation metrics (clashscore, Ramachandran, rotamers) |
+| `pdb_taxonomy` | 250,741 | NCBI taxonomy ID and organism per PDB entry |
+| `pdb_ligands` | 455,897 | Co-crystallized small molecules (ligand id, name, formula, weight) |
+| `pdb_citations` | 296,528 | Primary and secondary citations (PubMed IDs, DOIs, authors) |
+| `pdb_pfam` | 990,166 | PDB chain → Pfam domain mapping (from SIFTS) |
+| `pdb_sequence_clusters` | 9,532,482 | Pre-computed RCSB sequence clusters at 30/50/70/90/95/100% identity |
 
 ## Key Table Schemas
 
@@ -71,12 +76,76 @@ wwPDB validation metrics from RCSB GraphQL API (`pdbx_vrpt_summary_geometry`). O
 | `angles_rmsz` | FLOAT | RMS Z-score for bond angles |
 | `bonds_rmsz` | FLOAT | RMS Z-score for bond lengths |
 
+### pdb_taxonomy
+
+NCBI taxonomy assignment from RCSB GraphQL `rcsb_entity_source_organism`. One row per PDB entry.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `pdb_id` | STRING | PDB accession — FK to `pdb_entries.pdb_id` |
+| `taxonomy_id` | INT | NCBI taxonomy ID |
+| `organism` | STRING | Source organism scientific name |
+
+### pdb_ligands
+
+Co-crystallized small molecules and ions from RCSB GraphQL `nonpolymer_entities`. One row per (entry, ligand) pair.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `pdb_id` | STRING | PDB accession — FK to `pdb_entries.pdb_id` |
+| `ligand_id` | STRING | Three-letter chemical component ID (e.g., "HEM", "ATP") |
+| `ligand_name` | STRING | Human-readable name |
+| `ligand_type` | STRING | Component type (e.g., "non-polymer") |
+| `formula` | STRING | Chemical formula |
+| `formula_weight` | FLOAT | Molecular weight in Da |
+
+### pdb_citations
+
+Primary and secondary citations from RCSB GraphQL `citation`. Multiple rows per PDB entry.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `pdb_id` | STRING | PDB accession — FK to `pdb_entries.pdb_id` |
+| `citation_id` | STRING | Citation identifier within the entry |
+| `is_primary` | STRING | "true" if this is the primary citation |
+| `title` | STRING | Paper title |
+| `year` | INT | Publication year |
+| `journal` | STRING | Journal abbreviation |
+| `volume` | STRING | Journal volume |
+| `page_first` | STRING | First page |
+| `doi` | STRING | DOI |
+| `pubmed_id` | INT | PubMed ID |
+| `authors` | STRING | Author list (semicolon-separated) |
+
+### pdb_pfam
+
+PDB chain → Pfam domain mapping from SIFTS (`pdb_chain_pfam.tsv.gz`). Multiple rows per (entry, chain).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `pdb_id` | STRING | PDB accession — FK to `pdb_entries.pdb_id` |
+| `chain_id` | STRING | Chain identifier |
+| `uniprot_accession` | STRING | UniProt accession (links to AlphaFold, bakta) |
+| `pfam_id` | STRING | Pfam family ID (e.g., "PF00001") |
+| `coverage` | FLOAT | Domain coverage fraction |
+
+### pdb_sequence_clusters
+
+RCSB pre-computed sequence clusters at six identity thresholds. One row per (cluster, entity) at each identity level.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `cluster_id` | STRING | Cluster identifier |
+| `pdb_entity_id` | STRING | PDB entity ID (e.g., "1ABC_1") |
+| `identity_level` | INT | Identity threshold: 30, 50, 70, 90, 95, or 100 |
+
 ## Cross-Collection Links
 
 | Target Collection | Join Key | Notes |
 |-------------------|----------|-------|
 | `kescience_alphafold.alphafold_entries` | `pdb_uniprot_mapping.uniprot_accession = alphafold_entries.uniprot_accession` | Link experimental → predicted |
 | `kbase_ke_pangenome.bakta_annotations` | `pdb_uniprot_mapping.uniprot_accession = REPLACE(bakta_annotations.uniref100, 'UniRef100_', '')` | Link pangenome → experimental |
+| `kbase_ke_pangenome.bakta_annotations` (via Pfam) | `pdb_pfam.uniprot_accession = REPLACE(bakta_annotations.uniref100, 'UniRef100_', '')` | Domain-level link with Pfam ID |
 | `kescience_structural_biology.structure_projects` | `pdb_entries.pdb_id = structure_projects.pdb_id` | Link to Phenix projects |
 
 ## Example Queries
@@ -169,3 +238,5 @@ ORDER BY 1;
 ## Changelog
 
 - **2026-03-14**: Initial schema design, download, and ingestion. 250,741 PDB entries + 966,977 SIFTS mappings.
+- **2026-03-14**: Extended ingestion (commit `7845f8e`): 5 additional tables — `pdb_taxonomy`, `pdb_ligands`, `pdb_citations`, `pdb_pfam`, `pdb_sequence_clusters`. Doc was not updated at the time.
+- **2026-05-05**: Document the 5 extended tables ingested 2026-03-14.

--- a/docs/schemas/phagefoundry.md
+++ b/docs/schemas/phagefoundry.md
@@ -2,6 +2,7 @@
 
 **Databases**:
 - `phagefoundry_acinetobacter_genome_browser`
+- `phagefoundry_ecoliphagesgenomedepot`
 - `phagefoundry_klebsiella_genome_browser_genomedepot`
 - `phagefoundry_paeruginosa_genome_browser`
 - `phagefoundry_pviridiflava_genome_browser`
@@ -9,21 +10,20 @@
 
 **Location**: On-prem Delta Lakehouse (BERDL)
 **Tenant**: PhageFoundry
-**Last Updated**: 2026-02-11
+**Last Updated**: 2026-05-05
 
 ---
 
 ## Overview
 
-Species-specific genome browser databases for the PhageFoundry project, supporting phage-host interaction research. Each genome browser database shares the same schema (GenomeDepot format) with 37 tables covering genomes, genes, proteins, functional annotations, operons, regulons, and strain metadata.
+Species-specific genome browser databases for the PhageFoundry project, supporting phage-host interaction research. Each genome browser database shares the same schema (GenomeDepot format) with 37 tables covering genomes, genes, proteins, functional annotations, operons, regulons, and strain metadata. The companion `phagefoundry_strain_modelling` database (different schema) holds strain-modelling experiment results — see the dedicated section below.
 
 Confirmed species:
-- *Acinetobacter* (~891 strains, 112K contigs)
-- *Klebsiella* (GenomeDepot format)
-- *Pseudomonas aeruginosa*
-- *Pseudomonas viridiflava*
-
-An additional `phagefoundry_strain_modelling` database exists but timed out during introspection.
+- *Acinetobacter* (~891 strains, 112K contigs) — `phagefoundry_acinetobacter_genome_browser`
+- *E. coli* phages — `phagefoundry_ecoliphagesgenomedepot` (38 tables; the only browser DB with `browser_config`)
+- *Klebsiella* — `phagefoundry_klebsiella_genome_browser_genomedepot`
+- *Pseudomonas aeruginosa* — `phagefoundry_paeruginosa_genome_browser`
+- *Pseudomonas viridiflava* — `phagefoundry_pviridiflava_genome_browser`
 
 ---
 
@@ -87,17 +87,63 @@ All four genome browser databases share identical table structure:
 | `browser_strain_metadata` | Strain key-value metadata |
 | `browser_site_genes` | Regulatory site-gene associations |
 | `browser_site_operons` | Regulatory site-operon associations |
+| `browser_config` | Browser-instance configuration as `(id, param, value)` rows. Present only on `phagefoundry_ecoliphagesgenomedepot`. |
+
+---
+
+## phagefoundry_strain_modelling
+
+Companion database holding strain-modelling experiment results (genome-set comparisons, protein families, feature-level metrics). 18 tables, schema unrelated to the genome-browser tables above. All `id` columns are surrogate primary keys; foreign keys use `bigint`.
+
+### Genome and organism tables
+
+| Table | Columns | Notes |
+|-------|---------|-------|
+| `strainmodelling_organism` | `id` (int), `name` (string), `full_name` (string), `domain` (string), `description` (string) | Source organisms |
+| `strainmodelling_organism_metadata` | `id` (int), `param` (string), `value` (string), `organism_id` (bigint), `description` (string) | Key-value metadata for organisms |
+| `strainmodelling_genome` | `id` (int), `ref` (string), `organism_id` (bigint), `description` (string), `genome_file` (string), `name` (string) | Genome assemblies |
+| `strainmodelling_genome_set` | `id` (int), `description` (string), `name` (string) | Named genome groupings used in experiments |
+| `strainmodelling_genome_set_genomes` | `id` (int), `genome_set_id` (bigint), `genome_id` (bigint) | Genome-set membership |
+
+### Sequence and feature tables
+
+| Table | Columns | Notes |
+|-------|---------|-------|
+| `strainmodelling_sequence` | `id` (int), `name` (string), `accession` (string), `genome_id` (bigint), `sequence` (string) | Contig/scaffold sequences |
+| `strainmodelling_gene` | `id` (int), `name` (string), `locus_tag` (string), `start` (int), `end` (int), `strand` (int), `protein_seq` (string), `seq_src_id` (bigint), `genome_id` (bigint), `product` (string) | Gene records with protein sequence |
+| `strainmodelling_interval` | `id` (int), `start` (int), `end` (int), `strand` (int), `contig_id` (bigint) | Genomic intervals |
+| `strainmodelling_feature` | `id` (int), `feature_type` (string), `experiment_id` (bigint), `genome_id` (bigint) | Computed features per experiment |
+| `strainmodelling_feature_intervals` | `id` (int), `feature_id` (bigint), `interval_id` (bigint) | Feature ↔ interval junction |
+| `strainmodelling_feature_metric` | `id` (int), `param` (string), `value` (string), `feature_id` (bigint), `description` (string) | Per-feature metrics |
+
+### Experiment tables
+
+| Table | Columns | Notes |
+|-------|---------|-------|
+| `strainmodelling_experiment` | `id` (int), `name` (string), `timestamp` (string), `genomeset1_id` (bigint), `genomeset2_id` (bigint), `description` (string) | Strain-comparison experiments |
+| `strainmodelling_experiment_metadata` | `id` (int), `param` (string), `value` (string), `experiment_id` (bigint) | Experiment-level key-value metadata |
+| `strainmodelling_experiment_metric` | `id` (int), `param` (string), `value` (string), `experiment_id` (bigint), `description` (string) | Experiment-level metrics |
+| `strainmodelling_interaction` | `id` (int), `organism1_id` (bigint), `organism2_id` (bigint), `description` (string), `value` (int), `experiment_id` (bigint) | Pairwise organism interactions per experiment |
+
+### Protein family tables
+
+| Table | Columns | Notes |
+|-------|---------|-------|
+| `strainmodelling_protein_family` | `id` (int), `name` (string), `genomeset_id` (bigint) | Protein families derived per genome-set |
+| `strainmodelling_protein_family_features` | `id` (int), `protein_family_id` (bigint), `feature_id` (bigint) | Family ↔ feature junction |
+| `strainmodelling_protein_family_genes` | `id` (int), `protein_family_id` (bigint), `gene_id` (bigint) | Family ↔ gene junction |
 
 ---
 
 ## Pitfalls
 
-- Schema introspection timed out for most tables in these databases.
-- All four genome browsers share the same table structure but contain different species data.
-- `phagefoundry_strain_modelling` is a separate database with unknown schema.
+- Schema introspection of the genome-browser tables timed out in 2026-02 ingestion logs; column-level types for `browser_*` tables are not in this doc and should be fetched on demand via `DESCRIBE TABLE`.
+- All five genome browsers share the same `browser_*` core schema. `phagefoundry_ecoliphagesgenomedepot` has one extra table (`browser_config`) not present on the others.
+- `phagefoundry_strain_modelling` uses a different schema family (`strainmodelling_*`) and should not be joined to the genome-browser tables; it tracks experiment results, not browseable annotations.
 
 ---
 
 ## Changelog
 
 - **2026-02-11**: Initial schema documentation via REST API introspection.
+- **2026-05-05**: Document `phagefoundry_strain_modelling` (18 tables) and `phagefoundry_ecoliphagesgenomedepot`-only `browser_config`. Add `phagefoundry_ecoliphagesgenomedepot` to the database list (was missing).


### PR DESCRIPTION
## Summary

Three BERDL schema docs were out of date relative to the live Lakehouse. Each gap traces to a data PR that landed new tables without touching the corresponding human-maintained doc. This PR closes those three gaps and flags a follow-up to prevent the next round of drift.

## What changed

| File | Tables added |
|---|---|
| `.claude/skills/berdl/modules/pangenome.md` | 10: `bakta_amr`, `bakta_annotations`, `bakta_db_xrefs`, `bakta_pfam_domains`, `interproscan_domains`, `interproscan_go`, `interproscan_pathways`, `alphaearth_embeddings_all_years`, `phylogenetic_tree`, `phylogenetic_tree_distance_pairs` |
| `docs/schemas/pdb.md` | 5: `pdb_taxonomy`, `pdb_ligands`, `pdb_citations`, `pdb_pfam`, `pdb_sequence_clusters` |
| `docs/schemas/phagefoundry.md` | 19: full `phagefoundry_strain_modelling` schema (18 tables) + `browser_config` (ecoliphages browser only); `phagefoundry_ecoliphagesgenomedepot` added to the database list |

## Audit method

1. Crawled all 14 schema docs (`docs/schemas/*.md`, `.claude/skills/berdl/modules/*.md`) and compared their backtick-quoted table identifiers against the live `/delta/databases/tables/list` output.
2. Cross-checked against `ui/config/berdl_collections_snapshot.json` (2026-04-29) — its table inventory matches the live state today.
3. Pattern exemptions for known table families documented as patterns rather than enumerations: `fitbyexp_*` (per-organism fitness in fitnessbrowser) and `ddt_brick*` (per-asset bricks in enigma).
4. Column types for new schema sections fetched at write time via `DESCRIBE TABLE` SQL through the Lakehouse REST API (read-only).
5. Re-audit after edits: zero gaps for all three target databases.

## Why these tables were missing (Cause A — ingestion-misses)

- **`pangenome.md` (skill module copy)**: The canonical `docs/schemas/pangenome.md` was updated in `f513b3d` (Bakta) and `8177a96` (InterProScan) — but the skill-module variant at `.claude/skills/berdl/modules/pangenome.md` was never kept in sync. Two pangenome docs in two locations drifted apart.
- **`pdb.md`**: Commit `7845f8e` (2026-03-14) ingested 5 extended PDB tables and updated `data/pdb_collection/scripts/` and `pdb_collection.json`, but did not update `docs/schemas/pdb.md`. The commit message even lists all 8 tables — the doc update was simply missed an hour after the previous one (commit `8001d6e`, same day, same author).
- **`phagefoundry.md`**: The 2026-02-11 generalization commit (`8995e2f`, "Generalize repo from pangenome-only to all BERDL collections") noted that `phagefoundry_strain_modelling` "timed out during introspection" and never came back to it. `phagefoundry_ecoliphagesgenomedepot` was missing from the database list entirely.

## Out of scope (curatorial choices)

These remaining gaps look intentional, not bugs, and are not addressed here:

- `docs/schemas/planetmicrobe.md` — admin/system tables (`app_data_type`, `app_result`, `app_run`, `login`, `sampling_event_data`, `spatial_ref_sys`).
- `docs/schemas/fitnessbrowser.md` — annotation-extension tables (`besthitmetacyc`, `besthitswissprot`, `keggcompound/conf/map`, `seed*` extensions, `metacyc*` extensions, `straindataseek`, `swissprotdesc`, `locusxref`, etc.). Doc author chose a curated subset; the `fitbyexp_*` family is documented as a pattern rather than enumerated.
- `docs/schemas/enigma.md` — system/typedef tables (`sys_ddt_typedef`, `sys_process_input`, `sys_process_output`, `sdt_asv`).

If maintainers do want any of these enumerated, that can be a separate PR.

## Follow-up: drift prevention (Cause B)

The audit also surfaced a structural issue worth a separate PR/issue:

There are two parallel sources of truth for BERDL table inventory. `scripts/discover_berdl_collections.py` (added 2026-04-29 in `e76dd4b`) crawls the live API and writes `ui/config/berdl_collections_snapshot.json`. Nothing reconciles that snapshot against the human-curated `docs/schemas/*.md` and `.claude/skills/berdl/modules/*.md`. As long as ingestion lands new tables without touching the doc, the gap will keep growing — exactly what produced the gaps this PR closes.

Two reasonable durable fixes:

1. **Auto-regenerate** the `## Tables` section of each schema doc from the snapshot (deterministic block-replace between markers; preserves narrative content above and below).
2. **Lint** the doc table list against the snapshot in CI; fail the build when they diverge so that data PRs are forced to update the doc.

Recommend opening a tracking issue under `scripts/discover_berdl_collections.py` to choose between (1) and (2) and implement.

## Test plan

- [ ] Re-run the audit script on `origin/docs/berdl-schema-refresh`: gap=0 for `kbase_ke_pangenome`, `kescience_pdb`, all `phagefoundry_*` databases.
- [ ] Verify each new schema section's column types match `DESCRIBE TABLE` output for the corresponding live table.
- [ ] Spot-check that the BERDL skill, when loaded against the updated pangenome module, recognizes one of the previously-undocumented tables (e.g., asks it about `bakta_amr` and gets a coherent answer rather than "table not found").
- [ ] Render the three modified `.md` files in GitHub's preview and confirm Markdown table syntax is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)