### PR TITLE
feat(cli): improve onboarding UX for setup and start

### DIFF
--- a/beril_cli/cli.py
+++ b/beril_cli/cli.py
@@ -29,6 +29,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Agent to launch (default: from config, or claude)",
     )
+    start_parser.add_argument(
+        "--skip-onboard",
+        action="store_true",
+        default=False,
+        help="Skip the automatic /berdl_start onboarding prompt",
+    )
 
     args, remaining = parser.parse_known_args(argv)
 
@@ -49,7 +55,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "start":
         from beril_cli.start import run_start
 
-        return run_start(agent=args.agent, extra_args=remaining)
+        return run_start(agent=args.agent, extra_args=remaining, skip_onboard=args.skip_onboard)
 
     return 0
 

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -54,12 +54,26 @@ def run_setup() -> int:
 
     repo_root = _find_repo_root()
     if not repo_root:
-        print("Not inside the BERIL repository.")
-        print("Clone it first:")
-        print("  git clone https://github.com/kbaseincubator/BERIL-research-observatory.git")
-        print("  cd BERIL-research-observatory")
-        print("  beril setup")
-        return 1
+        print("  BERIL repository not found in current directory tree.")
+        clone_url = "https://github.com/kbaseincubator/BERIL-research-observatory.git"
+        if _confirm(f"  Clone it into {Path.cwd() / 'BERIL-research-observatory'}?"):
+            print(f"  Cloning {clone_url} ...")
+            result = subprocess.run(
+                ["git", "clone", clone_url],
+                check=False,
+            )
+            if result.returncode != 0:
+                print("  ERROR: git clone failed. Check your network and try again.")
+                return 1
+            repo_root = Path.cwd() / "BERIL-research-observatory"
+            os.chdir(repo_root)
+            print(f"  Cloned to: {repo_root}")
+        else:
+            print("  To set up manually:")
+            print(f"    git clone {clone_url}")
+            print("    cd BERIL-research-observatory")
+            print("    beril setup")
+            return 1
 
     print(f"  Found repo at: {repo_root}")
 
@@ -237,11 +251,11 @@ def run_setup() -> int:
     _step(8, "Launch")
 
     if agents_found and _confirm(f"  Launch {chosen} now?"):
-        print(f"\n  Starting {chosen}...\n")
+        print(f"\n  Starting {chosen} with /berdl_start...\n")
         binary = shutil.which(chosen)
         if binary:
             os.chdir(repo_root)
-            os.execvp(binary, [chosen])
+            os.execvp(binary, [chosen, "/berdl_start"])
         else:
             print(f"  Error: '{chosen}' not found on PATH.", file=sys.stderr)
             return 1

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -4,10 +4,32 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
 from beril_cli.config import get_default_agent
+
+
+def _sync_auth_token(env_path: Path) -> None:
+    """Sync KBASE_AUTH_TOKEN from live environment into .env if available."""
+    token = os.environ.get("KBASE_AUTH_TOKEN", "")
+    if not token or not env_path.exists():
+        return
+    lines = env_path.read_text().splitlines()
+    updated = False
+    for i, line in enumerate(lines):
+        if line.strip().startswith("KBASE_AUTH_TOKEN="):
+            if line.strip() != f"KBASE_AUTH_TOKEN={token}":
+                lines[i] = f"KBASE_AUTH_TOKEN={token}"
+                updated = True
+            break
+    else:
+        lines.append(f"KBASE_AUTH_TOKEN={token}")
+        updated = True
+    if updated:
+        env_path.write_text("\n".join(lines) + "\n")
+        print("Refreshed KBASE_AUTH_TOKEN in .env")
 
 
 def _find_repo_root() -> Path | None:
@@ -19,7 +41,11 @@ def _find_repo_root() -> Path | None:
     return None
 
 
-def run_start(agent: str | None = None, extra_args: list[str] | None = None) -> int:
+def run_start(
+    agent: str | None = None,
+    extra_args: list[str] | None = None,
+    skip_onboard: bool = False,
+) -> int:
     """Launch the selected coding agent from the repo root."""
     agent = agent or get_default_agent()
     extra_args = extra_args or []
@@ -35,7 +61,25 @@ def run_start(agent: str | None = None, extra_args: list[str] | None = None) -> 
     if repo_root:
         os.chdir(repo_root)
     else:
-        print("Warning: could not find repo root (PROJECT.md). Launching from current directory.", file=sys.stderr)
+        print("Error: BERIL repository not found. Run 'beril setup' first.", file=sys.stderr)
+        return 1
+
+    # Pull latest changes (repo is under active development)
+    result = subprocess.run(
+        ["git", "pull", "--ff-only"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode == 0 and "Already up to date" not in result.stdout:
+        print(f"Updated: {result.stdout.strip()}")
+    elif result.returncode != 0:
+        print("Warning: git pull failed (you may have local changes). Continuing anyway.", file=sys.stderr)
+
+    # Refresh KBASE_AUTH_TOKEN in .env from live environment (tokens expire)
+    _sync_auth_token(repo_root / ".env")
+
+    # Auto-run the onboarding skill unless skipped or the user already passed a prompt
+    if not skip_onboard and not extra_args:
+        extra_args = ["/berdl_start"]
 
     print(f"Launching {agent}...")
     # Replace the current process with the agent

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -81,6 +81,10 @@ def run_start(
     if not skip_onboard and not extra_args:
         extra_args = ["/berdl_start"]
 
+    # Default to Opus model for Claude
+    if agent == "claude" and "--model" not in extra_args:
+        extra_args = ["--model", "opus", *extra_args]
+
     print(f"Launching {agent}...")
     # Replace the current process with the agent
     os.execvp(binary, [agent, *extra_args])


### PR DESCRIPTION
## Summary
- **beril setup**: offer to git clone the repo when not found, then chdir into it
- **beril setup** step 8: launch agent with `/berdl_start` prompt
- **beril start**: auto-pass `/berdl_start` as initial prompt (`--skip-onboard` to opt out)
- **beril start**: error with "run beril setup first" when repo missing
- **beril start**: refresh `KBASE_AUTH_TOKEN` in `.env` from live environment
- **beril start**: `git pull --ff-only` to pick up latest changes
- **beril start**: default to Opus model for Claude

## Test plan
- [ ] Run `beril start` from outside the repo — should error with setup message
- [ ] Run `beril setup` from outside the repo — should offer to clone
- [ ] Run `beril start` — should pull, refresh token, and launch claude with `--model opus /berdl_start`
- [ ] Run `beril start --skip-onboard` — should launch without `/berdl_start`
- [ ] Run `beril start -- --model sonnet` — should respect user override

🤖 Generated with [Claude Code](https://claude.com/claude-code)