### PR TITLE
Clarifies root cause and solution of tenant access issues

### DIFF
--- a/.claude/skills/berdl-query/SKILL.md
+++ b/.claude/skills/berdl-query/SKILL.md
@@ -93,6 +93,14 @@ The proxy chain (SSH tunnels + pproxy) must be running.
 - `references/query-limits.md`: query tiering and fallback guidance.
 - `references/export-paths.md`: recommended MinIO path conventions and format choices.
 
+## Access Denied Errors
+
+If a query fails with `S3 access denied`, `403 Forbidden`, `Token denied`, `AccessControlException`, or similar, the user simply doesn't have permission to that tenant's data. **Do not surface the raw error text.** Tell the user:
+
+> "You don't have access to `<database>.<table>` (tenant: `<tenant>`). To request access, use the BERDL Tenant Browser."
+
+Never mention S3, token errors, or internal service details. This is a normal situation when exploring databases outside the user's tenant membership.
+
 ## Safety Rules
 
 1. Always apply a limit for inline returns unless explicitly asked otherwise.

--- a/.claude/skills/berdl/SKILL.md
+++ b/.claude/skills/berdl/SKILL.md
@@ -124,15 +124,18 @@ Before executing any query, verify against the checklist in [query-patterns.md](
 
 ## Error Handling
 
-| Error | Meaning | Solution |
+| Error | Meaning | User-facing message |
 |---|---|---|
 | 504 Gateway Timeout | Query took too long | Simplify query, add filters, switch to JupyterHub |
 | 524 Origin Timeout | Server didn't respond | Retry after a few seconds |
 | 503 "cannot schedule new futures" | Spark executor restarting | Wait 30s, retry |
 | Empty response | Query failed silently | Check query syntax, verify table exists |
 | Auth errors | Invalid or expired token | Validate `KBASE_AUTH_TOKEN` in `.env` |
+| S3 access denied / 403 / AccessControlException / Token denied | User lacks permission to this tenant's data | **Never surface raw S3/token error text.** Tell the user: "You don't have access to `<database>.<table>` (tenant: `<tenant>`). To request access, use the BERDL Tenant Browser." |
 
 **Rule of thumb**: Use `spark.sql()` directly in JupyterHub for complex, long-running, or large-result queries.
+
+**Access errors are expected** when a user explores databases outside their tenant membership. Treat them as a permissions prompt, not a system failure — translate to a plain message and point to the Tenant Browser.
 
 ## Adding New Databases
 

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -236,6 +236,30 @@ genome_ids = [str(g) for g in np.random.choice(all_genome_ids, 300, replace=Fals
 spark.createDataFrame([(g,) for g in genome_ids], ['genome_id'])  # OK
 ```
 
+### Access Denied Errors Mean Tenant Permissions, Not a Technical Fault
+
+When a query fails because the current user does not have access to a table, the underlying error from S3 or the Spark catalog will say things like `S3 access denied`, `403 Forbidden`, `Token denied`, or `AccessControlException`. These are internal authorization signals — they are not meaningful to a researcher.
+
+**Do not surface these raw error strings to the user.** Instead, translate to a plain explanation:
+
+> "You don't have access to the table `<table>` in the `<tenant>` tenant. If you need access, request it through the BERDL Tenant Browser."
+
+**How to identify table and tenant from an access error:**
+- The table is whatever was being queried when the error occurred.
+- The tenant is the database prefix (e.g., `kbase_ke_pangenome` → tenant `kbase`; `kescience_mgnify` → tenant `kescience`).
+- If the path is visible in the error (e.g., `s3a://cdm-lake/tenant-sql-warehouse/kbase/...`), the tenant is the path segment after `tenant-sql-warehouse/`.
+
+**What to tell the user:**
+```
+You don't have access to the table `<database>.<table>`.
+This table resides in the `<tenant>` tenant.
+To request access, use the BERDL Tenant Browser.
+```
+
+Never include the words "S3", "token", "403", "access denied", or any internal service URL in the user-facing message. The user only needs to know: what they can't reach, and how to get access.
+
+**Applies to**: Any skill that queries BERDL tables (`/berdl`, `/berdl-query`, `/berdl-discover`). Access errors are expected when exploring databases the user hasn't been granted — this is normal and should be treated as a permissions prompt, not an error condition.
+
 ### REST API Reliability
 
 The REST API at `https://hub.berdl.kbase.us/apis/mcp/` can experience issues:


### PR DESCRIPTION
Users may find while exploring project data for tenants they may not have access to.  Instead of reporting the technical issue, the user is told which tenant they don't have access to and told where to request it.

Updates to skills for berdl and query and noted in pitfalls.