### PR TITLE
feat(claude-code): default to auto permission mode

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "permissions": {
+    "defaultMode": "auto"
+  },
   "statusLine": {
     "type": "command",
     "command": "bash .claude/statusline.sh"


### PR DESCRIPTION
## Summary

- Set `permissions.defaultMode` to `auto` in `.claude/settings.json` so every contributor gets Claude Code's classifier-gated approval flow by default when running `claude` in this repo.
- `auto` mode (Claude Code 2026-W13+) uses a model classifier to approve or deny each tool call. It removes per-tool prompt friction during research work while still blocking scope-escalation and hostile actions — distinct from `bypassPermissions`.
- Researchers who prefer the standard prompt-each-time behavior can opt out per-machine by adding `{"permissions": {"defaultMode": "default"}}` to `.claude/settings.local.json` (already gitignored).

## Test plan

- [ ] Pull this branch and start a fresh session: `claude` (or `beril start`) — confirm Claude indicates auto mode in its UI / Shift-Tab cycle.
- [ ] Verify `Shift-Tab` still lets you switch modes mid-session (auto is just the default).
- [ ] Run a tool-using prompt and confirm it executes without per-call approval prompts (classifier-gated).
- [ ] Add `{"permissions": {"defaultMode": "default"}}` to a local `.claude/settings.local.json`, restart session, and confirm prompts are back.
- [ ] Confirm `beril setup` and `beril start` are unaffected (they don't read or write `.claude/settings.json`).
