### PR TITLE
feat(cli): add Google Vertex option during setup for shared BERIL key

### DIFF
--- a/beril_cli/config.py
+++ b/beril_cli/config.py
@@ -24,7 +24,7 @@ def _toml_escape(val: str) -> str:
 
 
 def save(cfg: dict[str, Any]) -> None:
-    """Write config to disk. Only supports the expected two-section shape."""
+    """Write config to disk. Only supports the expected section shape."""
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     lines: list[str] = []
 
@@ -44,6 +44,16 @@ def save(cfg: dict[str, Any]) -> None:
                 lines.append(f'{key} = "{_toml_escape(val)}"')
         lines.append("")
 
+    if "vertex" in cfg:
+        lines.append("[vertex]")
+        v = cfg["vertex"]
+        lines.append(f'enabled = {"true" if v.get("enabled") else "false"}')
+        for key in ("project_id", "region", "credentials_file"):
+            val = v.get(key, "")
+            if val:
+                lines.append(f'{key} = "{_toml_escape(val)}"')
+        lines.append("")
+
     CONFIG_PATH.write_text("\n".join(lines) + "\n")
 
 
@@ -51,3 +61,9 @@ def get_default_agent() -> str:
     """Return the user's default agent, or 'claude' as fallback."""
     cfg = load()
     return cfg.get("defaults", {}).get("agent", "claude")
+
+
+def get_vertex_config() -> dict[str, Any]:
+    """Return the [vertex] section, or empty dict if not configured."""
+    cfg = load()
+    return cfg.get("vertex", {})

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -239,23 +239,58 @@ def run_setup() -> int:
     else:
         chosen = default_agent or "claude"
 
+    # ── Step 8: BERIL Anthropic key (Google Vertex) ──
+    vertex_cfg: dict = {}
+    _VERTEX_CREDENTIALS = Path("/global_share/BERIL-setup/20260507_hackathon.json")
+    _VERTEX_PROJECT_ID = "beril-hackathon-2026"
+    _VERTEX_REGION = "global"
+
+    if chosen == "claude" and _VERTEX_CREDENTIALS.exists():
+        _step(8, "BERIL Anthropic key (Google Vertex)")
+        print("  A shared BERIL Anthropic API key is available via Google Vertex.")
+        print("  This lets you use Claude without a personal API key or subscription.")
+        if _confirm("  Use the BERIL Anthropic key?"):
+            vertex_cfg = {
+                "enabled": True,
+                "project_id": _VERTEX_PROJECT_ID,
+                "region": _VERTEX_REGION,
+                "credentials_file": str(_VERTEX_CREDENTIALS),
+            }
+            print("  Vertex enabled — Claude will use the shared BERIL key.")
+        else:
+            print("  Skipped — Claude will use your personal API key / subscription.")
+    elif chosen == "claude":
+        _step(8, "BERIL Anthropic key (Google Vertex)")
+        print("  Shared Vertex credentials not found at expected location.")
+        print("  Claude will use your personal API key / subscription.")
+
     # ── Save config ─────────────────────────────────
     cfg: dict = {}
     if user_cfg:
         cfg["user"] = user_cfg
     cfg["defaults"] = {"agent": chosen}
+    if vertex_cfg:
+        cfg["vertex"] = vertex_cfg
     config.save(cfg)
     print(f"\n  Config saved to {config.CONFIG_PATH}")
 
-    # ── Step 8: Launch ──────────────────────────────
-    _step(8, "Launch")
+    # ── Step 9: Launch ──────────────────────────────
+    _step(9, "Launch")
 
     if agents_found and _confirm(f"  Launch {chosen} now?"):
         print(f"\n  Starting {chosen} with /berdl_start...\n")
         binary = shutil.which(chosen)
         if binary:
             os.chdir(repo_root)
-            os.execvp(binary, [chosen, "/berdl_start"])
+            # Inject Vertex env vars if enabled
+            if chosen == "claude" and vertex_cfg.get("enabled"):
+                os.environ["CLAUDE_CODE_USE_VERTEX"] = "1"
+                os.environ["CLOUD_ML_REGION"] = vertex_cfg.get("region", "global")
+                os.environ["ANTHROPIC_VERTEX_PROJECT_ID"] = vertex_cfg.get("project_id", "")
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = vertex_cfg.get("credentials_file", "")
+                os.environ["VERTEX_REGION_CLAUDE_HAIKU_4_5"] = "us-east5"
+                os.environ["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
+            os.execvp(binary, [chosen, "--model", "opus", "/berdl_start"])
         else:
             print(f"  Error: '{chosen}' not found on PATH.", file=sys.stderr)
             return 1

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from beril_cli.config import get_default_agent
+from beril_cli.config import get_default_agent, get_vertex_config
 
 
 def _sync_auth_token(env_path: Path) -> None:
@@ -80,6 +80,26 @@ def run_start(
     # Auto-run the onboarding skill unless skipped or the user already passed a prompt
     if not skip_onboard and not extra_args:
         extra_args = ["/berdl_start"]
+
+    # Configure Google Vertex if enabled (shared BERIL Anthropic key)
+    if agent == "claude":
+        vertex = get_vertex_config()
+        if vertex.get("enabled"):
+            creds = vertex.get("credentials_file", "")
+            if creds and Path(creds).exists():
+                os.environ["CLAUDE_CODE_USE_VERTEX"] = "1"
+                os.environ["CLOUD_ML_REGION"] = vertex.get("region", "global")
+                os.environ["ANTHROPIC_VERTEX_PROJECT_ID"] = vertex.get("project_id", "")
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = creds
+                os.environ["VERTEX_REGION_CLAUDE_HAIKU_4_5"] = "us-east5"
+                os.environ["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
+                print("Using BERIL Anthropic key (Google Vertex)")
+            else:
+                print(
+                    "Warning: Vertex enabled but credentials file not found. "
+                    "Falling back to personal API key.",
+                    file=sys.stderr,
+                )
 
     # Default to Opus model for Claude
     if agent == "claude" and "--model" not in extra_args:

--- a/tests/test_cli_vertex.py
+++ b/tests/test_cli_vertex.py
@@ -1,0 +1,208 @@
+"""Tests for Vertex integration in beril CLI (config, setup, start)."""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from beril_cli import config
+
+
+@pytest.fixture()
+def tmp_config(tmp_path, monkeypatch):
+    """Point config at a temporary directory."""
+    cfg_dir = tmp_path / ".config" / "beril"
+    cfg_dir.mkdir(parents=True)
+    monkeypatch.setattr(config, "CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(config, "CONFIG_PATH", cfg_dir / "config.toml")
+    return cfg_dir / "config.toml"
+
+
+# ── config.py ──────────────────────────────────────────
+
+
+def test_save_and_load_vertex_config(tmp_config):
+    """Round-trip: save vertex config then load it back."""
+    cfg = {
+        "defaults": {"agent": "claude"},
+        "vertex": {
+            "enabled": True,
+            "project_id": "my-project",
+            "region": "global",
+            "credentials_file": "/tmp/creds.json",
+        },
+    }
+    config.save(cfg)
+    loaded = config.load()
+    assert loaded["vertex"]["enabled"] is True
+    assert loaded["vertex"]["project_id"] == "my-project"
+    assert loaded["vertex"]["region"] == "global"
+    assert loaded["vertex"]["credentials_file"] == "/tmp/creds.json"
+
+
+def test_save_without_vertex(tmp_config):
+    """Config without vertex section doesn't create one."""
+    cfg = {"defaults": {"agent": "claude"}}
+    config.save(cfg)
+    loaded = config.load()
+    assert "vertex" not in loaded
+
+
+def test_get_vertex_config_empty(tmp_config):
+    """get_vertex_config returns empty dict when not configured."""
+    config.save({"defaults": {"agent": "claude"}})
+    assert config.get_vertex_config() == {}
+
+
+def test_get_vertex_config_returns_section(tmp_config):
+    """get_vertex_config returns the vertex section."""
+    cfg = {
+        "defaults": {"agent": "claude"},
+        "vertex": {
+            "enabled": True,
+            "project_id": "test-proj",
+            "region": "global",
+            "credentials_file": "/tmp/c.json",
+        },
+    }
+    config.save(cfg)
+    v = config.get_vertex_config()
+    assert v["enabled"] is True
+    assert v["project_id"] == "test-proj"
+
+
+def test_vertex_disabled_saved_correctly(tmp_config):
+    """enabled=false is persisted and loaded correctly."""
+    cfg = {
+        "defaults": {"agent": "claude"},
+        "vertex": {"enabled": False},
+    }
+    config.save(cfg)
+    loaded = config.load()
+    assert loaded["vertex"]["enabled"] is False
+
+
+# ── start.py env injection ─────────────────────────────
+
+
+def test_start_injects_vertex_env(tmp_path, tmp_config, monkeypatch):
+    """run_start sets Vertex env vars when enabled and creds exist."""
+    from beril_cli import start
+
+    # Create fake credentials file
+    creds_file = tmp_path / "creds.json"
+    creds_file.write_text("{}")
+
+    # Save config with vertex enabled
+    config.save({
+        "defaults": {"agent": "claude"},
+        "vertex": {
+            "enabled": True,
+            "project_id": "test-proj",
+            "region": "global",
+            "credentials_file": str(creds_file),
+        },
+    })
+
+    # Create fake repo root with PROJECT.md
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "PROJECT.md").write_text("marker")
+    (repo / ".env").write_text("KBASE_AUTH_TOKEN=fake\n")
+    monkeypatch.chdir(repo)
+
+    # Capture the execvp call instead of actually exec-ing
+    captured = {}
+
+    def fake_execvp(binary, args):
+        captured["binary"] = binary
+        captured["args"] = args
+        captured["env"] = {
+            k: os.environ[k]
+            for k in (
+                "CLAUDE_CODE_USE_VERTEX",
+                "CLOUD_ML_REGION",
+                "ANTHROPIC_VERTEX_PROJECT_ID",
+                "GOOGLE_APPLICATION_CREDENTIALS",
+            )
+            if k in os.environ
+        }
+
+    monkeypatch.setattr(os, "execvp", fake_execvp)
+    monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}")
+
+    start.run_start(agent="claude", extra_args=["/berdl_start"])
+
+    assert captured["env"]["CLAUDE_CODE_USE_VERTEX"] == "1"
+    assert captured["env"]["CLOUD_ML_REGION"] == "global"
+    assert captured["env"]["ANTHROPIC_VERTEX_PROJECT_ID"] == "test-proj"
+    assert captured["env"]["GOOGLE_APPLICATION_CREDENTIALS"] == str(creds_file)
+
+
+def test_start_skips_vertex_when_disabled(tmp_path, tmp_config, monkeypatch):
+    """run_start does NOT set Vertex env vars when vertex is not configured."""
+    from beril_cli import start
+
+    config.save({"defaults": {"agent": "claude"}})
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "PROJECT.md").write_text("marker")
+    (repo / ".env").write_text("KBASE_AUTH_TOKEN=fake\n")
+    monkeypatch.chdir(repo)
+
+    # Clean env
+    for key in ("CLAUDE_CODE_USE_VERTEX", "ANTHROPIC_VERTEX_PROJECT_ID"):
+        monkeypatch.delenv(key, raising=False)
+
+    captured = {}
+
+    def fake_execvp(binary, args):
+        captured["env_vertex"] = os.environ.get("CLAUDE_CODE_USE_VERTEX")
+
+    monkeypatch.setattr(os, "execvp", fake_execvp)
+    monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}")
+
+    start.run_start(agent="claude", extra_args=["/berdl_start"])
+
+    assert captured["env_vertex"] is None
+
+
+def test_start_warns_missing_creds(tmp_path, tmp_config, monkeypatch, capsys):
+    """run_start warns when vertex enabled but creds file is missing."""
+    from beril_cli import start
+
+    config.save({
+        "defaults": {"agent": "claude"},
+        "vertex": {
+            "enabled": True,
+            "project_id": "test-proj",
+            "region": "global",
+            "credentials_file": "/nonexistent/creds.json",
+        },
+    })
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "PROJECT.md").write_text("marker")
+    (repo / ".env").write_text("KBASE_AUTH_TOKEN=fake\n")
+    monkeypatch.chdir(repo)
+
+    captured = {}
+
+    def fake_execvp(binary, args):
+        captured["called"] = True
+
+    monkeypatch.setattr(os, "execvp", fake_execvp)
+    monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.delenv("CLAUDE_CODE_USE_VERTEX", raising=False)
+
+    start.run_start(agent="claude", extra_args=["/berdl_start"])
+
+    stderr = capsys.readouterr().err
+    assert "credentials file not found" in stderr
+    assert os.environ.get("CLAUDE_CODE_USE_VERTEX") is None


### PR DESCRIPTION
Hackathon participants can now opt into the shared BERIL Anthropic key (Google Vertex) during `beril setup`. The preference is saved to ~/.config/beril/config.toml and applied automatically on `beril start`.