### PR TITLE
fix(skill): load author identity from ~/.config/beril/config.toml in …

### DIFF
--- a/.claude/skills/berdl_start/SKILL.md
+++ b/.claude/skills/berdl_start/SKILL.md
@@ -159,7 +159,7 @@ When the user wants to start a new research project, the agent drives the entire
 
 **Additional setup (Phase 1.5 should have already checked KBASE_AUTH_TOKEN and proxy):**
 6. Check `gh auth status` — needed for creating branches, PRs, and pushing code. If not authenticated, prompt the user to run `gh auth login`
-7. Note the user's ORCID and affiliation for the Authors section — ask once, remember for future projects
+7. Load author identity for the Authors section. The `beril setup` CLI writes `name`, `affiliation`, and `orcid` to `~/.config/beril/config.toml` under `[user]`. **Read that file first** — if it exists and `[user]` has values, use them and do not prompt. Only ask the user for any missing field (or for all three if the file doesn't exist), then suggest they run `beril setup` to persist it for future sessions. Once collected (from file or prompt), reuse for the rest of this session and across future projects.
 
 **Then engage with the user:**
 9. Chat with the user about their research interest


### PR DESCRIPTION
…berdl_start

The beril setup CLI prompts for name, affiliation, and ORCID and writes them to ~/.config/beril/config.toml under [user], but berdl_start never read that file — Path 1 still prompted on every new project. Update step 7 to read the config first and only fall back to prompting for missing fields, with a nudge to run `beril setup` to persist them.