### PR TITLE
remove outdated tests against removed code paths

### DIFF
--- a/ui/tests/test_dataloader.py
+++ b/ui/tests/test_dataloader.py
@@ -859,34 +859,6 @@ class TestParseAtlas:
 
 
 # ---------------------------------------------------------------------------
-# RepositoryParser._parse_row_counts
-# ---------------------------------------------------------------------------
-
-
-class TestParseRowCounts:
-    def setup_method(self):
-        self.parser = RepositoryParser.__new__(RepositoryParser)
-
-    def test_parses_row_counts(self):
-        content = (
-            "## Table Summary\n\n"
-            "| Table | Row Count | Description |\n"
-            "|-------|-----------|-------------|\n"
-            "| genome | 293,059 | Genome rows |\n"
-            "| feature | 1,500,000 | Gene features |\n"
-            "\n---\n"
-        )
-        result = self.parser._parse_row_counts(content)
-        assert result["genome"] == 293059
-        assert result["feature"] == 1500000
-
-    def test_no_summary_section(self):
-        content = "## Overview\n\nNo table summary here.\n"
-        result = self.parser._parse_row_counts(content)
-        assert result == {}
-
-
-# ---------------------------------------------------------------------------
 # RepositoryParser._cluster_research_areas
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Now that the dataloader just pulls schemas directly from BERDL, we don't need the schema paths.

Though we might need it for non-KBase projects if we port this over to them. Just noting here.