### PR TITLE
feat(beril): print JupyterLab file-browser hint on JupyterHub

### DIFF
--- a/beril_cli/detect.py
+++ b/beril_cli/detect.py
@@ -11,6 +11,7 @@ import os
 import re
 import urllib.error
 import urllib.request
+from pathlib import Path
 
 ORCID_PUB_API = "https://pub.orcid.org/v3.0"
 KBASE_ME_PATH = "/api/V2/me"
@@ -122,3 +123,39 @@ def detect_user_identity() -> dict[str, str]:
     name = detect_name_from_orcid(orcid) or detect_name_from_kbase()
     affiliation = detect_affiliation_from_orcid(orcid)
     return {"name": name, "affiliation": affiliation, "orcid": orcid}
+
+
+def is_on_jupyterhub() -> bool:
+    """True when running inside a JupyterHub-spawned single-user session."""
+    return bool(os.environ.get("JUPYTERHUB_USER"))
+
+
+def print_jupyterhub_path_hint(repo_root) -> None:
+    """If on JupyterHub, print a path/navigation hint so users know where to
+    look in the JupyterLab file browser. No-op off-hub.
+
+    Users on JupyterHub commonly miss that they need to navigate the left-side
+    file browser to actually see their work. The clone path is in their home
+    directory, but the file browser opens at home by default and shows many
+    sibling files; the BERIL repo isn't visually obvious. A path-with-arrows
+    hint costs nothing and saves a real support burden.
+    """
+    if not is_on_jupyterhub():
+        return
+    repo_root = Path(repo_root)
+    home = Path.home()
+    try:
+        rel = repo_root.relative_to(home)
+        display_path = f"~/{rel}"
+        breadcrumb_parts = list(rel.parts)
+    except ValueError:
+        display_path = str(repo_root)
+        breadcrumb_parts = list(repo_root.parts)
+    breadcrumb = "  →  ".join([*breadcrumb_parts, "projects", "<your_project>"])
+    print()
+    print("  You're on JupyterHub. Your work lives at:")
+    print(f"    {display_path}")
+    print()
+    print("  In the JupyterLab file browser (left sidebar), navigate to:")
+    print(f"    {breadcrumb}")
+    print()

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 from beril_cli import config
-from beril_cli.detect import detect_user_identity
+from beril_cli.detect import detect_user_identity, print_jupyterhub_path_hint
 
 
 def _find_repo_root() -> Path | None:
@@ -287,6 +287,7 @@ def run_setup() -> int:
 
     if agents_found and _confirm(f"  Launch {chosen} now?"):
         print(f"\n  Starting {chosen} with /berdl_start...\n")
+        print_jupyterhub_path_hint(repo_root)
         binary = shutil.which(chosen)
         if binary:
             os.chdir(repo_root)
@@ -304,6 +305,7 @@ def run_setup() -> int:
             return 1
 
     print("\n  Setup complete! Run 'beril start' when you're ready.\n")
+    print_jupyterhub_path_hint(repo_root)
     return 0
 
 

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from beril_cli.config import get_default_agent, get_vertex_config
+from beril_cli.detect import print_jupyterhub_path_hint
 
 
 def _sync_auth_token(env_path: Path) -> None:
@@ -106,6 +107,7 @@ def run_start(
         extra_args = ["--model", "opus", *extra_args]
 
     print(f"Launching {agent}...")
+    print_jupyterhub_path_hint(repo_root)
     # Replace the current process with the agent
     os.execvp(binary, [agent, *extra_args])
 


### PR DESCRIPTION
## Summary

Users running \`beril setup\` / \`beril start\` from a JupyterHub session frequently don't realize they need to navigate the JupyterLab left-sidebar file browser to find their work — the browser opens at \`~\` by default and the BERIL repo isn't visually obvious among siblings, so they end up not knowing where their projects live. Add a tiny JupyterHub-aware hint printer.

## Behavior

When \`JUPYTERHUB_USER\` env var is set, both commands print:

\`\`\`
  You're on JupyterHub. Your work lives at:
    ~/BERIL-research-observatory

  In the JupyterLab file browser (left sidebar), navigate to:
    BERIL-research-observatory  →  projects  →  <your_project>
\`\`\`

The arrow-breadcrumb form mirrors how the JupyterLab file browser renders the path, making the mapping from output to UI obvious.

Off JupyterHub the helper is a silent no-op — terminal/local sessions get no extra noise.

## Implementation

- \`beril_cli/detect.py\`: \`is_on_jupyterhub()\` and \`print_jupyterhub_path_hint(repo_root)\` helpers, alongside the existing environment-detection helpers.
- \`beril_cli/setup_cmd.py\`: prints at completion AND just before the \"Launch agent now?\" auto-launch.
- \`beril_cli/start.py\`: prints just before the \`os.execvp\` agent launch.

## Why not auto-navigate the file browser?

Considered but rejected:

- **\`/lab/tree/path\` URL link** — works for selecting the directory, but clicking either spawns a new tab (loses terminal context) or full-reloads the JupyterLab workspace in-tab (also loses terminal). Tested empirically; UX worse than no link.
- **Notebook one-liner with \`IPython.display.Javascript\`** — only works if the user has a notebook open, and pasting it is more friction than just clicking the file tree.
- **Tiny JupyterLab extension watching a sidecar file** — actually right long-term, but real engineering (TS + npm + per-user install) for marginal gain over a clear path.

The path-with-arrows hint costs ~40 LOC and probably solves 80% of the pain.

## Test plan

- [ ] Off-hub: \`beril setup\` and \`beril start\` produce no extra output (verified via Python repl: \`is_on_jupyterhub()\` returns \`False\`, helper is silent).
- [ ] On-hub: with \`JUPYTERHUB_USER=psdehal\`, helper prints the breadcrumb hint with the correct \`~/BERIL-research-observatory\` path.
- [ ] On-hub setup auto-launch: hint appears just before the agent takes over the terminal.
- [ ] On-hub setup decline: hint appears alongside the \"Setup complete!\" message.
- [ ] On-hub \`beril start\`: hint appears just before \`os.execvp\` (visible while the agent loads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)