### PR TITLE
fix(cli): sync to latest release ref

### DIFF
--- a/beril_cli/repo_sync.py
+++ b/beril_cli/repo_sync.py
@@ -1,0 +1,107 @@
+"""Git synchronization helpers for the BERIL repository."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+GITHUB_API = "https://api.github.com"
+
+
+class GitSyncError(RuntimeError):
+    """Raised when the repository cannot be synchronized."""
+
+
+def _run_git(repo_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a git command in the repository and raise on failure."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise GitSyncError(f"git {' '.join(args)} failed: {detail}")
+    return result
+
+
+def _github_repo_from_remote(repo_root: Path, remote: str) -> tuple[str, str]:
+    """Return GitHub owner/repo from a git remote URL."""
+    result = _run_git(repo_root, ["remote", "get-url", remote])
+    remote_url = result.stdout.strip()
+    match = re.match(
+        r"(?:git@github\.com:|ssh://git@github\.com/|https://github\.com/)([^/]+)/(.+?)(?:\.git)?$",
+        remote_url,
+    )
+    if not match:
+        raise GitSyncError(f"{remote} is not a supported GitHub remote: {remote_url}")
+    return match.group(1), match.group(2)
+
+
+def _latest_release_tag(owner: str, repo: str) -> str | None:
+    """Return the latest published GitHub release tag, or None if no release exists."""
+    request = urllib.request.Request(
+        f"{GITHUB_API}/repos/{owner}/{repo}/releases/latest",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "beril-cli",
+        },
+    )
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise GitSyncError(f"GitHub release lookup failed: HTTP {exc.code}") from exc
+    except (OSError, TimeoutError, json.JSONDecodeError) as exc:
+        raise GitSyncError(f"GitHub release lookup failed: {exc}") from exc
+
+    tag_name = (payload.get("tag_name") or "").strip()
+    if not tag_name:
+        raise GitSyncError("GitHub latest release response did not include tag_name")
+    return tag_name
+
+
+def _checkout_remote_head_commit(repo_root: Path, remote: str) -> str:
+    """Fetch and check out the remote HEAD commit."""
+    _run_git(repo_root, ["fetch", remote])
+    commit = _run_git(repo_root, ["rev-parse", "--verify", f"{remote}/HEAD"]).stdout.strip()
+    _run_git(repo_root, ["checkout", "--detach", commit])
+    return f"Checked out remote HEAD commit {commit[:12]}"
+
+
+def sync_repo_to_latest_ref(repo_root: Path, remote: str = "origin") -> str:
+    """Check out the latest GitHub release tag, or remote HEAD if no release exists.
+
+    Parameters
+    ----------
+    repo_root
+        Path to the BERIL git repository.
+    remote
+        Git remote to fetch refs from.
+
+    Returns
+    -------
+    str
+        Human-readable description of the checked out ref.
+    """
+    owner, repo = _github_repo_from_remote(repo_root, remote)
+    release_tag = _latest_release_tag(owner, repo)
+    if not release_tag:
+        return _checkout_remote_head_commit(repo_root, remote)
+
+    _run_git(repo_root, ["fetch", "--force", remote, f"refs/tags/{release_tag}:refs/tags/{release_tag}"])
+    _run_git(repo_root, ["checkout", "--detach", release_tag])
+    return f"Checked out release {release_tag}"

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from beril_cli import config
 from beril_cli.detect import detect_user_identity, print_jupyterhub_path_hint
+from beril_cli.repo_sync import GitSyncError, sync_repo_to_latest_ref
 
 
 def _find_repo_root() -> Path | None:
@@ -77,6 +78,11 @@ def run_setup() -> int:
             return 1
 
     print(f"  Found repo at: {repo_root}")
+    try:
+        sync_message = sync_repo_to_latest_ref(repo_root)
+        print(f"  {sync_message}")
+    except GitSyncError as exc:
+        print(f"  Warning: {exc}. Continuing with the current checkout.")
 
     # ── Step 2: .env creation + credential sync ─────
     _step(2, "Environment file (.env)")

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
 from beril_cli.config import get_default_agent, get_vertex_config
 from beril_cli.detect import print_jupyterhub_path_hint
+from beril_cli.repo_sync import GitSyncError, sync_repo_to_latest_ref
 
 
 def _sync_auth_token(env_path: Path) -> None:
@@ -65,15 +65,12 @@ def run_start(
         print("Error: BERIL repository not found. Run 'beril setup' first.", file=sys.stderr)
         return 1
 
-    # Pull latest changes (repo is under active development)
-    result = subprocess.run(
-        ["git", "pull", "--ff-only"],
-        capture_output=True, text=True, check=False,
-    )
-    if result.returncode == 0 and "Already up to date" not in result.stdout:
-        print(f"Updated: {result.stdout.strip()}")
-    elif result.returncode != 0:
-        print("Warning: git pull failed (you may have local changes). Continuing anyway.", file=sys.stderr)
+    # Use the latest published GitHub release when available, not main's tip.
+    try:
+        sync_message = sync_repo_to_latest_ref(repo_root)
+        print(f"Updated: {sync_message}")
+    except GitSyncError as exc:
+        print(f"Warning: {exc}. Continuing anyway.", file=sys.stderr)
 
     # Refresh KBASE_AUTH_TOKEN in .env from live environment (tokens expire)
     _sync_auth_token(repo_root / ".env")


### PR DESCRIPTION
## Summary
- add a shared git sync helper that fetches tags and checks out the latest version tag
- fall back to the remote HEAD commit when no tags are available
- use the helper from both `beril setup` and `beril start` instead of pulling the current branch tip

## Verification
- `uv run --no-project --with ruff ruff check beril_cli/setup_cmd.py beril_cli/start.py beril_cli/repo_sync.py`
- `uv run --no-project python -m py_compile beril_cli/setup_cmd.py beril_cli/start.py beril_cli/repo_sync.py`
- `PYTHONPATH=. uv run --no-project --with pytest pytest tests/test_cli_vertex.py tests/test_cli_user.py tests/test_cli_detect.py`