### PR TITLE
`beril start` should use the latest release

### DIFF
--- a/beril_cli/cli.py
+++ b/beril_cli/cli.py
@@ -35,6 +35,12 @@ def main(argv: list[str] | None = None) -> int:
         default=False,
         help="Skip the automatic /berdl_start onboarding prompt",
     )
+    start_parser.add_argument(
+        "--version",
+        default=None,
+        metavar="VERSION",
+        help="Pin to a specific release tag (e.g. v0.3.4.5). Defaults to the latest tag.",
+    )
 
     # user
     user_parser = sub.add_parser(
@@ -67,7 +73,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "start":
         from beril_cli.start import run_start
 
-        return run_start(agent=args.agent, extra_args=remaining, skip_onboard=args.skip_onboard)
+        return run_start(
+            agent=args.agent,
+            extra_args=remaining,
+            skip_onboard=args.skip_onboard,
+            version=args.version,
+        )
 
     if args.command == "user":
         from beril_cli.user_cmd import run_user

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import os
+import re
 import shutil
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 from beril_cli.config import get_default_agent, get_vertex_config
+
+GITHUB_API_TIMEOUT_SECONDS = 10
 
 
 def _sync_auth_token(env_path: Path) -> None:
@@ -41,10 +47,112 @@ def _find_repo_root() -> Path | None:
     return None
 
 
+def _github_repo_slug(repo_root: Path) -> str | None:
+    """Return 'owner/repo' parsed from origin's URL, or None if it isn't a GitHub remote."""
+    result = subprocess.run(
+        ["git", "config", "--get", "remote.origin.url"],
+        cwd=repo_root, capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    # Handles https://github.com/owner/repo(.git) and git@github.com:owner/repo(.git)
+    match = re.search(r"github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?/?$", url)
+    if not match:
+        return None
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def _latest_release_tag(repo_root: Path) -> str | None:
+    """Return the tag of the latest published GitHub release, or None.
+
+    Uses the public Releases API, which excludes drafts and prereleases. Raw git tags
+    that were never published as a release (e.g. internal version bumps) are ignored.
+    """
+    slug = _github_repo_slug(repo_root)
+    if not slug:
+        return None
+    url = f"https://api.github.com/repos/{slug}/releases/latest"
+    req = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+    try:
+        with urllib.request.urlopen(req, timeout=GITHUB_API_TIMEOUT_SECONDS) as resp:
+            payload = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        print(f"Warning: could not query GitHub releases: {exc}", file=sys.stderr)
+        return None
+    tag = payload.get("tag_name")
+    return tag if isinstance(tag, str) and tag else None
+
+
+def _checkout_release(repo_root: Path, requested_version: str | None) -> int:
+    """Fetch tags and check out the requested release (or the latest if unspecified).
+
+    Returns 0 on success, non-zero on failure.
+    """
+    fetch = subprocess.run(
+        ["git", "fetch", "--tags", "--quiet"],
+        cwd=repo_root, capture_output=True, text=True, check=False,
+    )
+    if fetch.returncode != 0:
+        print(
+            f"Warning: git fetch --tags failed: {fetch.stderr.strip()}",
+            file=sys.stderr,
+        )
+
+    if requested_version:
+        tag = requested_version if requested_version.startswith("v") else f"v{requested_version}"
+        verify = subprocess.run(
+            ["git", "rev-parse", "--verify", f"refs/tags/{tag}"],
+            cwd=repo_root, capture_output=True, text=True, check=False,
+        )
+        if verify.returncode != 0:
+            print(f"Error: release '{tag}' not found.", file=sys.stderr)
+            return 1
+    else:
+        tag = _latest_release_tag(repo_root)
+        if not tag:
+            print("Error: no release tags found in repository.", file=sys.stderr)
+            return 1
+
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root, capture_output=True, text=True, check=False,
+    )
+    target = subprocess.run(
+        ["git", "rev-parse", f"{tag}^{{commit}}"],
+        cwd=repo_root, capture_output=True, text=True, check=False,
+    )
+    if (
+        head.returncode == 0
+        and target.returncode == 0
+        and head.stdout.strip() == target.stdout.strip()
+    ):
+        print(f"Already on release {tag}")
+        return 0
+
+    checkout = subprocess.run(
+        ["git", "checkout", "--quiet", tag],
+        cwd=repo_root, capture_output=True, text=True, check=False,
+    )
+    if checkout.returncode != 0:
+        print(
+            f"Error: failed to check out release {tag}: {checkout.stderr.strip()}",
+            file=sys.stderr,
+        )
+        print(
+            "You may have local changes. Commit or stash them and try again.",
+            file=sys.stderr,
+        )
+        return checkout.returncode
+    print(f"Checked out release {tag}")
+    return 0
+
+
 def run_start(
     agent: str | None = None,
     extra_args: list[str] | None = None,
     skip_onboard: bool = False,
+    version: str | None = None,
 ) -> int:
     """Launch the selected coding agent from the repo root."""
     agent = agent or get_default_agent()
@@ -64,15 +172,10 @@ def run_start(
         print("Error: BERIL repository not found. Run 'beril setup' first.", file=sys.stderr)
         return 1
 
-    # Pull latest changes (repo is under active development)
-    result = subprocess.run(
-        ["git", "pull", "--ff-only"],
-        capture_output=True, text=True, check=False,
-    )
-    if result.returncode == 0 and "Already up to date" not in result.stdout:
-        print(f"Updated: {result.stdout.strip()}")
-    elif result.returncode != 0:
-        print("Warning: git pull failed (you may have local changes). Continuing anyway.", file=sys.stderr)
+    # Check out the requested release (or the latest published tag by default).
+    rc = _checkout_release(repo_root, version)
+    if rc != 0:
+        return rc
 
     # Refresh KBASE_AUTH_TOKEN in .env from live environment (tokens expire)
     _sync_auth_token(repo_root / ".env")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = []
 [project.scripts]
 beril = "beril_cli.cli:main"
 
+[dependency-groups]
+test = ["pytest>=8"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/scripts/test_berdl_inventory.py
+++ b/tests/scripts/test_berdl_inventory.py
@@ -166,7 +166,7 @@ def test_format_inventory_hides_globalusers_databases():
 
 
 def test_format_inventory_lists_other_tenants_without_access():
-    """Tenants the user has no accessible databases in show up in a brief footer."""
+    """Non-member tenants the user has no access to show up in a brief footer."""
     from scripts.berdl_inventory import format_inventory
     structure = {"kbase_genomes": ["t1"]}
     tenants = [
@@ -175,7 +175,7 @@ def test_format_inventory_lists_other_tenants_without_access():
         _tenant("planetmicrobe", prefix="planetmicrobe_"),
     ]
     out = format_inventory(structure, tenants=tenants, emoji=False)
-    assert "Other tenants in BERDL (no access): nmdc, planetmicrobe" in out
+    assert "Other tenants in BERDL (no membership): nmdc, planetmicrobe" in out
 
 
 def test_format_inventory_other_tenants_excludes_hidden():
@@ -189,8 +189,25 @@ def test_format_inventory_other_tenants_excludes_hidden():
     ]
     out = format_inventory(structure, tenants=tenants, emoji=False)
     # nmdc is in the footer; globalusers is suppressed entirely.
-    assert "Other tenants in BERDL (no access): nmdc" in out
+    assert "Other tenants in BERDL (no membership): nmdc" in out
     assert "globalusers" not in out
+
+
+def test_format_inventory_separates_member_no_dbs_from_non_member():
+    """Member-with-no-databases tenants get their own footer line, separate from non-members."""
+    from scripts.berdl_inventory import format_inventory
+    structure = {"kbase_genomes": ["t1"]}
+    tenants = [
+        _tenant("kbase", prefix="kbase_"),
+        _tenant("microbialdiscoveryforge", prefix="microbialdiscoveryforge_", is_member=True),
+        _tenant("nmdc", prefix="nmdc_"),
+    ]
+    out = format_inventory(structure, tenants=tenants, emoji=False)
+    assert "Tenants you can access (no databases yet): microbialdiscoveryforge" in out
+    assert "Other tenants in BERDL (no membership): nmdc" in out
+    # The member-but-no-DBs tenant must NOT be lumped into the non-membership line.
+    assert "no membership): microbialdiscoveryforge" not in out
+    assert "no membership): nmdc, microbialdiscoveryforge" not in out
 
 
 def test_format_inventory_no_other_tenants_footer_when_only_user_tenants():

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -1,0 +1,250 @@
+"""Tests for release-pinning logic in `beril_cli.start`."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from io import BytesIO
+from pathlib import Path
+from typing import Callable
+from urllib.error import URLError
+
+import pytest
+
+from beril_cli import start
+
+
+# ── helpers ───────────────────────────────────────────────
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _patch_run(monkeypatch, handler: Callable[[list[str]], subprocess.CompletedProcess]) -> list[list[str]]:
+    """Replace start.subprocess.run with `handler(argv)`. Records every argv received."""
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **_kwargs):
+        calls.append(list(argv))
+        return handler(argv)
+
+    monkeypatch.setattr(start.subprocess, "run", fake_run)
+    return calls
+
+
+def _patch_urlopen(monkeypatch, payload=None, *, exc: BaseException | None = None) -> None:
+    """Patch urllib.request.urlopen used inside start. Either returns `payload` JSON or raises `exc`."""
+
+    class _Resp:
+        def __init__(self, body: bytes):
+            self._body = BytesIO(body)
+
+        def __enter__(self):
+            return self._body
+
+        def __exit__(self, *_a):
+            return False
+
+    def fake_urlopen(_req, timeout=None):
+        if exc is not None:
+            raise exc
+        return _Resp(json.dumps(payload).encode())
+
+    monkeypatch.setattr(start.urllib.request, "urlopen", fake_urlopen)
+
+
+# ── _github_repo_slug ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://github.com/kbaseincubator/BERIL-research-observatory.git\n", "kbaseincubator/BERIL-research-observatory"),
+        ("https://github.com/kbaseincubator/BERIL-research-observatory\n", "kbaseincubator/BERIL-research-observatory"),
+        ("git@github.com:kbaseincubator/BERIL-research-observatory.git\n", "kbaseincubator/BERIL-research-observatory"),
+        ("git@github.com:owner/repo\n", "owner/repo"),
+    ],
+)
+def test_repo_slug_parses_github_urls(monkeypatch, tmp_path, url, expected):
+    _patch_run(monkeypatch, lambda argv: _completed(stdout=url))
+    assert start._github_repo_slug(tmp_path) == expected
+
+
+def test_repo_slug_rejects_non_github_remote(monkeypatch, tmp_path):
+    _patch_run(monkeypatch, lambda argv: _completed(stdout="https://gitlab.com/owner/repo.git\n"))
+    assert start._github_repo_slug(tmp_path) is None
+
+
+def test_repo_slug_returns_none_when_git_fails(monkeypatch, tmp_path):
+    _patch_run(monkeypatch, lambda argv: _completed(returncode=1, stderr="no remote"))
+    assert start._github_repo_slug(tmp_path) is None
+
+
+# ── _latest_release_tag ───────────────────────────────────
+
+
+def test_latest_release_tag_reads_tag_name(monkeypatch, tmp_path):
+    _patch_run(monkeypatch, lambda argv: _completed(stdout="https://github.com/owner/repo.git\n"))
+    _patch_urlopen(monkeypatch, payload={"tag_name": "v0.0.1", "name": "First release"})
+    assert start._latest_release_tag(tmp_path) == "v0.0.1"
+
+
+def test_latest_release_tag_returns_none_on_http_failure(monkeypatch, tmp_path, capsys):
+    _patch_run(monkeypatch, lambda argv: _completed(stdout="https://github.com/owner/repo.git\n"))
+    _patch_urlopen(monkeypatch, exc=URLError("network down"))
+    assert start._latest_release_tag(tmp_path) is None
+    assert "could not query GitHub releases" in capsys.readouterr().err
+
+
+def test_latest_release_tag_skips_when_slug_unparseable(monkeypatch, tmp_path):
+    _patch_run(monkeypatch, lambda argv: _completed(stdout="https://gitlab.com/owner/repo.git\n"))
+    # If slug is None, we should never reach urlopen. Make urlopen explode if it's called.
+    def _boom(*_a, **_kw):
+        raise AssertionError("urlopen should not be called when slug is unparseable")
+
+    monkeypatch.setattr(start.urllib.request, "urlopen", _boom)
+    assert start._latest_release_tag(tmp_path) is None
+
+
+def test_latest_release_tag_returns_none_when_tag_name_missing(monkeypatch, tmp_path):
+    _patch_run(monkeypatch, lambda argv: _completed(stdout="https://github.com/owner/repo.git\n"))
+    _patch_urlopen(monkeypatch, payload={"name": "no tag here"})
+    assert start._latest_release_tag(tmp_path) is None
+
+
+# ── _checkout_release ─────────────────────────────────────
+
+
+def _make_git_dispatcher(
+    *,
+    tags: dict[str, str] | None = None,
+    head_sha: str = "HEADSHA",
+    checkout_rc: int = 0,
+    fetch_rc: int = 0,
+) -> Callable[[list[str]], subprocess.CompletedProcess]:
+    """Build a handler that simulates a git repo with known tags.
+
+    `tags` maps tag name → commit SHA. Anything not in `tags` fails `rev-parse --verify`.
+    """
+    tags = tags or {}
+
+    def handler(argv: list[str]) -> subprocess.CompletedProcess:
+        # git fetch --tags --quiet
+        if argv[:2] == ["git", "fetch"]:
+            return _completed(returncode=fetch_rc, stderr="" if fetch_rc == 0 else "fetch failed")
+        # git rev-parse --verify refs/tags/<tag>
+        if argv[:3] == ["git", "rev-parse", "--verify"]:
+            ref = argv[3]  # "refs/tags/v0.0.1"
+            tag = ref.removeprefix("refs/tags/")
+            if tag in tags:
+                return _completed(stdout=tags[tag] + "\n")
+            return _completed(returncode=128, stderr=f"unknown ref {ref}")
+        # git rev-parse HEAD
+        if argv[:3] == ["git", "rev-parse", "HEAD"]:
+            return _completed(stdout=head_sha + "\n")
+        # git rev-parse <tag>^{commit}
+        if argv[:2] == ["git", "rev-parse"] and argv[2].endswith("^{commit}"):
+            tag = argv[2].removesuffix("^{commit}")
+            if tag in tags:
+                return _completed(stdout=tags[tag] + "\n")
+            return _completed(returncode=128, stderr="unknown")
+        # git checkout --quiet <tag>
+        if argv[:2] == ["git", "checkout"]:
+            return _completed(returncode=checkout_rc, stderr="" if checkout_rc == 0 else "dirty tree")
+        # Anything else (e.g. git config --get remote.origin.url) — return empty success.
+        return _completed()
+
+    return handler
+
+
+def test_checkout_release_explicit_version(monkeypatch, tmp_path, capsys):
+    calls = _patch_run(
+        monkeypatch,
+        _make_git_dispatcher(tags={"v0.0.1": "ABC"}, head_sha="OLD"),
+    )
+    rc = start._checkout_release(tmp_path, "v0.0.1")
+    assert rc == 0
+    assert "Checked out release v0.0.1" in capsys.readouterr().out
+    # Verify a checkout happened, targeting the requested tag.
+    assert ["git", "checkout", "--quiet", "v0.0.1"] in calls
+
+
+def test_checkout_release_accepts_version_without_v_prefix(monkeypatch, tmp_path):
+    calls = _patch_run(
+        monkeypatch,
+        _make_git_dispatcher(tags={"v0.0.1": "ABC"}, head_sha="OLD"),
+    )
+    rc = start._checkout_release(tmp_path, "0.0.1")
+    assert rc == 0
+    # The user passed "0.0.1"; we should have normalized to "v0.0.1" before verifying/checking out.
+    assert ["git", "rev-parse", "--verify", "refs/tags/v0.0.1"] in calls
+    assert ["git", "checkout", "--quiet", "v0.0.1"] in calls
+
+
+def test_checkout_release_unknown_version_fails(monkeypatch, tmp_path, capsys):
+    _patch_run(monkeypatch, _make_git_dispatcher(tags={"v0.0.1": "ABC"}))
+    rc = start._checkout_release(tmp_path, "v9.9.9")
+    assert rc == 1
+    assert "release 'v9.9.9' not found" in capsys.readouterr().err
+
+
+def test_checkout_release_uses_latest_when_no_version(monkeypatch, tmp_path):
+    calls = _patch_run(
+        monkeypatch,
+        _make_git_dispatcher(tags={"v0.0.1": "ABC"}, head_sha="OLD"),
+    )
+    # `_latest_release_tag` is called when requested_version is None. Stub it directly so
+    # we don't have to wire up the GitHub URL parsing in this test.
+    monkeypatch.setattr(start, "_latest_release_tag", lambda _root: "v0.0.1")
+    rc = start._checkout_release(tmp_path, None)
+    assert rc == 0
+    assert ["git", "checkout", "--quiet", "v0.0.1"] in calls
+
+
+def test_checkout_release_no_releases_available(monkeypatch, tmp_path, capsys):
+    _patch_run(monkeypatch, _make_git_dispatcher())
+    monkeypatch.setattr(start, "_latest_release_tag", lambda _root: None)
+    rc = start._checkout_release(tmp_path, None)
+    assert rc == 1
+    assert "no release tags found" in capsys.readouterr().err
+
+
+def test_checkout_release_skips_when_already_on_tag(monkeypatch, tmp_path, capsys):
+    # HEAD and the tag both point at SHA "ABC" — no checkout should run.
+    calls = _patch_run(
+        monkeypatch,
+        _make_git_dispatcher(tags={"v0.0.1": "ABC"}, head_sha="ABC"),
+    )
+    rc = start._checkout_release(tmp_path, "v0.0.1")
+    assert rc == 0
+    assert "Already on release v0.0.1" in capsys.readouterr().out
+    # No checkout invocation should appear.
+    assert not any(argv[:2] == ["git", "checkout"] for argv in calls)
+
+
+def test_checkout_release_propagates_checkout_failure(monkeypatch, tmp_path, capsys):
+    _patch_run(
+        monkeypatch,
+        _make_git_dispatcher(
+            tags={"v0.0.1": "ABC"},
+            head_sha="OLD",
+            checkout_rc=1,
+        ),
+    )
+    rc = start._checkout_release(tmp_path, "v0.0.1")
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "failed to check out release v0.0.1" in err
+    assert "local changes" in err
+
+
+def test_checkout_release_warns_on_fetch_failure_but_continues(monkeypatch, tmp_path, capsys):
+    _patch_run(
+        monkeypatch,
+        _make_git_dispatcher(tags={"v0.0.1": "ABC"}, head_sha="OLD", fetch_rc=1),
+    )
+    rc = start._checkout_release(tmp_path, "v0.0.1")
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "git fetch --tags failed" in err

--- a/tests/test_cli_vertex.py
+++ b/tests/test_cli_vertex.py
@@ -134,6 +134,7 @@ def test_start_injects_vertex_env(tmp_path, tmp_config, monkeypatch):
 
     monkeypatch.setattr(os, "execvp", fake_execvp)
     monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(start, "_checkout_release", lambda *_a, **_kw: 0)
 
     start.run_start(agent="claude", extra_args=["/berdl_start"])
 
@@ -166,6 +167,7 @@ def test_start_skips_vertex_when_disabled(tmp_path, tmp_config, monkeypatch):
 
     monkeypatch.setattr(os, "execvp", fake_execvp)
     monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(start, "_checkout_release", lambda *_a, **_kw: 0)
 
     start.run_start(agent="claude", extra_args=["/berdl_start"])
 
@@ -199,6 +201,7 @@ def test_start_warns_missing_creds(tmp_path, tmp_config, monkeypatch, capsys):
 
     monkeypatch.setattr(os, "execvp", fake_execvp)
     monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(start, "_checkout_release", lambda *_a, **_kw: 0)
     monkeypatch.delenv("CLAUDE_CODE_USE_VERTEX", raising=False)
 
     start.run_start(agent="claude", extra_args=["/berdl_start"])


### PR DESCRIPTION
Instead of just pulling the head of the `main` branch, this ensures that the latest release gets pulled.

Also adds tests for the beril start script, and polishes the top-level pyproject.toml file. To run tests, do (from the root directory):

```
> uv sync --group test
> uv run pytest tests/
```