### PR TITLE
update URL in readme to the live site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Architecture](docs/figures/architecture_dark.png)
 
-The **Microbial Discovery Forge** is an AI co-scientist and research observatory, enabling researchers to interface with large-scale biological data through natural language, reusable skills, and shared knowledge.  You can browse the Forge through the [Observatory UI](http://beril-observatory.knowledge-engine.development.svc.spin.nersc.org/), or engage with it through an AI agent.
+The **Microbial Discovery Forge** is an AI co-scientist and research observatory, enabling researchers to interface with large-scale biological data through natural language, reusable skills, and shared knowledge.  You can browse the Forge through the [Observatory UI](https://beril.kbase.us/), or engage with it through an AI agent.
 
 Currently, it connects to the KBase BER Data Lakehouse (K-BERDL), a curated Delta Lakehouse spanning pangenomics, fitness, biochemistry, metagenomics, and more.
 
@@ -157,7 +157,7 @@ BERIL CLI commands (`beril doctor`, `beril setup`, `beril start`) handle environ
 ## Observatory UI
 A web application is available for browsing collections, projects, and the BERIL Atlas.
 
-The hosted instance is available at: **[BERIL Observatory](http://beril-observatory.knowledge-engine.development.svc.spin.nersc.org/)**
+The hosted instance is available at: **[BERIL Observatory](https://beril.kbase.us/)**
 
 If you want to run it locally:
 
@@ -253,7 +253,7 @@ BERIL-research-observatory/
 ## Resources
 
 - **BERDL JupyterHub**: [https://hub.berdl.kbase.us](https://hub.berdl.kbase.us)
-- **BERIL Observatory UI**: [http://beril-observatory.knowledge-engine.development.svc.spin.nersc.org/](http://beril-observatory.knowledge-engine.development.svc.spin.nersc.org/)
+- **BERIL Observatory UI**: [https://beril.kbase.us/](https://beril.kbase.us/)
 - **KBase**: [https://www.kbase.us](https://www.kbase.us)
 - **Schema Documentation**: [docs/schemas/](docs/schemas/)
 - **Query Pitfalls**: [docs/pitfalls.md](docs/pitfalls.md)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -148,7 +148,7 @@ git commit -m "Add initial analysis notebook"
 git push
 ```
 
-Others can see work in progress on the [Observatory UI](http://beril-observatory.knowledge-engine.development.svc.spin.nersc.org/). Pushing early and often makes your work visible and lets collaborators build on it.
+Others can see work in progress on the [Observatory UI](https://beril.kbase.us/). Pushing early and often makes your work visible and lets collaborators build on it.
 
 ## Step 8: Submit for review when ready
 
@@ -180,7 +180,7 @@ You can keep working on the project after submitting — submission is not a one
 
 ## Resources
 
-- **Observatory UI**: [BERIL Observatory](http://beril-observatory.knowledge-engine.development.svc.spin.nersc.org/)
+- **Observatory UI**: [BERIL Observatory](https://beril.kbase.us/)
 - **BERDL JupyterHub**: [hub.berdl.kbase.us](https://hub.berdl.kbase.us)
 - **CBORG (LBL users)**: [cborg.lbl.gov](https://cborg.lbl.gov/tools_claudecode/)
 - **Query pitfalls**: [docs/pitfalls.md](pitfalls.md)


### PR DESCRIPTION
The previous URLs - http://beril-observatory.knowledge-engine.development.svc.spin.nersc.org/ should now be https://beril.kbase.us 

Hooray for SSL certs and brief URLs!