### PR TITLE
docs(onboarding): surface OpenViking setup front and center

### DIFF
--- a/.claude/skills/berdl_start/SKILL.md
+++ b/.claude/skills/berdl_start/SKILL.md
@@ -184,11 +184,21 @@ uv run --env-file .env knowledge/scripts/knowledge_query.py doctor
   **Do not enumerate `projects/` or read `projects/*/README.md` / REPORTs by hand for
   context** — the server has them indexed and ranked, and hand-scanning misses the
   cross-project connections it surfaces.
-- **NO API KEY / AUTH FAILED** → the remote layer needs a key. Tell the user:
-  `uv run knowledge/scripts/setup_remote_ov.py --cookie '<beril_session>'`
-  (walkthrough: `docs/remote-openviking-setup.md`). Until then keep using
-  `knowledge_query.py` — `find` / `grep` / `read` / `overview` fall back to local
-  search over the same corpus.
+- **NO API KEY / AUTH FAILED** → server is up but you have no valid key. OpenViking is
+  the default knowledge layer, so surface these steps to the user, then continue
+  (non-blocking — don't wait on them):
+
+  > **Set up OpenViking (~2 min, one-time):**
+  > 1. Open `https://beril-dev.kbase.us` and log in with your ORCiD.
+  > 2. Copy the `beril_session` cookie (DevTools → Application/Storage → Cookies).
+  > 3. In **your own terminal** (never paste the cookie into chat):
+  >    `uv run knowledge/scripts/setup_remote_ov.py --cookie '<paste beril_session value>'`
+  > 4. Verify: `uv run --env-file .env knowledge/scripts/knowledge_query.py doctor` → `OpenViking: OK`.
+  > Full walkthrough & troubleshooting: `docs/remote-openviking-setup.md`.
+
+  Until the key is set, knowledge-layer queries won't return results — the server is
+  reachable, so there's no local fallback (that only applies to `UNREACHABLE`). Setting
+  up the key is what unblocks `find` / `grep` / `read` / `overview`.
 - **UNREACHABLE** → no server; `find` / `grep` / `read` / `overview` still work via
   local fallback, so keep using them instead of hand-scanning. Only
   `relations` / `glob` / `ls` / `tree` / `stat` need the server — for those, a plain

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ beril setup             # interactive onboarding — configures .env, checks pre
 
 On BERDL JupyterHub, `beril setup` auto-detects your `KBASE_AUTH_TOKEN` and MinIO credentials from the environment.
 
+> 🧭 **Set up OpenViking — the default knowledge layer (do this first).**
+> OpenViking indexes every project report and central doc so the agent can find prior
+> work, related research, and answer "has this been done?" — it's the default way BERIL
+> looks things up. One-time API-key setup, ~2 min:
+> **[docs/remote-openviking-setup.md](docs/remote-openviking-setup.md)**.
+> Skip it now and `/berdl_start` will surface the same steps when you launch the agent.
+
 Once set up, use `beril doctor` to check your environment and `beril start` to launch your coding agent.
 
 ### Manual Setup
@@ -151,24 +158,6 @@ BERIL CLI commands (`beril doctor`, `beril setup`, `beril start`) handle environ
    ```bash
    KBASE_AUTH_TOKEN="your-token-here"
    ```
-
----
-
-### Knowledge context (remote OpenViking)
-
-BERIL indexes project reports and central docs in a shared **OpenViking**
-knowledge server, searchable with `knowledge/scripts/knowledge_query.py`. To use
-the remote server you need a one-time API key. Get one with:
-
-```bash
-uv run knowledge/scripts/setup_remote_ov.py --cookie '<your beril_session cookie>'
-uv run --env-file .env knowledge/scripts/knowledge_query.py doctor   # verify
-```
-
-Full walkthrough (how to get the cookie, troubleshooting, rotation):
-**[docs/remote-openviking-setup.md](docs/remote-openviking-setup.md)**. The
-query toolkit itself is documented in the `knowledge-context` skill and
-[docs/openviking.md](docs/openviking.md).
 
 ---
 


### PR DESCRIPTION
## Why

OpenViking is the **default knowledge layer** for BERIL, but its setup was easy to miss: buried in a low-visibility README subsection, and a user who skips the README and just launches the agent got only a one-line pointer with no actual steps. This makes OpenViking onboarding prominent and self-serve.

## What

- **README** — adds a prominent 🧭 callout in the Quick Start flow framing OpenViking as the default knowledge layer with a "do this first" nudge, linking to `docs/remote-openviking-setup.md` as the single source of truth. No step duplication, so the temporary dev→prod host change touches only the doc.
- **`berdl_start` Phase 1.8** — expands the `NO API KEY` / `AUTH FAILED` branch into a condensed **4-step, non-blocking** walkthrough (log in → copy `beril_session` cookie → run `setup_remote_ov.py` in the user's own terminal → verify with `doctor`), so a user who never read the README still gets step-by-step guidance when they launch the agent. Includes a "never paste the cookie into chat" security note.
- **Accuracy fix** — corrected an inherited inaccuracy: on `NO API KEY` / `AUTH FAILED` the server is reachable, so `knowledge_query.py` does **not** fall back to local search (that only applies to `UNREACHABLE`). The guidance now reflects that setting up the key is what unblocks `find`/`grep`/`read`/`overview`.

## Scope

Docs/skill-text only — no logic changes. `OK` / `UNREACHABLE` branches and the non-blocking Phase 1.8 flow are unchanged.

## Notes

- The dev host `beril-dev.kbase.us` is referenced in exactly the two edited spots plus the canonical doc; when OpenViking moves to production, update `docs/remote-openviking-setup.md` (one `SERVER=` line) and the `berdl_start` bullet.
- Reviewed with Codex: both findings (placeholder wording consistency + the fallback-claim bug) were verified against the code and fixed before commit.
