### PR TITLE
auth: Bearer token wins over session cookie (4/5)

### DIFF
--- a/ui/app/auth.py
+++ b/ui/app/auth.py
@@ -43,24 +43,32 @@ def get_beril_user_id(request: Request) -> str | None:
 async def get_current_user_session_or_token(
     request: Request, db: AsyncSession
 ) -> "BerilUser | None":
-    """Authenticate via session cookie or Authorization: Bearer token.
+    """Authenticate via Authorization: Bearer token or session cookie.
 
-    Tries the session first (cheaper, no DB hit). Falls back to the Bearer
-    token in the Authorization header, which requires a DB lookup.
+    Bearer wins when both are present. An explicit Bearer header signals
+    programmatic intent — a stale session cookie shouldn't silently shadow
+    the token the caller actually meant to use. If the Bearer is missing OR
+    invalid (unknown, expired, or revoked), we fall through to the session
+    cookie rather than short-circuiting to 401: that keeps a browser tab
+    working even if some other tool on the same machine holds a bad token.
+
     Returns the BerilUser ORM object, or None if neither method succeeds.
     """
+    # Bearer token path — scheme is case-insensitive per HTTP spec
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        raw_token = auth_header[len("bearer "):]
+        user = await get_user_by_api_token(db, raw_token)
+        if user is not None:
+            return user
+        # Invalid Bearer — fall through to session rather than failing hard.
+
     # Session path — only trust it if the orcid_id still resolves in the DB
     orcid_id = request.session.get("orcid_id")
     if orcid_id:
         user = await get_user_by_orcid(db, orcid_id)
         if user is not None:
             return user
-
-    # Bearer token path — scheme is case-insensitive per HTTP spec
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.lower().startswith("bearer "):
-        raw_token = auth_header[len("bearer "):]
-        return await get_user_by_api_token(db, raw_token)
 
     return None
 

--- a/ui/tests/test_auth.py
+++ b/ui/tests/test_auth.py
@@ -409,7 +409,9 @@ class TestGetCurrentUserOrToken:
         assert result is not None
         assert result.id == user.id
 
-    async def test_session_takes_priority_over_bearer(self, db_session):
+    async def test_bearer_takes_priority_over_session(self, db_session):
+        """An explicit Bearer header wins over a lingering session cookie —
+        programmatic intent should not be silently shadowed."""
         from app.auth import get_current_user_session_or_token
         from app.db.crud import get_or_create_api_token
         from app.db.models import BerilUser
@@ -428,7 +430,24 @@ class TestGetCurrentUserOrToken:
         request.headers = {"Authorization": f"Bearer {raw_token}"}
         result = await get_current_user_session_or_token(request, db_session)
         assert result is not None
-        assert result.id == user_a.id
+        assert result.id == user_b.id
+
+    async def test_invalid_bearer_falls_through_to_session(self, db_session):
+        """A stale/bad Bearer must not lock out a valid browser session —
+        we fall through rather than failing hard on invalid Bearer."""
+        from app.auth import get_current_user_session_or_token
+        from app.db.models import BerilUser
+
+        user = BerilUser(orcid_id="0000-0001-2345-6789")
+        db_session.add(user)
+        await db_session.commit()
+
+        request = MagicMock()
+        request.session = {"orcid_id": "0000-0001-2345-6789"}
+        request.headers = {"Authorization": "Bearer beril_not_a_real_token"}
+        result = await get_current_user_session_or_token(request, db_session)
+        assert result is not None
+        assert result.orcid_id == "0000-0001-2345-6789"
 
     async def test_bad_bearer_token_returns_none(self, db_session):
         from app.auth import get_current_user_session_or_token
@@ -458,8 +477,9 @@ class TestGetCurrentUserOrToken:
         assert result is not None
         assert result.id == user.id
 
-    async def test_stale_session_falls_back_to_bearer(self, db_session):
-        """If the session orcid_id no longer resolves, bearer token is still honoured."""
+    async def test_bearer_wins_even_when_session_is_stale(self, db_session):
+        """Bearer succeeds regardless of session state — a stale session
+        cookie doesn't interfere with a valid Bearer token."""
         from app.auth import get_current_user_session_or_token
         from app.db.crud import get_or_create_api_token
         from app.db.models import BerilUser


### PR DESCRIPTION
## Summary

Phase 4 of the PAT stack. Two-line semantic fix: when a request presents
both an `Authorization: Bearer` header and a session cookie, the Bearer
now wins.

**Stacked on #326** (phase 3: `/whoami`). Base branch is
`pat/3-whoami-route` — retarget up the chain as earlier PRs merge.

### The change

An explicit `Authorization: Bearer` header signals programmatic intent
— the CLI, JupyterHub agents, curl scripts. A lingering session cookie
from a browser tab on the same domain should not silently shadow the
token the caller actually meant to use.

New order in `get_current_user_session_or_token`:

1. If `Authorization: Bearer <token>` is present **and valid**, return
   that user.
2. If the Bearer is missing OR invalid (unknown, expired, revoked),
   **fall through to the session cookie** rather than short-circuiting
   to 401.
3. If neither authenticates, return `None`.

### Why fall through on invalid Bearer?

Chosen deliberately during phase 2 planning: it keeps the failure mode
gentle for the "I have both a browser tab and a stale CLI token in some
config file" case. A hard 401 would lock users out of the browser
session they can see, over a token they cannot. A valid Bearer still
always wins, so no security posture is weakened.

### Tests

- `test_session_takes_priority_over_bearer` → flipped and renamed to
  `test_bearer_takes_priority_over_session`.
- `test_stale_session_falls_back_to_bearer` → renamed to
  `test_bearer_wins_even_when_session_is_stale`. The assertion is
  unchanged, but the reason it passes is now "Bearer wins first" rather
  than "session lookup failed so we tried Bearer."
- **New**: `test_invalid_bearer_falls_through_to_session` locks in the
  fall-through policy so we cannot accidentally regress to
  "hard 401 on any bad Bearer."

Full suite: **780 passing** (+1 from 779).

### What's not in this PR

- `POST /api/user/token` deprecation — grep confirms nothing in the
  repo (routes, CLI, tests apart from its own) calls it programmatically.
  A `X-Deprecation` header would go unread; leaving cleanup for a
  future PR.

## Test plan
- [ ] `cd ui && uv run pytest tests/ -q --no-cov` — 780 tests pass.
- [ ] Log in via browser (session cookie set). Send a request with
      `Authorization: Bearer beril_<other-user-token>` — response
      identifies as the other user.
- [ ] Same session, `Authorization: Bearer beril_garbage` — response
      still identifies as the browser user (fall-through).
- [ ] No session, `Authorization: Bearer beril_garbage` — 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
