### PR TITLE
cli: beril auth login/status/logout for CLI authentication

### DIFF
--- a/.claude/skills/knowledge-context/SKILL.md
+++ b/.claude/skills/knowledge-context/SKILL.md
@@ -19,8 +19,12 @@ OpenViking holds an indexed context layer over BERIL projects and central docs. 
 ## Picking the right primitive
 
 ```
-QUERY="uv run --env-file .env knowledge/scripts/knowledge_query.py"
+QUERY="uv run knowledge/scripts/knowledge_query.py"
 ```
+
+Credentials resolve from `~/.beril` after `beril login` (see § Configuration) —
+no `--env-file` needed. To override, set `OPENVIKING_URL` / `OPENVIKING_API_KEY`
+in the env or prepend `--env-file .env`.
 
 | Question | Use | Why |
 |---|---|---|
@@ -216,7 +220,7 @@ For everything else (project→doc, doc→doc, file-level links), use the `link`
 ## Refreshing context
 
 ```bash
-INGEST="uv run --env-file .env knowledge/scripts/ingest_context.py"
+INGEST="uv run knowledge/scripts/ingest_context.py"   # creds from ~/.beril; see § Configuration
 $INGEST --project <project_id>     # after editing one project
 $INGEST --changed                  # after mixed edits — diffs against state manifest
 $INGEST --all                      # full refresh
@@ -228,22 +232,36 @@ $INGEST --docs                     # central docs only
 
 ## Configuration
 
-`.env` (copy from `.env.example`):
+**Remote server (recommended for most users):** BERIL runs a shared OpenViking
+server (currently the dev host `https://beril-dev.kbase.us`). The one-call setup
+is `beril login` — it validates your token and links + caches your OpenViking
+credential in `~/.beril`, so the query CLI resolves it automatically:
+
+```bash
+beril login                 # links OpenViking too; no browser cookie needed
+$QUERY doctor               # verify (no --env-file required once cached)
+```
+
+If login couldn't reach OpenViking (or you logged in before this was wired up),
+link it separately against the same stored token:
+
+```bash
+beril ov setup              # or `beril ov setup --regenerate` to rotate the key
+beril ov status             # show the cached credential + server health
+```
+
+`ContextConfig.from_env` precedence is: explicit env vars → the `~/.beril`
+cached credential → the local default URL. So `OPENVIKING_URL` /
+`OPENVIKING_API_KEY` (in `.env` or the shell) still override the cache when set
+— useful for CI or pointing at a different server. `beril ov print-env` emits
+those two lines if you'd rather populate `.env` (`eval "$(beril ov print-env)"`).
+
+`.env` keys (copy from `.env.example`), when you set them explicitly:
 
 - `OPENVIKING_URL` — defaults to `http://127.0.0.1:1933`
 - `OPENVIKING_API_KEY` — only when the server enforces auth (remote deployments)
 
-**Remote server (recommended for most users):** BERIL runs a shared OpenViking
-server (currently the dev host `https://beril-dev.kbase.us`). Get a one-time API
-key and write it into `.env` with the helper, then verify:
-
-```bash
-uv run knowledge/scripts/setup_remote_ov.py --cookie '<beril_session cookie>'
-$QUERY doctor
-```
-
-Full walkthrough (how to copy the cookie, rotation, troubleshooting):
-`docs/remote-openviking-setup.md`.
+Full walkthrough (rotation, troubleshooting): `docs/remote-openviking-setup.md`.
 
 **Local server:** copy `knowledge/openviking/ov.conf.example` → `knowledge/openviking/ov.conf` and set the OpenRouter key in `embedding` and the CBORG key in `vlm`. The local `ov.conf` is gitignored.
 

--- a/beril_cli/auth_cmd.py
+++ b/beril_cli/auth_cmd.py
@@ -17,8 +17,10 @@ logged in.
 
 logout: remove ~/.beril/auth.json. Idempotent.
 
-stdlib only (urllib.request for HTTP) — the CLI package has no runtime
-dependencies and this module should not add one.
+Uses httpx for HTTP. urllib was tried first (to keep beril-cli
+dep-free) but Cloudflare in front of the prod server rejects the
+default ``Python-urllib/*`` User-Agent with a 403 while letting
+``httpx``'s default UA through.
 """
 
 from __future__ import annotations
@@ -27,8 +29,8 @@ import argparse
 import getpass
 import json
 import sys
-import urllib.error
-import urllib.request
+
+import httpx
 
 from beril_cli import auth_store, config
 
@@ -149,7 +151,7 @@ def _run_logout(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
-# whoami HTTP call (stdlib only)
+# whoami HTTP call
 # ---------------------------------------------------------------------------
 
 
@@ -165,26 +167,34 @@ def _whoami(base_url: str, token: str) -> dict:
     message suitable for printing to the user.
     """
     url = base_url.rstrip("/") + _WHOAMI_PATH
-    req = urllib.request.Request(
-        url,
-        method="GET",
-        headers={"Authorization": f"Bearer {token}"},
-    )
     try:
-        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:
-            body = resp.read()
-    except urllib.error.HTTPError as e:
-        if e.code == 401:
-            raise _WhoamiError("token was rejected by the server (401).") from e
-        raise _WhoamiError(f"server returned HTTP {e.code}.") from e
-    except urllib.error.URLError as e:
-        raise _WhoamiError(f"could not reach {base_url}: {e.reason}") from e
-    except TimeoutError as e:
+        res = httpx.get(
+            url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=_HTTP_TIMEOUT_SECONDS,
+        )
+    except httpx.TimeoutException as e:
+        # TimeoutException is a subclass of TransportError; catch it first
+        # so timeouts get their specific message.
         raise _WhoamiError(f"timed out talking to {base_url}.") from e
+    except httpx.TransportError as e:
+        # Covers ConnectError, ReadError, WriteError, ProtocolError, etc.
+        raise _WhoamiError(f"could not reach {base_url}: {e}") from e
+
+    if res.status_code == 401:
+        raise _WhoamiError("token was rejected by the server (401).")
+    if res.status_code == 403:
+        raise _WhoamiError("unable to retrieve information with this token (403).")
+    if res.status_code >= 400:
+        raise _WhoamiError(
+            f"an error occurred while validating token at {base_url} ({res.status_code})"
+        )
 
     try:
-        data = json.loads(body)
-    except json.JSONDecodeError as e:
+        data = res.json()
+    except (json.JSONDecodeError, ValueError) as e:
+        # res.json() raises ValueError on garbage bodies; JSONDecodeError
+        # is a ValueError subclass but we spell both for clarity.
         raise _WhoamiError("server returned invalid JSON.") from e
 
     if not isinstance(data, dict) or "orcid_id" not in data:

--- a/beril_cli/auth_cmd.py
+++ b/beril_cli/auth_cmd.py
@@ -7,7 +7,7 @@ login flow:
      Otherwise print the "open <url>/account/tokens in a browser and
      paste the token" prompt and read via getpass so the token does not
      echo on the terminal.
-  3. POST /api/user/whoami with Authorization: Bearer <token>. If 2xx,
+  3. GET /api/user/whoami with Authorization: Bearer <token>. If 2xx,
      parse ORCiD + display name and save to ~/.beril/auth.json (mode
      0600). If not, print the server error and exit non-zero without
      writing anything.
@@ -25,7 +25,6 @@ default ``Python-urllib/*`` User-Agent with a 403 while letting
 
 from __future__ import annotations
 
-import argparse
 import getpass
 import json
 import sys
@@ -113,6 +112,32 @@ def check_status() -> int:
         print("Not logged in. Run `beril login` to authenticate.")
         return 1
 
+    # validate token
+    try:
+        _whoami(record.base_url, record.token)
+    except _WhoamiError as e:
+        if e.rejected:
+            print(
+                f"Stored credentials are no longer valid: {e}\n"
+                "Run `beril login` to re-authenticate, or "
+                "`beril logout` to remove them.",
+                file=sys.stderr
+            )
+            return 1
+        elif e.unreachable:
+            print(
+                f"Could not verify credentials: {e}\n"
+                "Your stored login may still be valid, the server was unreachable",
+                file=sys.stderr
+            )
+            return 2
+        else:
+            print(
+                f"An error occurred while checking your stored login credentials: {e}",
+                file=sys.stderr,
+            )
+            return 2
+
     name = record.display_name or record.orcid_id
     print(f"Logged in as {name} ({record.orcid_id}) on {record.base_url}.")
     print(f"Token file: {auth_store.AUTH_PATH}")
@@ -143,6 +168,10 @@ def run_logout() -> int:
 
 class _WhoamiError(Exception):
     """Any failure of the whoami validation call. Message is user-facing."""
+    def __init__(self, msg: str, rejected:bool=False, unreachable: bool=False):
+        super().__init__(msg)
+        self.rejected = rejected
+        self.unreachable = unreachable
 
 
 def _whoami(base_url: str, token: str) -> dict:
@@ -162,15 +191,15 @@ def _whoami(base_url: str, token: str) -> dict:
     except httpx.TimeoutException as e:
         # TimeoutException is a subclass of TransportError; catch it first
         # so timeouts get their specific message.
-        raise _WhoamiError(f"timed out talking to {base_url}.") from e
+        raise _WhoamiError(f"timed out talking to {base_url}.", unreachable=True) from e
     except httpx.TransportError as e:
         # Covers ConnectError, ReadError, WriteError, ProtocolError, etc.
-        raise _WhoamiError(f"could not reach {base_url}: {e}") from e
+        raise _WhoamiError(f"could not reach {base_url}: {e}", unreachable=True) from e
 
     if res.status_code == 401:
-        raise _WhoamiError("token was rejected by the server (401).")
+        raise _WhoamiError("token was rejected by the server (401).", rejected=True)
     if res.status_code == 403:
-        raise _WhoamiError("unable to retrieve information with this token (403).")
+        raise _WhoamiError("unable to retrieve information with this token (403).", rejected=True)
     if res.status_code >= 400:
         raise _WhoamiError(
             f"an error occurred while validating token at {base_url} ({res.status_code})"

--- a/beril_cli/auth_cmd.py
+++ b/beril_cli/auth_cmd.py
@@ -32,6 +32,7 @@ import sys
 import httpx
 
 from beril_cli import auth_store, config
+from beril_cli.ov_client import OvLinkError, fetch_ov_credential
 
 _WHOAMI_PATH = "/api/user/whoami"
 _HTTP_TIMEOUT_SECONDS = 15.0
@@ -77,14 +78,39 @@ def run_login(token: str|None = None, base_url: str|None = None, status:bool=Fal
         print(f"Login failed: {e}", file=sys.stderr)
         return 1
 
+    # Link OpenViking in the same step. This is best-effort: a valid BERIL
+    # login must still succeed (and be saved) even if OpenViking is
+    # unreachable or the 409 "key exists but BERIL holds none" case fires —
+    # the user can repair it later with `beril ov setup [--regenerate]`.
+    ov_url: str | None = None
+    ov_user_key: str | None = None
+    ov_warning: str | None = None
+    try:
+        ov_url, ov_user_key = fetch_ov_credential(base_url, token)
+    except OvLinkError as e:
+        if e.needs_regenerate:
+            ov_warning = (
+                f"OpenViking not linked: {e} "
+                "Run `beril ov setup --regenerate` to mint a fresh key."
+            )
+        else:
+            ov_warning = (
+                f"OpenViking not linked: {e} "
+                "Run `beril ov setup` to link it later."
+            )
+
     auth_store.save(
         token=token,
         base_url=base_url,
         orcid_id=identity["orcid_id"],
         display_name=identity.get("display_name"),
+        ov_url=ov_url,
+        ov_user_key=ov_user_key,
     )
     name = identity.get("display_name") or identity["orcid_id"]
     print(f"Logged in to {base_url} as {name} ({identity['orcid_id']}).")
+    if not ov_user_key:
+        print(ov_warning, file=sys.stderr)
     return 0
 
 

--- a/beril_cli/auth_cmd.py
+++ b/beril_cli/auth_cmd.py
@@ -1,0 +1,192 @@
+"""beril auth — log in / show status / log out of a BERIL server.
+
+login flow:
+  1. If --base-url is given, use and persist it (so future runs don't
+     need it). Otherwise resolve from config or the compiled-in default.
+  2. If --token is given, use it directly (scriptable / headless path).
+     Otherwise print the "open <url>/account/tokens in a browser and
+     paste the token" prompt and read via getpass so the token does not
+     echo on the terminal.
+  3. POST /api/user/whoami with Authorization: Bearer <token>. If 2xx,
+     parse ORCiD + display name and save to ~/.beril/auth.json (mode
+     0600). If not, print the server error and exit non-zero without
+     writing anything.
+
+status: print who the stored token belongs to. Non-zero exit if not
+logged in.
+
+logout: remove ~/.beril/auth.json. Idempotent.
+
+stdlib only (urllib.request for HTTP) — the CLI package has no runtime
+dependencies and this module should not add one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import sys
+import urllib.error
+import urllib.request
+
+from beril_cli import auth_store, config
+
+_WHOAMI_PATH = "/api/user/whoami"
+_HTTP_TIMEOUT_SECONDS = 15.0
+
+
+def run_auth(args: argparse.Namespace) -> int:
+    """Dispatch on args.action (login/status/logout)."""
+    action = getattr(args, "action", None)
+    if action == "login":
+        return _run_login(args)
+    if action == "status":
+        return _run_status(args)
+    if action == "logout":
+        return _run_logout(args)
+    # argparse's `choices=` already rejects anything else, but be defensive.
+    print(f"Unknown auth action: {action}", file=sys.stderr)
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# login
+# ---------------------------------------------------------------------------
+
+
+def _run_login(args: argparse.Namespace) -> int:
+    # Resolve and (if given) persist the base URL BEFORE reading the token
+    # so a --base-url override affects the whoami request in this same
+    # invocation.
+    if getattr(args, "base_url", None):
+        config.set_base_url(args.base_url)
+    base_url = config.get_base_url()
+
+    token = (getattr(args, "token", None) or "").strip()
+    if not token:
+        token = _prompt_for_token(base_url)
+    if not token:
+        print("No token provided.", file=sys.stderr)
+        return 1
+
+    try:
+        identity = _whoami(base_url, token)
+    except _WhoamiError as e:
+        print(f"Login failed: {e}", file=sys.stderr)
+        return 1
+
+    auth_store.save(
+        token=token,
+        base_url=base_url,
+        orcid_id=identity["orcid_id"],
+        display_name=identity.get("display_name"),
+    )
+    name = identity.get("display_name") or identity["orcid_id"]
+    print(f"Logged in to {base_url} as {name} ({identity['orcid_id']}).")
+    return 0
+
+
+def _prompt_for_token(base_url: str) -> str:
+    print(
+        "To log in:\n"
+        f"  1. Open {base_url}/account/tokens in your browser\n"
+        "  2. Create a new personal access token\n"
+        "  3. Paste it below (input will not echo)\n"
+    )
+    try:
+        return getpass.getpass("Token: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print("", file=sys.stderr)  # newline so the shell prompt looks clean
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+def _run_status(args: argparse.Namespace) -> int:
+    record = auth_store.load()
+    if record is None:
+        print("Not logged in. Run `beril auth login` to authenticate.")
+        return 1
+
+    if getattr(args, "json", False):
+        # Redact the token from status output — CLI status is a human
+        # convenience, not a token exporter.
+        payload = {
+            "base_url": record["base_url"],
+            "orcid_id": record["orcid_id"],
+            "display_name": record.get("display_name"),
+            "path": str(auth_store.AUTH_PATH),
+        }
+        json.dump(payload, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    name = record.get("display_name") or record["orcid_id"]
+    print(f"Logged in as {name} ({record['orcid_id']}) on {record['base_url']}.")
+    print(f"Token file: {auth_store.AUTH_PATH}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# logout
+# ---------------------------------------------------------------------------
+
+
+def _run_logout(args: argparse.Namespace) -> int:
+    had_record = auth_store.load() is not None
+    auth_store.clear()
+    if had_record:
+        print("Logged out.")
+    else:
+        # Idempotent: still exit 0, but be honest that there was nothing
+        # to clear so scripts can tell.
+        print("Not logged in; nothing to do.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# whoami HTTP call (stdlib only)
+# ---------------------------------------------------------------------------
+
+
+class _WhoamiError(Exception):
+    """Any failure of the whoami validation call. Message is user-facing."""
+
+
+def _whoami(base_url: str, token: str) -> dict:
+    """Call GET {base_url}/api/user/whoami with the given Bearer token.
+
+    Returns the parsed JSON dict on success (guaranteed to contain at
+    least ``orcid_id``). Raises _WhoamiError on any failure with a
+    message suitable for printing to the user.
+    """
+    url = base_url.rstrip("/") + _WHOAMI_PATH
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            raise _WhoamiError("token was rejected by the server (401).") from e
+        raise _WhoamiError(f"server returned HTTP {e.code}.") from e
+    except urllib.error.URLError as e:
+        raise _WhoamiError(f"could not reach {base_url}: {e.reason}") from e
+    except TimeoutError as e:
+        raise _WhoamiError(f"timed out talking to {base_url}.") from e
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as e:
+        raise _WhoamiError("server returned invalid JSON.") from e
+
+    if not isinstance(data, dict) or "orcid_id" not in data:
+        raise _WhoamiError("server response missing orcid_id.")
+    return data

--- a/beril_cli/auth_cmd.py
+++ b/beril_cli/auth_cmd.py
@@ -37,35 +37,35 @@ from beril_cli import auth_store, config
 _WHOAMI_PATH = "/api/user/whoami"
 _HTTP_TIMEOUT_SECONDS = 15.0
 
-
-def run_auth(args: argparse.Namespace) -> int:
-    """Dispatch on args.action (login/status/logout)."""
-    action = getattr(args, "action", None)
-    if action == "login":
-        return _run_login(args)
-    if action == "status":
-        return _run_status(args)
-    if action == "logout":
-        return _run_logout(args)
-    # argparse's `choices=` already rejects anything else, but be defensive.
-    print(f"Unknown auth action: {action}", file=sys.stderr)
-    return 2
-
-
 # ---------------------------------------------------------------------------
 # login
 # ---------------------------------------------------------------------------
 
 
-def _run_login(args: argparse.Namespace) -> int:
-    # Resolve and (if given) persist the base URL BEFORE reading the token
-    # so a --base-url override affects the whoami request in this same
-    # invocation.
-    if getattr(args, "base_url", None):
-        config.set_base_url(args.base_url)
+def run_login(token: str|None = None, base_url: str|None = None, status:bool=False) -> int:
+    """
+    Performs the action that lets a user log in to the BERIL webapp
+    locally.
+
+    arg options:
+    base_url: if not None, set the base url for the BERIL server (i.e. https://beril.kbase.us)
+      this happens BEFORE any other action takes place, including login and status checking
+    token: if not None, this skips the token prompt and uses the given token
+    status: if True, this does no login change (i.e. setting the token) and returns
+      the current token status. If a token is not currently set, it prints an error
+      and returns 1.
+    """
+
+    if base_url is not None:
+        config.set_base_url(base_url)
     base_url = config.get_base_url()
 
-    token = (getattr(args, "token", None) or "").strip()
+    if status:
+        return check_status()
+
+    if token is None:
+        token = ""
+    token = token.strip()
     if not token:
         token = _prompt_for_token(base_url)
     if not token:
@@ -107,28 +107,14 @@ def _prompt_for_token(base_url: str) -> str:
 # status
 # ---------------------------------------------------------------------------
 
-
-def _run_status(args: argparse.Namespace) -> int:
+def check_status() -> int:
     record = auth_store.load()
     if record is None:
-        print("Not logged in. Run `beril auth login` to authenticate.")
+        print("Not logged in. Run `beril login` to authenticate.")
         return 1
 
-    if getattr(args, "json", False):
-        # Redact the token from status output — CLI status is a human
-        # convenience, not a token exporter.
-        payload = {
-            "base_url": record["base_url"],
-            "orcid_id": record["orcid_id"],
-            "display_name": record.get("display_name"),
-            "path": str(auth_store.AUTH_PATH),
-        }
-        json.dump(payload, sys.stdout)
-        sys.stdout.write("\n")
-        return 0
-
-    name = record.get("display_name") or record["orcid_id"]
-    print(f"Logged in as {name} ({record['orcid_id']}) on {record['base_url']}.")
+    name = record.display_name or record.orcid_id
+    print(f"Logged in as {name} ({record.orcid_id}) on {record.base_url}.")
     print(f"Token file: {auth_store.AUTH_PATH}")
     return 0
 
@@ -138,7 +124,7 @@ def _run_status(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _run_logout(args: argparse.Namespace) -> int:
+def run_logout() -> int:
     had_record = auth_store.load() is not None
     auth_store.clear()
     if had_record:

--- a/beril_cli/auth_store.py
+++ b/beril_cli/auth_store.py
@@ -1,0 +1,97 @@
+"""Persistent CLI auth token store at ~/.beril/auth.json.
+
+Stores the raw personal access token, the base URL it was minted against,
+and enough identity metadata (ORCiD, display name) to render `beril auth
+status` without a network call. The file is written with mode 0600 on
+POSIX so other users on a shared machine can not read it. On Windows,
+permissions are less strict but the file is still written.
+
+We deliberately keep this module stdlib-only — `beril-cli` has no runtime
+dependencies and we should not add one just to hold a JSON blob.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import TypedDict
+
+AUTH_DIR = Path.home() / ".beril"
+AUTH_PATH = AUTH_DIR / "auth.json"
+
+
+class AuthRecord(TypedDict):
+    """Shape of the persisted auth blob."""
+
+    token: str
+    base_url: str
+    orcid_id: str
+    display_name: str | None
+
+
+def save(
+    *,
+    token: str,
+    base_url: str,
+    orcid_id: str,
+    display_name: str | None,
+) -> None:
+    """Write auth.json with mode 0600 (POSIX).
+
+    Uses os.open with O_CREAT | O_WRONLY | O_TRUNC so the mode is set at
+    creation time — a Path.write_text + chmod dance would briefly expose
+    a 0644 file to any process racing us.
+    """
+    AUTH_DIR.mkdir(parents=True, exist_ok=True)
+    payload: AuthRecord = {
+        "token": token,
+        "base_url": base_url,
+        "orcid_id": orcid_id,
+        "display_name": display_name,
+    }
+    # 0o600 on POSIX; ignored (no-op) on Windows. This intentionally
+    # replaces any existing file.
+    fd = os.open(AUTH_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(payload, f, indent=2)
+            f.write("\n")
+    except BaseException:
+        # If write fails partway, remove the possibly-partial file rather
+        # than leaving a broken auth.json behind.
+        try:
+            AUTH_PATH.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def load() -> AuthRecord | None:
+    """Return the persisted auth record, or None if not present.
+
+    A corrupt file (unparseable JSON, missing required fields) also
+    returns None — the caller should treat it as "not logged in" and
+    the user can re-run `beril auth login`.
+    """
+    if not AUTH_PATH.exists():
+        return None
+    try:
+        with AUTH_PATH.open("r") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    # Minimal shape check — enough to keep type-narrowed downstream code honest.
+    for key in ("token", "base_url", "orcid_id"):
+        if key not in data:
+            return None
+    data.setdefault("display_name", None)
+    return data
+
+
+def clear() -> None:
+    """Remove auth.json if present. Idempotent."""
+    try:
+        AUTH_PATH.unlink()
+    except FileNotFoundError:
+        pass

--- a/beril_cli/auth_store.py
+++ b/beril_cli/auth_store.py
@@ -23,11 +23,19 @@ AUTH_PATH = AUTH_DIR / "auth.json"
 
 @dataclass
 class AuthRecord:
-    """Shape of the persisted auth blob."""
+    """Shape of the persisted auth blob.
+
+    ``ov_url`` / ``ov_user_key`` cache the user's OpenViking credential so a
+    single ``beril login`` links both BERIL and OpenViking. They are optional:
+    an old auth.json predating them, or a login where OpenViking couldn't be
+    reached, reads as logged-in-but-OV-unlinked (both None).
+    """
     token: str
     base_url: str
     orcid_id: str
     display_name: str | None
+    ov_url: str | None = None
+    ov_user_key: str | None = None
 
 
 def save(
@@ -36,19 +44,27 @@ def save(
     base_url: str,
     orcid_id: str,
     display_name: str | None,
+    ov_url: str | None = None,
+    ov_user_key: str | None = None,
 ) -> None:
     """Write auth.json with mode 0600 (POSIX).
 
     Uses os.open with O_CREAT | O_WRONLY | O_TRUNC so the mode is set at
     creation time — a Path.write_text + chmod dance would briefly expose
     a 0644 file to any process racing us.
+
+    ``ov_url`` / ``ov_user_key`` are the cached OpenViking credential; pass
+    both when a login (or ``beril ov setup``) successfully links OpenViking,
+    or leave them None to record a BERIL-only login.
     """
     AUTH_DIR.mkdir(parents=True, exist_ok=True)
     payload: AuthRecord = AuthRecord(
         token=token,
         base_url=base_url,
         orcid_id = orcid_id,
-        display_name=display_name
+        display_name=display_name,
+        ov_url=ov_url,
+        ov_user_key=ov_user_key,
     )
     # 0o600 on POSIX; ignored (no-op) on Windows. This intentionally
     # replaces any existing file.
@@ -93,6 +109,9 @@ def load() -> AuthRecord | None:
             base_url=raw["base_url"],
             orcid_id=raw["orcid_id"],
             display_name=raw.get("display_name"),
+            # Optional — absent in older files or a BERIL-only login.
+            ov_url=raw.get("ov_url"),
+            ov_user_key=raw.get("ov_user_key"),
         )
     except KeyError:
         return None
@@ -101,6 +120,19 @@ def load() -> AuthRecord | None:
         if not getattr(data, key):
             return None
     return data
+
+
+def load_ov() -> tuple[str, str] | None:
+    """Return the cached ``(ov_url, ov_user_key)``, or None if not linked.
+
+    Convenience for consumers (the query CLI, ``beril ov``) that only need
+    the OpenViking credential. Returns None when not logged in or when the
+    login didn't link OpenViking (either field missing).
+    """
+    record = load()
+    if record is None or not record.ov_url or not record.ov_user_key:
+        return None
+    return (record.ov_url, record.ov_user_key)
 
 
 def clear() -> None:

--- a/beril_cli/auth_store.py
+++ b/beril_cli/auth_store.py
@@ -12,18 +12,18 @@ dependencies and we should not add one just to hold a JSON blob.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, asdict
 import json
 import os
 from pathlib import Path
-from typing import TypedDict
 
 AUTH_DIR = Path.home() / ".beril"
 AUTH_PATH = AUTH_DIR / "auth.json"
 
 
-class AuthRecord(TypedDict):
+@dataclass
+class AuthRecord:
     """Shape of the persisted auth blob."""
-
     token: str
     base_url: str
     orcid_id: str
@@ -44,18 +44,18 @@ def save(
     a 0644 file to any process racing us.
     """
     AUTH_DIR.mkdir(parents=True, exist_ok=True)
-    payload: AuthRecord = {
-        "token": token,
-        "base_url": base_url,
-        "orcid_id": orcid_id,
-        "display_name": display_name,
-    }
+    payload: AuthRecord = AuthRecord(
+        token=token,
+        base_url=base_url,
+        orcid_id = orcid_id,
+        display_name=display_name
+    )
     # 0o600 on POSIX; ignored (no-op) on Windows. This intentionally
     # replaces any existing file.
     fd = os.open(AUTH_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         with os.fdopen(fd, "w") as f:
-            json.dump(payload, f, indent=2)
+            json.dump(asdict(payload), f, indent=2)
             f.write("\n")
     except BaseException:
         # If write fails partway, remove the possibly-partial file rather
@@ -78,14 +78,13 @@ def load() -> AuthRecord | None:
         return None
     try:
         with AUTH_PATH.open("r") as f:
-            data = json.load(f)
+            data = AuthRecord(**json.load(f))
     except (OSError, json.JSONDecodeError):
         return None
     # Minimal shape check — enough to keep type-narrowed downstream code honest.
     for key in ("token", "base_url", "orcid_id"):
-        if key not in data:
+        if not getattr(data, key):
             return None
-    data.setdefault("display_name", None)
     return data
 
 

--- a/beril_cli/auth_store.py
+++ b/beril_cli/auth_store.py
@@ -78,8 +78,23 @@ def load() -> AuthRecord | None:
         return None
     try:
         with AUTH_PATH.open("r") as f:
-            data = AuthRecord(**json.load(f))
+            raw = json.load(f)
     except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    # display_name is optional; everything else is required. Pulling the
+    # fields explicitly (rather than AuthRecord(**raw)) means an old or
+    # hand-edited file with extra/missing keys reads as "corrupt -> None"
+    # or backfills display_name, instead of raising TypeError.
+    try:
+        data = AuthRecord(
+            token=raw["token"],
+            base_url=raw["base_url"],
+            orcid_id=raw["orcid_id"],
+            display_name=raw.get("display_name"),
+        )
+    except KeyError:
         return None
     # Minimal shape check — enough to keep type-narrowed downstream code honest.
     for key in ("token", "base_url", "orcid_id"):

--- a/beril_cli/cli.py
+++ b/beril_cli/cli.py
@@ -75,32 +75,32 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     # auth
-    auth_parser = sub.add_parser(
-        "auth",
-        help="Log in to a BERIL server with a personal access token",
+    login_parser = sub.add_parser(
+        "login",
+        help = "Log in to the BERIL server with a personal access token",
     )
-    auth_parser.add_argument(
-        "action",
-        choices=["login", "status", "logout"],
-        help="login pastes/validates a token; status shows the stored login; logout removes it",
-    )
-    auth_parser.add_argument(
+    login_parser.add_argument(
         "--token",
         default=None,
         metavar="TOKEN",
-        help="Provide the token directly instead of the interactive paste prompt (login only)",
+        help="Provide the token directly instead of the interactive prompt"
     )
-    auth_parser.add_argument(
+    login_parser.add_argument(
+        "--status",
+        action="store_true",
+        default=False,
+        help="Show the current login status, including the current user"
+    )
+    login_parser.add_argument(
         "--base-url",
         default=None,
         metavar="URL",
         help="Server base URL for login; persisted to ~/.config/beril/config.toml (login only)",
     )
-    auth_parser.add_argument(
-        "--json",
-        action="store_true",
-        default=False,
-        help="Emit machine-readable JSON (status only; token is redacted)",
+
+    sub.add_parser(
+        "logout",
+        help = "Log out of BERIL server, deletes local BERIL auth credentials"
     )
 
     # runtime-snapshot (settings.json SessionStart hook; reads the hook payload from stdin)
@@ -145,10 +145,13 @@ def main(argv: list[str] | None = None) -> int:
 
         return run_claims(args)
 
-    if args.command == "auth":
-        from beril_cli.auth_cmd import run_auth
+    if args.command == "login":
+        from beril_cli.auth_cmd import run_login
+        return run_login(token=args.token, base_url=args.base_url, status=args.status)
 
-        return run_auth(args)
+    if args.command == "logout":
+        from beril_cli.auth_cmd import run_logout
+        return run_logout()
 
     if args.command == "runtime-snapshot":
         from beril_cli.audit_cmd import run_runtime_snapshot

--- a/beril_cli/cli.py
+++ b/beril_cli/cli.py
@@ -103,6 +103,31 @@ def main(argv: list[str] | None = None) -> int:
         help = "Log out of BERIL server, deletes local BERIL auth credentials"
     )
 
+    # ov — link/inspect/export the OpenViking credential (login links it too)
+    ov_parser = sub.add_parser(
+        "ov",
+        help="Link, inspect, or export your OpenViking credential",
+    )
+    ov_sub = ov_parser.add_subparsers(dest="ov_action", required=True)
+    ov_setup = ov_sub.add_parser(
+        "setup",
+        help="Link OpenViking against your stored login (repair / rotation path)",
+    )
+    ov_setup.add_argument(
+        "--regenerate",
+        action="store_true",
+        default=False,
+        help="Mint a fresh OpenViking key, invalidating the old one",
+    )
+    ov_sub.add_parser(
+        "status",
+        help="Show the cached OpenViking credential and probe server health",
+    )
+    ov_sub.add_parser(
+        "print-env",
+        help='Emit OPENVIKING_URL / OPENVIKING_API_KEY (eval "$(beril ov print-env)")',
+    )
+
     # runtime-snapshot (settings.json SessionStart hook; reads the hook payload from stdin)
     sub.add_parser(
         "runtime-snapshot",
@@ -152,6 +177,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "logout":
         from beril_cli.auth_cmd import run_logout
         return run_logout()
+
+    if args.command == "ov":
+        from beril_cli.ov_cmd import run_ov
+        return run_ov(args)
 
     if args.command == "runtime-snapshot":
         from beril_cli.audit_cmd import run_runtime_snapshot

--- a/beril_cli/cli.py
+++ b/beril_cli/cli.py
@@ -74,6 +74,35 @@ def main(argv: list[str] | None = None) -> int:
         help="Emit machine-readable JSON (summary action)",
     )
 
+    # auth
+    auth_parser = sub.add_parser(
+        "auth",
+        help="Log in to a BERIL server with a personal access token",
+    )
+    auth_parser.add_argument(
+        "action",
+        choices=["login", "status", "logout"],
+        help="login pastes/validates a token; status shows the stored login; logout removes it",
+    )
+    auth_parser.add_argument(
+        "--token",
+        default=None,
+        metavar="TOKEN",
+        help="Provide the token directly instead of the interactive paste prompt (login only)",
+    )
+    auth_parser.add_argument(
+        "--base-url",
+        default=None,
+        metavar="URL",
+        help="Server base URL for login; persisted to ~/.config/beril/config.toml (login only)",
+    )
+    auth_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit machine-readable JSON (status only; token is redacted)",
+    )
+
     # runtime-snapshot (settings.json SessionStart hook; reads the hook payload from stdin)
     sub.add_parser(
         "runtime-snapshot",
@@ -115,6 +144,11 @@ def main(argv: list[str] | None = None) -> int:
         from beril_cli.claims_cmd import run_claims
 
         return run_claims(args)
+
+    if args.command == "auth":
+        from beril_cli.auth_cmd import run_auth
+
+        return run_auth(args)
 
     if args.command == "runtime-snapshot":
         from beril_cli.audit_cmd import run_runtime_snapshot

--- a/beril_cli/config.py
+++ b/beril_cli/config.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import os
 import tomllib
 from pathlib import Path
 from typing import Any
 
 CONFIG_DIR = Path.home() / ".config" / "beril"
 CONFIG_PATH = CONFIG_DIR / "config.toml"
+
+DEFAULT_BASE_URL = "https://beril.kbase.us"
 
 
 def load() -> dict[str, Any]:
@@ -54,6 +57,14 @@ def save(cfg: dict[str, Any]) -> None:
                 lines.append(f'{key} = "{_toml_escape(val)}"')
         lines.append("")
 
+    if "beril" in cfg:
+        lines.append("[beril]")
+        for key in ("base_url",):
+            val = cfg["beril"].get(key, "")
+            if val:
+                lines.append(f'{key} = "{_toml_escape(val)}"')
+        lines.append("")
+
     CONFIG_PATH.write_text("\n".join(lines) + "\n")
 
 
@@ -67,3 +78,32 @@ def get_vertex_config() -> dict[str, Any]:
     """Return the [vertex] section, or empty dict if not configured."""
     cfg = load()
     return cfg.get("vertex", {})
+
+
+def get_base_url() -> str:
+    """Return the BERIL server base URL.
+
+    Resolution order:
+      1. BERIL_BASE_URL env var (per-invocation override).
+      2. [beril].base_url in config.toml (persisted preference).
+      3. DEFAULT_BASE_URL compiled in above.
+
+    Trailing slashes are stripped so callers can safely concatenate a
+    path like "/api/user/whoami".
+    """
+    url = os.environ.get("BERIL_BASE_URL") or ""
+    if not url:
+        cfg = load()
+        url = cfg.get("beril", {}).get("base_url") or ""
+    if not url:
+        url = DEFAULT_BASE_URL
+    return url.rstrip("/")
+
+
+def set_base_url(base_url: str) -> None:
+    """Persist ``base_url`` under [beril] in config.toml, preserving other
+    sections. Trailing slashes are stripped for consistency with
+    :func:`get_base_url`."""
+    cfg = load()
+    cfg.setdefault("beril", {})["base_url"] = base_url.rstrip("/")
+    save(cfg)

--- a/beril_cli/ov_client.py
+++ b/beril_cli/ov_client.py
@@ -1,0 +1,126 @@
+"""Fetch a user's OpenViking (OV) credential from BERIL with a Bearer PAT.
+
+BERIL brokers OV credentials: an authenticated user POSTs ``/api/ov/user`` to
+provision their OV account (idempotent) and GETs ``/api/ov/credentials`` to read
+back the OV url + user_key. This module wraps that two-step exchange using the
+stored personal access token, so ``beril login`` and ``beril ov`` share one
+implementation instead of each re-deriving the endpoint/error handling.
+
+Auth is ``Authorization: Bearer <token>`` — the same header ``_whoami`` uses.
+This is the headless replacement for the browser-cookie flow in
+``knowledge/scripts/setup_remote_ov.py``.
+
+Uses httpx (already a beril-cli dependency) for the same Cloudflare-UA reason
+documented in ``auth_cmd``.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+_USER_PATH = "/api/ov/user"
+_REGENERATE_PATH = "/api/ov/user/regenerate"
+_CREDENTIALS_PATH = "/api/ov/credentials"
+_HTTP_TIMEOUT_SECONDS = 15.0
+
+
+class OvLinkError(Exception):
+    """An OpenViking credential exchange failed. Message is user-facing.
+
+    ``needs_regenerate`` marks the specific recoverable case where OpenViking
+    already has a user for this ORCiD but BERIL holds no key for it (HTTP 409
+    from ``POST /api/ov/user``) — the caller should point the user at
+    ``beril ov setup --regenerate``.
+    """
+
+    def __init__(self, msg: str, *, needs_regenerate: bool = False) -> None:
+        super().__init__(msg)
+        self.needs_regenerate = needs_regenerate
+
+
+def fetch_ov_credential(
+    base_url: str, token: str, *, regenerate: bool = False
+) -> tuple[str, str]:
+    """Provision (or rotate) and return ``(ov_url, ov_user_key)``.
+
+    With ``regenerate=False`` (default), POSTs ``/api/ov/user`` — idempotent, so
+    a user who already has a stored key just gets it back. With
+    ``regenerate=True``, POSTs ``/api/ov/user/regenerate`` to mint a fresh key
+    (invalidating the old one) — the recovery path for the 409 case and for key
+    rotation. Either way, the key is then read via ``GET /api/ov/credentials``.
+
+    The returned ``ov_url`` is always ``{base_url}/ov`` — the public proxy path
+    the client already reached BERIL on. We deliberately ignore the ``ov_url``
+    in BERIL's response: that field is ``settings.ov_url``, the address BERIL
+    uses to reach OpenViking *server-to-server* (e.g. ``http://openviking:1933``
+    inside a compose/SPIN network), which is not resolvable from the client.
+
+    Raises :class:`OvLinkError` on any failure, with a message suitable for
+    printing to the user.
+    """
+    base = base_url.rstrip("/")
+    ov_url = f"{base}/ov"
+    with httpx.Client(
+        timeout=_HTTP_TIMEOUT_SECONDS,
+        headers={"Authorization": f"Bearer {token}"},
+    ) as client:
+        if regenerate:
+            resp = _request(client, "POST", base + _REGENERATE_PATH)
+            _guard(resp, action="regenerate your OpenViking key")
+        else:
+            resp = _request(client, "POST", base + _USER_PATH)
+            if resp.status_code == 409:
+                raise OvLinkError(
+                    "OpenViking already has a user for your ORCiD, but BERIL "
+                    "holds no key for it.",
+                    needs_regenerate=True,
+                )
+            _guard(resp, action="create your OpenViking account")
+
+        creds = _request(client, "GET", base + _CREDENTIALS_PATH)
+        _guard(creds, action="fetch your OpenViking credentials")
+
+    try:
+        body = creds.json()
+    except ValueError as e:
+        raise OvLinkError("BERIL returned invalid JSON for OpenViking credentials.") from e
+
+    # Only the key comes from the response; the URL is the proxy path derived
+    # from base_url above (BERIL's response ov_url is its internal address).
+    user_key = (body or {}).get("user_key")
+    if not user_key:
+        raise OvLinkError(
+            "BERIL did not return an OpenViking user_key."
+        )
+    return (ov_url, user_key)
+
+
+def _request(client: httpx.Client, method: str, url: str) -> httpx.Response:
+    try:
+        return client.request(method, url)
+    except httpx.TimeoutException as e:
+        raise OvLinkError(f"timed out talking to {url}.") from e
+    except httpx.TransportError as e:
+        raise OvLinkError(f"could not reach {url}: {e}") from e
+
+
+def _guard(response: httpx.Response, *, action: str) -> None:
+    """Raise :class:`OvLinkError` unless the response is a success."""
+    if response.is_success:
+        return
+    if response.status_code == 401:
+        raise OvLinkError(
+            f"your token was rejected (401) while trying to {action}."
+        )
+    raise OvLinkError(f"failed to {action}: {_detail(response)}")
+
+
+def _detail(response: httpx.Response) -> str:
+    """Best-effort human-readable reason from a failed response body."""
+    try:
+        body = response.json()
+    except ValueError:
+        return response.text.strip()[:200] or f"HTTP {response.status_code}"
+    if isinstance(body, dict) and body.get("detail"):
+        return str(body["detail"])
+    return f"HTTP {response.status_code}"

--- a/beril_cli/ov_client.py
+++ b/beril_cli/ov_client.py
@@ -21,6 +21,7 @@ import httpx
 _USER_PATH = "/api/ov/user"
 _REGENERATE_PATH = "/api/ov/user/regenerate"
 _CREDENTIALS_PATH = "/api/ov/credentials"
+_HEALTH_PATH = "/api/ov/health"
 _HTTP_TIMEOUT_SECONDS = 15.0
 
 
@@ -93,6 +94,26 @@ def fetch_ov_credential(
             "BERIL did not return an OpenViking user_key."
         )
     return (ov_url, user_key)
+
+
+def ov_health(base_url: str, token: str) -> dict:
+    """Return BERIL's view of OpenViking health via ``GET /api/ov/health``.
+
+    The route always answers 200 with ``{"status": "ok"|"unreachable", ...}``
+    when the caller is authenticated. Raises :class:`OvLinkError` on transport
+    failure or a non-2xx (e.g. 401).
+    """
+    base = base_url.rstrip("/")
+    with httpx.Client(
+        timeout=_HTTP_TIMEOUT_SECONDS,
+        headers={"Authorization": f"Bearer {token}"},
+    ) as client:
+        resp = _request(client, "GET", base + _HEALTH_PATH)
+        _guard(resp, action="check OpenViking health")
+    try:
+        return resp.json()
+    except ValueError as e:
+        raise OvLinkError("BERIL returned invalid JSON for OpenViking health.") from e
 
 
 def _request(client: httpx.Client, method: str, url: str) -> httpx.Response:

--- a/beril_cli/ov_cmd.py
+++ b/beril_cli/ov_cmd.py
@@ -1,0 +1,123 @@
+"""beril ov — link, inspect, and export the OpenViking (OV) credential.
+
+`beril login` already links OV in the happy path (see auth_cmd). This command
+covers the cases login intentionally doesn't force:
+
+  beril ov setup                re-link OV against the stored PAT (repair path:
+                                login couldn't reach OV, or an old auth.json
+                                predates OV linking).
+  beril ov setup --regenerate   mint a fresh OV key (invalidates the old one) —
+                                the recovery path for the 409 "key exists but
+                                BERIL holds none" case, and for key rotation.
+  beril ov status               show the cached OV credential and probe health.
+  beril ov print-env            emit OPENVIKING_URL / OPENVIKING_API_KEY lines
+                                for `.env` or `eval "$(beril ov print-env)"`.
+
+All of these reuse the stored BERIL PAT (~/.beril/auth.json) — no browser
+cookie. The credential exchange itself lives in ov_client, shared with login.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from beril_cli import auth_store
+from beril_cli.ov_client import OvLinkError, fetch_ov_credential, ov_health
+
+
+def run_ov(args: argparse.Namespace) -> int:
+    action = getattr(args, "ov_action", None)
+    if action == "setup":
+        return _run_setup(regenerate=args.regenerate)
+    if action == "status":
+        return _run_status()
+    if action == "print-env":
+        return _run_print_env()
+    # argparse is configured with required subcommands, so this is unreachable
+    # in normal dispatch; guard anyway.
+    print("Usage: beril ov {setup|status|print-env}", file=sys.stderr)
+    return 1
+
+
+def _require_login() -> auth_store.AuthRecord | None:
+    record = auth_store.load()
+    if record is None:
+        print("Not logged in. Run `beril login` first.", file=sys.stderr)
+        return None
+    return record
+
+
+def _run_setup(*, regenerate: bool) -> int:
+    record = _require_login()
+    if record is None:
+        return 1
+
+    try:
+        ov_url, ov_user_key = fetch_ov_credential(
+            record.base_url, record.token, regenerate=regenerate
+        )
+    except OvLinkError as e:
+        print(f"OpenViking setup failed: {e}", file=sys.stderr)
+        if e.needs_regenerate:
+            print(
+                "Run `beril ov setup --regenerate` to mint a fresh key.",
+                file=sys.stderr,
+            )
+        return 1
+
+    # Re-persist the full record so the BERIL token/identity are preserved and
+    # only the OV fields change.
+    auth_store.save(
+        token=record.token,
+        base_url=record.base_url,
+        orcid_id=record.orcid_id,
+        display_name=record.display_name,
+        ov_url=ov_url,
+        ov_user_key=ov_user_key,
+    )
+    verb = "regenerated" if regenerate else "linked"
+    print(f"OpenViking {verb} ({_mask(ov_user_key)}). URL: {ov_url}")
+    return 0
+
+
+def _run_status() -> int:
+    record = _require_login()
+    if record is None:
+        return 1
+
+    if not record.ov_url or not record.ov_user_key:
+        print("OpenViking is not linked. Run `beril ov setup` to link it.")
+        # Not an error state per se, but scripts should be able to tell.
+        return 1
+
+    print(f"OpenViking URL: {record.ov_url}")
+    print(f"API key:        {_mask(record.ov_user_key)}")
+
+    # Best-effort health probe — never let it fail the command.
+    try:
+        body = ov_health(record.base_url, record.token)
+        status = body.get("status", "unknown")
+        print(f"Server health:  {status}")
+    except OvLinkError as e:
+        print(f"Server health:  unknown ({e})")
+    return 0
+
+
+def _run_print_env() -> int:
+    creds = auth_store.load_ov()
+    if creds is None:
+        print(
+            "OpenViking is not linked. Run `beril login` or `beril ov setup` first.",
+            file=sys.stderr,
+        )
+        return 1
+    ov_url, ov_user_key = creds
+    print(f"OPENVIKING_URL={ov_url}")
+    print(f"OPENVIKING_API_KEY={ov_user_key}")
+    return 0
+
+
+def _mask(secret: str) -> str:
+    """Show only the last 4 chars of a secret for confirmation output."""
+    return f"…{secret[-4:]}" if len(secret) > 4 else "set"

--- a/docs/remote-openviking-setup.md
+++ b/docs/remote-openviking-setup.md
@@ -1,106 +1,81 @@
 # Remote OpenViking — New User Setup
 
 The BERIL knowledge context layer (project reports + central docs, searchable
-with `knowledge_query.py`) runs on a shared **remote OpenViking server**. This
-is a one-time setup: you exchange your BERIL login for an OpenViking API key,
-put it in `.env`, and then query freely — you don't need to run a local server.
+with `knowledge_query.py`) runs on a shared **remote OpenViking server**. Setup
+is a single command: `beril login` validates your BERIL token and, in the same
+step, provisions and caches your OpenViking credential — after that you can
+query freely without running a local server.
 
 > ⚠️ **The server currently runs on the dev host `https://beril-dev.kbase.us`.**
 > This is temporary. When OpenViking moves to production, substitute the new
-> base URL everywhere below (or pass `--server <url>` to the helper). Every
-> example uses a single `SERVER=` line so there's exactly one place to change.
-
-```bash
-SERVER=https://beril-dev.kbase.us     # ← the only host-specific value
-```
+> base URL (or pass `--base-url <url>` to `beril login`).
 
 ## Prerequisites
 
-- The repo cloned, with `uv` installed.
-- A `.env` file: `cp .env.example .env` if you don't have one.
-- An ORCiD you can log in with.
+- The repo cloned, with `uv` installed, and the `beril` CLI available.
+- An ORCiD you can log in with, and a BERIL personal access token (create one at
+  `https://beril-dev.kbase.us/account/tokens`).
 
 ## Step 1 — Log in
 
-Open **`https://beril-dev.kbase.us`** in your browser and log in with your
-ORCiD. Logging in sets a session cookie named **`beril_session`**.
-
-## Step 2 — Copy your `beril_session` cookie
-
-The server identifies you by that cookie. It's `HttpOnly` (not readable from
-JavaScript), but you can copy it from your browser's dev tools:
-
-- **Chrome/Edge:** DevTools (`F12` / `Cmd-Opt-I`) → **Application** tab →
-  **Storage → Cookies → `https://beril-dev.kbase.us`** → click `beril_session`
-  → copy its **Value**.
-- **Firefox:** DevTools → **Storage** tab → **Cookies** → select the site →
-  copy the `beril_session` value.
-
-The value is a long opaque string — copy the whole thing.
-
-## Step 3 — Get your API key
-
-### Option A — helper script (recommended)
-
 ```bash
-uv run knowledge/scripts/setup_remote_ov.py --cookie '<paste beril_session value>'
+beril login --base-url https://beril-dev.kbase.us
 ```
 
-It creates your OpenViking account (idempotent), fetches your key, writes
-`OPENVIKING_URL` and `OPENVIKING_API_KEY` into `.env`, and verifies the
-connection. Useful flags:
+Paste your personal access token when prompted (input doesn't echo), or pass it
+with `--token`. `beril login` then:
 
-- `--server "$SERVER"` — point at a different host (default is beril-dev).
-- `--regenerate` — mint a fresh key, invalidating the old one (rotation, or the
-  recovery path if you hit the 409 case below).
-- `--print-only` — print the two env lines instead of writing `.env`.
-- The cookie can also come from `$BERIL_SESSION` or an interactive prompt.
+1. validates the token against BERIL, and
+2. provisions your OpenViking account (idempotent) and **caches the OpenViking
+   URL + key in `~/.beril`** alongside your BERIL login.
 
-### Option B — manual (curl)
+That cached credential is what the query CLI reads — no browser cookie, no
+manual `.env` editing.
 
-The key comes from **two** calls: create the account, then read the credential.
-
-```bash
-COOKIE='<paste beril_session value>'
-
-# 1. Create your OpenViking account (idempotent — safe to re-run).
-curl -X POST "$SERVER/api/ov/user" -H "Cookie: beril_session=$COOKIE"
-
-# 2. Read your key (note: GET, not POST).
-curl "$SERVER/api/ov/credentials" -H "Cookie: beril_session=$COOKIE" \
-  | jq -r .user_key
-```
-
-> The key is **not** returned by `POST /api/ov/user` (that returns
-> `{"created": true}`). You always retrieve it with **`GET /api/ov/credentials`**.
-
-Then put both values in `.env` (note the `/ov` suffix on the URL):
-
-```bash
-OPENVIKING_URL=https://beril-dev.kbase.us/ov
-OPENVIKING_API_KEY=<the user_key from step 2>
-```
-
-## Step 4 — Verify
+## Step 2 — Verify
 
 ```bash
 # Reachability + auth check — tells server-down apart from a bad key.
-uv run --env-file .env knowledge/scripts/knowledge_query.py doctor
+uv run knowledge/scripts/knowledge_query.py doctor
 
 # A real query.
-uv run --env-file .env knowledge/scripts/knowledge_query.py find "metal resistance"
+uv run knowledge/scripts/knowledge_query.py find "metal resistance"
 ```
 
-A healthy `doctor` prints `OpenViking: OK`. After this, you never need the cookie
-again — queries talk directly to the server with your API key, which is
-long-lived until you regenerate it.
+A healthy `doctor` prints `OpenViking: OK`. No `--env-file` is required — the
+query CLI resolves the credential from `~/.beril`.
+
+## If OpenViking wasn't linked at login
+
+`beril login` links OpenViking best-effort: if the server was briefly
+unreachable (or you logged in before this was wired up), the login still
+succeeds but OpenViking is left unlinked. Link it separately against your stored
+token:
+
+```bash
+beril ov setup              # link now (idempotent)
+beril ov status             # show the cached credential + server health
+```
 
 ## Recovery & rotation
 
-- **Lost your key?** Re-run the helper (or `GET /api/ov/credentials`) — it
-  returns the same stored key; nothing is invalidated.
-- **Rotate / force a fresh key?** `setup_remote_ov.py --cookie '...' --regenerate`
-  (this invalidates the old key everywhere it's in use).
+- **Check what's cached:** `beril ov status`.
+- **Rotate / force a fresh key:** `beril ov setup --regenerate` (this
+  invalidates the old key everywhere it's in use). This is also the recovery
+  path for the 409 case below.
+- **Populate `.env` instead** (CI, or a tool that reads env vars):
+  `eval "$(beril ov print-env)"`, or paste the `beril ov print-env` output into
+  `.env`.
+
+## Configuration precedence
+
+`ContextConfig.from_env` resolves the OpenViking credential in this order:
+
+1. **Explicit env vars** — `OPENVIKING_URL` / `OPENVIKING_API_KEY` (from the
+   shell or an `--env-file`). These always win, so CI and "point at a different
+   server" keep working.
+2. **The `~/.beril` cached credential** from `beril login` / `beril ov setup`.
+3. **The local default URL** (`http://127.0.0.1:1933`) with no key.
 
 ## Troubleshooting
 
@@ -109,27 +84,29 @@ Run `knowledge_query.py doctor` first — its verdict tells you what's wrong:
 | Verdict | Meaning | Fix |
 |---|---|---|
 | `OK` | Reachable, key valid | — |
-| `UNREACHABLE` | Server down or wrong URL | Check `OPENVIKING_URL` ends in `/ov`; confirm `$SERVER/ov/health` responds in a browser; check network/VPN |
-| `NO API KEY` | Reachable, but `OPENVIKING_API_KEY` unset | Run the setup helper (Step 3) |
-| `AUTH FAILED` | Reachable, but your key was rejected | Key expired/invalid → `setup_remote_ov.py --regenerate` |
+| `UNREACHABLE` | Server down or wrong URL | Confirm `$SERVER/ov/health` responds in a browser; check network/VPN |
+| `NO API KEY` | Reachable, but no key resolved | Run `beril ov setup` (or `beril login`) |
+| `AUTH FAILED` | Reachable, but your key was rejected | Key expired/invalid → `beril ov setup --regenerate` |
 | `UNHEALTHY` | Reachable, but the server reports itself unhealthy | Server-side — flag a maintainer / check the OV deployment |
 | `ERROR` | Reachable, but an authenticated call failed unexpectedly | Retry; if it persists, check the OV server logs |
 
 Other cases:
 
-- **`HTTP 401` from a curl/helper call** — your `beril_session` cookie is
-  missing or expired. Log in again (Step 1) and re-copy it (Step 2).
-- **`HTTP 409` on `POST /api/ov/user`** — OpenViking already has a user for your
-  ORCiD but BERIL holds no key for it. Run `setup_remote_ov.py --regenerate` (or
-  `POST /api/ov/user/regenerate` then `GET /api/ov/credentials`).
+- **`Not logged in`** — run `beril login` first.
+- **OpenViking not linked after login** — the server was unreachable during
+  login; run `beril ov setup`.
+- **`HTTP 409` / "key exists but BERIL holds none"** — OpenViking already has a
+  user for your ORCiD but BERIL holds no key for it. Run
+  `beril ov setup --regenerate` to mint and store a fresh key.
 - **Quick server liveness, no auth needed:** `curl "$SERVER/ov/health"` should
   return `{"status":"ok","healthy":true,...}`.
 
 ## Security
 
-`OPENVIKING_API_KEY` is a secret. `.env` and `*.env` are gitignored — keep the
-key there, never commit it, and **never paste it into a chat**. If it leaks,
-rotate it with `--regenerate`.
+`OPENVIKING_API_KEY` is a secret. The cached copy in `~/.beril/auth.json` is
+written mode `0600`. If you populate `.env`, note that `.env` and `*.env` are
+gitignored — never commit the key, and **never paste it into a chat**. If it
+leaks, rotate it with `beril ov setup --regenerate`.
 
 ## See also
 

--- a/knowledge/tests/test_config.py
+++ b/knowledge/tests/test_config.py
@@ -1,0 +1,93 @@
+"""Tests for ContextConfig.from_env credential resolution.
+
+Precedence: explicit env vars win, then the credential cached by
+`beril login` / `beril ov setup` in ~/.beril, then the local default URL.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from observatory_context import config as ovcfg
+from observatory_context.config import DEFAULT_OPENVIKING_URL, ContextConfig
+
+
+@pytest.fixture(autouse=True)
+def clear_ov_env(monkeypatch):
+    """Start each test from a known state — no OV env vars set."""
+    monkeypatch.delenv("OPENVIKING_URL", raising=False)
+    monkeypatch.delenv("OPENVIKING_API_KEY", raising=False)
+
+
+def _patch_cache(monkeypatch, value):
+    """Stub the ~/.beril cached-credential lookup."""
+    monkeypatch.setattr(ovcfg, "_cached_ov_credential", lambda: value)
+
+
+class TestFromEnvPrecedence:
+    def test_env_vars_win(self, monkeypatch):
+        monkeypatch.setenv("OPENVIKING_URL", "https://env/ov")
+        monkeypatch.setenv("OPENVIKING_API_KEY", "env_key")
+        _patch_cache(monkeypatch, ("https://cached/ov", "cached_key"))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == "https://env/ov"
+        assert cfg.openviking_api_key == "env_key"
+
+    def test_falls_back_to_cached_credential(self, monkeypatch):
+        _patch_cache(monkeypatch, ("https://cached/ov", "cached_key"))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == "https://cached/ov"
+        assert cfg.openviking_api_key == "cached_key"
+
+    def test_default_url_when_nothing_available(self, monkeypatch):
+        _patch_cache(monkeypatch, (None, None))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == DEFAULT_OPENVIKING_URL
+        assert cfg.openviking_api_key is None
+
+    def test_env_url_with_cached_key_do_not_mix_when_both_env_present(
+        self, monkeypatch
+    ):
+        # If only the URL is set in the env, the key is drawn from the cache —
+        # partial env config still gets completed from ~/.beril.
+        monkeypatch.setenv("OPENVIKING_URL", "https://env/ov")
+        _patch_cache(monkeypatch, ("https://cached/ov", "cached_key"))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == "https://env/ov"
+        assert cfg.openviking_api_key == "cached_key"
+
+
+class TestCachedCredentialImportGuard:
+    def test_returns_none_pair_when_beril_cli_absent(self, monkeypatch):
+        # Simulate an environment where beril_cli isn't importable.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name.startswith("beril_cli"):
+                raise ImportError("no beril_cli here")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+        assert ovcfg._cached_ov_credential() == (None, None)
+
+    def test_returns_none_pair_when_not_linked(self, monkeypatch):
+        from beril_cli import auth_store
+
+        monkeypatch.setattr(auth_store, "load_ov", lambda: None)
+        assert ovcfg._cached_ov_credential() == (None, None)
+
+    def test_returns_pair_from_auth_store(self, monkeypatch):
+        from beril_cli import auth_store
+
+        monkeypatch.setattr(
+            auth_store, "load_ov", lambda: ("https://srv/ov", "k")
+        )
+        assert ovcfg._cached_ov_credential() == ("https://srv/ov", "k")

--- a/observatory_context/config.py
+++ b/observatory_context/config.py
@@ -10,6 +10,23 @@ PROJECTS_TARGET_URI = "viking://resources/projects/"
 DOCS_TARGET_URI = "viking://resources/docs/"
 
 
+def _cached_ov_credential() -> tuple[str | None, str | None]:
+    """Return ``(ov_url, ov_user_key)`` cached by ``beril login`` / ``beril ov``.
+
+    Reads ~/.beril/auth.json via ``beril_cli.auth_store``. The import is guarded
+    so ``observatory_context`` keeps working in environments where ``beril_cli``
+    isn't on the path (returns ``(None, None)`` — same as no cached credential).
+    """
+    try:
+        from beril_cli import auth_store
+    except ImportError:
+        return (None, None)
+    creds = auth_store.load_ov()
+    if creds is None:
+        return (None, None)
+    return creds
+
+
 @dataclass(frozen=True)
 class ContextConfig:
     repo_root: Path
@@ -19,10 +36,22 @@ class ContextConfig:
     @classmethod
     def from_env(cls, repo_root: Path | None = None) -> "ContextConfig":
         root = repo_root or Path(__file__).resolve().parents[1]
+
+        # Precedence: explicit env vars win (CI, `--env-file .env`, manual
+        # export), then fall back to the credential `beril login` / `beril ov
+        # setup` cached in ~/.beril. This lets the query CLI work with no
+        # env-file once the user has logged in.
+        url = os.getenv("OPENVIKING_URL")
+        key = os.getenv("OPENVIKING_API_KEY")
+        if not url or not key:
+            cached_url, cached_key = _cached_ov_credential()
+            url = url or cached_url
+            key = key or cached_key
+
         return cls(
             repo_root=root,
-            openviking_url=os.getenv("OPENVIKING_URL", DEFAULT_OPENVIKING_URL),
-            openviking_api_key=os.getenv("OPENVIKING_API_KEY"),
+            openviking_url=url or DEFAULT_OPENVIKING_URL,
+            openviking_api_key=key,
         )
 
     def __post_init__(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "BERIL Research Observatory — CLI launcher and environment manager"
 requires-python = ">=3.11"
 license = "MIT"
-dependencies = []
+dependencies = ["httpx", "certifi"]
 
 [project.scripts]
 beril = "beril_cli.cli:main"

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import argparse
-import io
 import json
-import os
 import stat
 import sys
-import urllib.error
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
+import httpx
 import pytest
 
 from beril_cli import auth_cmd, auth_store, config
@@ -52,13 +50,17 @@ def _ns(**kwargs) -> argparse.Namespace:
     return argparse.Namespace(**defaults)
 
 
-def _mock_whoami_response(body: dict, status: int = 200):
-    """Build a context-manager-shaped mock for urlopen returning the given body."""
-    mock_resp = MagicMock()
-    mock_resp.read.return_value = json.dumps(body).encode()
-    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
-    mock_resp.__exit__ = MagicMock(return_value=False)
-    return mock_resp
+def _httpx_response(body: dict | str, status: int = 200) -> httpx.Response:
+    """Build a real httpx.Response so res.status_code / res.json() behave normally.
+
+    ``body`` as dict -> JSON-serialized; as str -> raw text (used to test
+    the invalid-JSON path).
+    """
+    if isinstance(body, dict):
+        content = json.dumps(body).encode()
+    else:
+        content = body.encode()
+    return httpx.Response(status_code=status, content=content)
 
 
 # ---------------------------------------------------------------------------
@@ -185,12 +187,10 @@ class TestAuthLogin:
     def test_login_with_token_flag_saves_record(
         self, tmp_auth, tmp_config, capsys
     ):
-        response = _mock_whoami_response(
+        response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
         )
-        with patch(
-            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
-        ):
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
             rc = run_auth(
                 _ns(
                     action="login",
@@ -210,12 +210,10 @@ class TestAuthLogin:
         assert record["orcid_id"] == "0000-0001-2345-6789"
 
     def test_login_persists_base_url_flag(self, tmp_auth, tmp_config):
-        response = _mock_whoami_response(
+        response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": None}
         )
-        with patch(
-            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
-        ):
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
             run_auth(
                 _ns(
                     action="login",
@@ -229,12 +227,12 @@ class TestAuthLogin:
     def test_login_hits_correct_whoami_url_with_bearer_header(
         self, tmp_auth, tmp_config
     ):
-        response = _mock_whoami_response(
+        response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": None}
         )
         with patch(
-            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
-        ) as mock_urlopen:
+            "beril_cli.auth_cmd.httpx.get", return_value=response
+        ) as mock_get:
             run_auth(
                 _ns(
                     action="login",
@@ -242,19 +240,16 @@ class TestAuthLogin:
                     base_url="https://srv.example.test",
                 )
             )
-        req = mock_urlopen.call_args.args[0]
-        assert req.full_url == "https://srv.example.test/api/user/whoami"
-        assert req.headers["Authorization"] == "Bearer beril_abc"
+        # httpx.get(url, headers=..., timeout=...) — url is positional.
+        call = mock_get.call_args
+        assert call.args[0] == "https://srv.example.test/api/user/whoami"
+        assert call.kwargs["headers"]["Authorization"] == "Bearer beril_abc"
 
     def test_login_401_prints_error_and_does_not_save(
         self, tmp_auth, tmp_config, capsys
     ):
-        err = urllib.error.HTTPError(
-            "url", 401, "Unauthorized", hdrs=None, fp=io.BytesIO(b"")
-        )
-        with patch(
-            "beril_cli.auth_cmd.urllib.request.urlopen", side_effect=err
-        ):
+        response = _httpx_response({"detail": "Unauthorized"}, status=401)
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
             rc = run_auth(
                 _ns(
                     action="login",
@@ -267,13 +262,44 @@ class TestAuthLogin:
         assert "401" in captured.err or "rejected" in captured.err
         assert auth_store.load() is None
 
+    def test_login_403_prints_specific_error(
+        self, tmp_auth, tmp_config, capsys
+    ):
+        response = _httpx_response("blocked by upstream", status=403)
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_auth(
+                _ns(
+                    action="login",
+                    token="beril_abc",
+                    base_url="https://srv.example.test",
+                )
+            )
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "403" in captured.err
+        assert auth_store.load() is None
+
+    def test_login_other_4xx_5xx_status_fails(
+        self, tmp_auth, tmp_config, capsys
+    ):
+        response = _httpx_response("upstream broken", status=502)
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_auth(
+                _ns(
+                    action="login",
+                    token="beril_abc",
+                    base_url="https://srv.example.test",
+                )
+            )
+        assert rc == 1
+        assert "502" in capsys.readouterr().err
+        assert auth_store.load() is None
+
     def test_login_connection_error_reports_reason(
         self, tmp_auth, tmp_config, capsys
     ):
-        err = urllib.error.URLError("connection refused")
-        with patch(
-            "beril_cli.auth_cmd.urllib.request.urlopen", side_effect=err
-        ):
+        err = httpx.ConnectError("connection refused")
+        with patch("beril_cli.auth_cmd.httpx.get", side_effect=err):
             rc = run_auth(
                 _ns(
                     action="login",
@@ -286,14 +312,26 @@ class TestAuthLogin:
         assert "connection refused" in captured.err
         assert auth_store.load() is None
 
+    def test_login_timeout_reports_specific_message(
+        self, tmp_auth, tmp_config, capsys
+    ):
+        err = httpx.ConnectTimeout("connect timeout")
+        with patch("beril_cli.auth_cmd.httpx.get", side_effect=err):
+            rc = run_auth(
+                _ns(
+                    action="login",
+                    token="beril_abc",
+                    base_url="https://srv.example.test",
+                )
+            )
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "timed out" in captured.err
+        assert auth_store.load() is None
+
     def test_login_bad_json_response_fails(self, tmp_auth, tmp_config, capsys):
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = b"not json"
-        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        with patch(
-            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=mock_resp
-        ):
+        response = _httpx_response("not json", status=200)
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
             rc = run_auth(
                 _ns(
                     action="login",
@@ -309,10 +347,8 @@ class TestAuthLogin:
     def test_login_missing_orcid_in_response_fails(
         self, tmp_auth, tmp_config, capsys
     ):
-        response = _mock_whoami_response({"display_name": "Alice"})
-        with patch(
-            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
-        ):
+        response = _httpx_response({"display_name": "Alice"})
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
             rc = run_auth(
                 _ns(
                     action="login",
@@ -326,13 +362,11 @@ class TestAuthLogin:
     def test_login_prompts_for_token_when_not_given(
         self, tmp_auth, tmp_config, monkeypatch
     ):
-        response = _mock_whoami_response(
+        response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
         )
         monkeypatch.setattr(auth_cmd.getpass, "getpass", lambda _prompt: "beril_pasted")
-        with patch(
-            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
-        ):
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
             rc = run_auth(
                 _ns(
                     action="login",
@@ -432,12 +466,10 @@ class TestCliDispatch:
     def test_beril_auth_login_dispatches(self, tmp_auth, tmp_config):
         from beril_cli.cli import main
 
-        response = _mock_whoami_response(
+        response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
         )
-        with patch(
-            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
-        ):
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
             rc = main(
                 [
                     "auth",

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -12,6 +12,7 @@ import pytest
 
 from beril_cli import auth_cmd, auth_store, config
 from beril_cli.auth_cmd import run_login, run_logout
+from beril_cli.ov_client import OvLinkError
 
 
 # ---------------------------------------------------------------------------
@@ -40,6 +41,20 @@ def tmp_config(tmp_path, monkeypatch):
     # Also clear any base-url env var so tests start from a known baseline.
     monkeypatch.delenv("BERIL_BASE_URL", raising=False)
     return cfg_path
+
+
+@pytest.fixture
+def stub_ov(monkeypatch):
+    """Stub OpenViking linking during login so the tests that only care about
+    BERIL auth don't reach the (real) OV endpoints. Returns a fixed credential.
+
+    auth_cmd imports ``fetch_ov_credential`` by name, so we patch it there.
+    """
+    def _fake(base_url, token, *, regenerate=False):
+        return ("https://srv.example.test/ov", "ov_key_1234")
+
+    monkeypatch.setattr(auth_cmd, "fetch_ov_credential", _fake)
+    return _fake
 
 
 def _httpx_response(body: dict | str, status: int = 200) -> httpx.Response:
@@ -117,6 +132,62 @@ class TestAuthStore:
         assert record is not None
         assert record.display_name is None
 
+    def test_save_then_load_round_trips_ov_fields(self, tmp_auth):
+        auth_store.save(
+            token="t",
+            base_url="u",
+            orcid_id="0",
+            display_name=None,
+            ov_url="https://srv/ov",
+            ov_user_key="ovk",
+        )
+        record = auth_store.load()
+        assert record.ov_url == "https://srv/ov"
+        assert record.ov_user_key == "ovk"
+
+    def test_ov_fields_default_to_none(self, tmp_auth):
+        auth_store.save(token="t", base_url="u", orcid_id="0", display_name=None)
+        record = auth_store.load()
+        assert record.ov_url is None
+        assert record.ov_user_key is None
+
+    def test_old_file_without_ov_fields_still_loads(self, tmp_auth):
+        # Pre-OV auth.json — must remain readable (logged-in, OV unlinked).
+        tmp_auth.parent.mkdir(parents=True)
+        tmp_auth.write_text(
+            json.dumps(
+                {
+                    "token": "t",
+                    "base_url": "u",
+                    "orcid_id": "0",
+                    "display_name": "Alice",
+                }
+            )
+        )
+        record = auth_store.load()
+        assert record is not None
+        assert record.token == "t"
+        assert record.ov_url is None
+        assert record.ov_user_key is None
+
+    def test_load_ov_returns_pair_when_present(self, tmp_auth):
+        auth_store.save(
+            token="t",
+            base_url="u",
+            orcid_id="0",
+            display_name=None,
+            ov_url="https://srv/ov",
+            ov_user_key="ovk",
+        )
+        assert auth_store.load_ov() == ("https://srv/ov", "ovk")
+
+    def test_load_ov_returns_none_when_not_logged_in(self, tmp_auth):
+        assert auth_store.load_ov() is None
+
+    def test_load_ov_returns_none_when_ov_unlinked(self, tmp_auth):
+        auth_store.save(token="t", base_url="u", orcid_id="0", display_name=None)
+        assert auth_store.load_ov() is None
+
     def test_clear_is_idempotent_when_missing(self, tmp_auth):
         # Should not raise
         auth_store.clear()
@@ -177,7 +248,7 @@ class TestBaseUrlResolution:
 
 class TestAuthLogin:
     def test_login_with_token_flag_saves_record(
-        self, tmp_auth, tmp_config, capsys
+        self, tmp_auth, tmp_config, stub_ov, capsys
     ):
         response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
@@ -198,7 +269,7 @@ class TestAuthLogin:
         assert record.base_url == "https://srv.example.test"
         assert record.orcid_id == "0000-0001-2345-6789"
 
-    def test_login_persists_base_url_flag(self, tmp_auth, tmp_config):
+    def test_login_persists_base_url_flag(self, tmp_auth, tmp_config, stub_ov):
         response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": None}
         )
@@ -211,7 +282,7 @@ class TestAuthLogin:
         assert config.get_base_url() == "https://srv.example.test"
 
     def test_login_hits_correct_whoami_url_with_bearer_header(
-        self, tmp_auth, tmp_config
+        self, tmp_auth, tmp_config, stub_ov
     ):
         response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": None}
@@ -227,6 +298,62 @@ class TestAuthLogin:
         call = mock_get.call_args
         assert call.args[0] == "https://srv.example.test/api/user/whoami"
         assert call.kwargs["headers"]["Authorization"] == "Bearer beril_abc"
+
+    def test_login_caches_ov_credential(
+        self, tmp_auth, tmp_config, stub_ov, capsys
+    ):
+        response = _httpx_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
+        )
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_login(token="beril_abc", base_url="https://srv.example.test")
+        assert rc == 0
+        record = auth_store.load()
+        assert record.ov_url == "https://srv.example.test/ov"
+        assert record.ov_user_key == "ov_key_1234"
+        out = capsys.readouterr().out
+        # The full key is never printed — only a masked suffix.
+        assert "ov_key_1234" not in out
+
+    def test_login_when_ov_unreachable_still_succeeds(
+        self, tmp_auth, tmp_config, monkeypatch, capsys
+    ):
+        def _boom(base_url, token, *, regenerate=False):
+            raise OvLinkError("could not reach OpenViking.")
+
+        monkeypatch.setattr(auth_cmd, "fetch_ov_credential", _boom)
+        response = _httpx_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
+        )
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_login(token="beril_abc", base_url="https://srv.example.test")
+        captured = capsys.readouterr()
+        # BERIL login still succeeds and is saved; OV fields are None.
+        assert rc == 0
+        record = auth_store.load()
+        assert record is not None
+        assert record.token == "beril_abc"
+        assert record.ov_url is None
+        assert record.ov_user_key is None
+        assert "OpenViking not linked" in captured.err
+        assert "beril ov setup" in captured.err
+
+    def test_login_409_points_at_regenerate(
+        self, tmp_auth, tmp_config, monkeypatch, capsys
+    ):
+        def _conflict(base_url, token, *, regenerate=False):
+            raise OvLinkError("already exists", needs_regenerate=True)
+
+        monkeypatch.setattr(auth_cmd, "fetch_ov_credential", _conflict)
+        response = _httpx_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
+        )
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_login(token="beril_abc", base_url="https://srv.example.test")
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert auth_store.load().ov_user_key is None
+        assert "--regenerate" in captured.err
 
     def test_login_401_prints_error_and_does_not_save(
         self, tmp_auth, tmp_config, capsys
@@ -322,7 +449,7 @@ class TestAuthLogin:
         assert auth_store.load() is None
 
     def test_login_prompts_for_token_when_not_given(
-        self, tmp_auth, tmp_config, monkeypatch
+        self, tmp_auth, tmp_config, stub_ov, monkeypatch
     ):
         response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
@@ -456,7 +583,7 @@ class TestAuthLogout:
 
 
 class TestCliDispatch:
-    def test_beril_login_dispatches(self, tmp_auth, tmp_config):
+    def test_beril_login_dispatches(self, tmp_auth, tmp_config, stub_ov):
         from beril_cli.cli import main
 
         response = _httpx_response(

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -1,0 +1,465 @@
+"""Tests for `beril auth` subcommand and its supporting modules."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import stat
+import sys
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from beril_cli import auth_cmd, auth_store, config
+from beril_cli.auth_cmd import run_auth
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures — redirect on-disk paths into tmp_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_auth(tmp_path, monkeypatch):
+    """Redirect auth_store's on-disk location into tmp_path."""
+    auth_dir = tmp_path / ".beril"
+    auth_path = auth_dir / "auth.json"
+    monkeypatch.setattr(auth_store, "AUTH_DIR", auth_dir)
+    monkeypatch.setattr(auth_store, "AUTH_PATH", auth_path)
+    return auth_path
+
+
+@pytest.fixture
+def tmp_config(tmp_path, monkeypatch):
+    """Redirect config's on-disk location into tmp_path."""
+    cfg_dir = tmp_path / ".config" / "beril"
+    cfg_dir.mkdir(parents=True)
+    cfg_path = cfg_dir / "config.toml"
+    monkeypatch.setattr(config, "CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(config, "CONFIG_PATH", cfg_path)
+    # Also clear any base-url env var so tests start from a known baseline.
+    monkeypatch.delenv("BERIL_BASE_URL", raising=False)
+    return cfg_path
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    """Build a Namespace with the flags run_auth expects."""
+    defaults = {"action": None, "token": None, "base_url": None, "json": False}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _mock_whoami_response(body: dict, status: int = 200):
+    """Build a context-manager-shaped mock for urlopen returning the given body."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(body).encode()
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+# ---------------------------------------------------------------------------
+# auth_store
+# ---------------------------------------------------------------------------
+
+
+class TestAuthStore:
+    def test_load_returns_none_when_missing(self, tmp_auth):
+        assert auth_store.load() is None
+
+    def test_save_then_load_round_trip(self, tmp_auth):
+        auth_store.save(
+            token="beril_abc",
+            base_url="https://example.test",
+            orcid_id="0000-0001-2345-6789",
+            display_name="Alice",
+        )
+        record = auth_store.load()
+        assert record is not None
+        assert record["token"] == "beril_abc"
+        assert record["base_url"] == "https://example.test"
+        assert record["orcid_id"] == "0000-0001-2345-6789"
+        assert record["display_name"] == "Alice"
+
+    def test_save_creates_parent_dir(self, tmp_auth):
+        assert not tmp_auth.parent.exists()
+        auth_store.save(
+            token="t", base_url="u", orcid_id="0", display_name=None
+        )
+        assert tmp_auth.parent.is_dir()
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="POSIX file mode semantics"
+    )
+    def test_save_sets_mode_0600(self, tmp_auth):
+        auth_store.save(token="t", base_url="u", orcid_id="0", display_name=None)
+        mode = stat.S_IMODE(tmp_auth.stat().st_mode)
+        assert mode == 0o600
+
+    def test_save_overwrites_existing(self, tmp_auth):
+        auth_store.save(token="t1", base_url="u", orcid_id="0", display_name=None)
+        auth_store.save(token="t2", base_url="u", orcid_id="0", display_name=None)
+        assert auth_store.load()["token"] == "t2"
+
+    def test_load_returns_none_for_corrupt_json(self, tmp_auth):
+        tmp_auth.parent.mkdir(parents=True)
+        tmp_auth.write_text("{not json")
+        assert auth_store.load() is None
+
+    def test_load_returns_none_for_missing_required_field(self, tmp_auth):
+        tmp_auth.parent.mkdir(parents=True)
+        tmp_auth.write_text(json.dumps({"token": "t"}))  # no base_url, no orcid
+        assert auth_store.load() is None
+
+    def test_load_backfills_missing_display_name(self, tmp_auth):
+        tmp_auth.parent.mkdir(parents=True)
+        tmp_auth.write_text(
+            json.dumps({"token": "t", "base_url": "u", "orcid_id": "0"})
+        )
+        record = auth_store.load()
+        assert record is not None
+        assert record["display_name"] is None
+
+    def test_clear_is_idempotent_when_missing(self, tmp_auth):
+        # Should not raise
+        auth_store.clear()
+        auth_store.clear()
+
+    def test_clear_removes_existing_file(self, tmp_auth):
+        auth_store.save(token="t", base_url="u", orcid_id="0", display_name=None)
+        assert tmp_auth.exists()
+        auth_store.clear()
+        assert not tmp_auth.exists()
+
+
+# ---------------------------------------------------------------------------
+# config.get_base_url / set_base_url
+# ---------------------------------------------------------------------------
+
+
+class TestBaseUrlResolution:
+    def test_default_when_nothing_set(self, tmp_config):
+        assert config.get_base_url() == config.DEFAULT_BASE_URL
+
+    def test_env_var_overrides_default(self, tmp_config, monkeypatch):
+        monkeypatch.setenv("BERIL_BASE_URL", "https://env.example.test/")
+        assert config.get_base_url() == "https://env.example.test"
+
+    def test_config_file_overrides_default(self, tmp_config):
+        config.save({"beril": {"base_url": "https://cfg.example.test"}})
+        assert config.get_base_url() == "https://cfg.example.test"
+
+    def test_env_var_beats_config_file(self, tmp_config, monkeypatch):
+        config.save({"beril": {"base_url": "https://cfg.example.test"}})
+        monkeypatch.setenv("BERIL_BASE_URL", "https://env.example.test")
+        assert config.get_base_url() == "https://env.example.test"
+
+    def test_trailing_slash_is_stripped(self, tmp_config):
+        config.save({"beril": {"base_url": "https://cfg.example.test/"}})
+        assert config.get_base_url() == "https://cfg.example.test"
+
+    def test_set_base_url_persists(self, tmp_config):
+        config.set_base_url("https://new.example.test/")
+        # Reload from disk to prove persistence, not in-memory retention.
+        reloaded = config.load()
+        assert reloaded["beril"]["base_url"] == "https://new.example.test"
+
+    def test_set_base_url_preserves_other_sections(self, tmp_config):
+        config.save({"user": {"name": "Alice"}, "defaults": {"agent": "claude"}})
+        config.set_base_url("https://new.example.test")
+        reloaded = config.load()
+        assert reloaded["user"]["name"] == "Alice"
+        assert reloaded["defaults"]["agent"] == "claude"
+        assert reloaded["beril"]["base_url"] == "https://new.example.test"
+
+
+# ---------------------------------------------------------------------------
+# run_auth login
+# ---------------------------------------------------------------------------
+
+
+class TestAuthLogin:
+    def test_login_with_token_flag_saves_record(
+        self, tmp_auth, tmp_config, capsys
+    ):
+        response = _mock_whoami_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
+        )
+        with patch(
+            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
+        ):
+            rc = run_auth(
+                _ns(
+                    action="login",
+                    token="beril_abc",
+                    base_url="https://srv.example.test",
+                )
+            )
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Alice" in out
+        assert "0000-0001-2345-6789" in out
+
+        record = auth_store.load()
+        assert record is not None
+        assert record["token"] == "beril_abc"
+        assert record["base_url"] == "https://srv.example.test"
+        assert record["orcid_id"] == "0000-0001-2345-6789"
+
+    def test_login_persists_base_url_flag(self, tmp_auth, tmp_config):
+        response = _mock_whoami_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": None}
+        )
+        with patch(
+            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
+        ):
+            run_auth(
+                _ns(
+                    action="login",
+                    token="beril_abc",
+                    base_url="https://srv.example.test/",
+                )
+            )
+        # The base URL should now be persisted (trailing slash stripped).
+        assert config.get_base_url() == "https://srv.example.test"
+
+    def test_login_hits_correct_whoami_url_with_bearer_header(
+        self, tmp_auth, tmp_config
+    ):
+        response = _mock_whoami_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": None}
+        )
+        with patch(
+            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
+        ) as mock_urlopen:
+            run_auth(
+                _ns(
+                    action="login",
+                    token="beril_abc",
+                    base_url="https://srv.example.test",
+                )
+            )
+        req = mock_urlopen.call_args.args[0]
+        assert req.full_url == "https://srv.example.test/api/user/whoami"
+        assert req.headers["Authorization"] == "Bearer beril_abc"
+
+    def test_login_401_prints_error_and_does_not_save(
+        self, tmp_auth, tmp_config, capsys
+    ):
+        err = urllib.error.HTTPError(
+            "url", 401, "Unauthorized", hdrs=None, fp=io.BytesIO(b"")
+        )
+        with patch(
+            "beril_cli.auth_cmd.urllib.request.urlopen", side_effect=err
+        ):
+            rc = run_auth(
+                _ns(
+                    action="login",
+                    token="bad",
+                    base_url="https://srv.example.test",
+                )
+            )
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "401" in captured.err or "rejected" in captured.err
+        assert auth_store.load() is None
+
+    def test_login_connection_error_reports_reason(
+        self, tmp_auth, tmp_config, capsys
+    ):
+        err = urllib.error.URLError("connection refused")
+        with patch(
+            "beril_cli.auth_cmd.urllib.request.urlopen", side_effect=err
+        ):
+            rc = run_auth(
+                _ns(
+                    action="login",
+                    token="beril_abc",
+                    base_url="https://srv.example.test",
+                )
+            )
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "connection refused" in captured.err
+        assert auth_store.load() is None
+
+    def test_login_bad_json_response_fails(self, tmp_auth, tmp_config, capsys):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"not json"
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch(
+            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=mock_resp
+        ):
+            rc = run_auth(
+                _ns(
+                    action="login",
+                    token="beril_abc",
+                    base_url="https://srv.example.test",
+                )
+            )
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "invalid JSON" in captured.err
+        assert auth_store.load() is None
+
+    def test_login_missing_orcid_in_response_fails(
+        self, tmp_auth, tmp_config, capsys
+    ):
+        response = _mock_whoami_response({"display_name": "Alice"})
+        with patch(
+            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
+        ):
+            rc = run_auth(
+                _ns(
+                    action="login",
+                    token="beril_abc",
+                    base_url="https://srv.example.test",
+                )
+            )
+        assert rc == 1
+        assert auth_store.load() is None
+
+    def test_login_prompts_for_token_when_not_given(
+        self, tmp_auth, tmp_config, monkeypatch
+    ):
+        response = _mock_whoami_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
+        )
+        monkeypatch.setattr(auth_cmd.getpass, "getpass", lambda _prompt: "beril_pasted")
+        with patch(
+            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
+        ):
+            rc = run_auth(
+                _ns(
+                    action="login",
+                    token=None,
+                    base_url="https://srv.example.test",
+                )
+            )
+        assert rc == 0
+        assert auth_store.load()["token"] == "beril_pasted"
+
+    def test_login_empty_paste_exits_1(self, tmp_auth, tmp_config, monkeypatch, capsys):
+        monkeypatch.setattr(auth_cmd.getpass, "getpass", lambda _prompt: "")
+        rc = run_auth(
+            _ns(
+                action="login",
+                token=None,
+                base_url="https://srv.example.test",
+            )
+        )
+        assert rc == 1
+        assert "No token provided" in capsys.readouterr().err
+        assert auth_store.load() is None
+
+
+# ---------------------------------------------------------------------------
+# run_auth status
+# ---------------------------------------------------------------------------
+
+
+class TestAuthStatus:
+    def test_not_logged_in_returns_1(self, tmp_auth, capsys):
+        rc = run_auth(_ns(action="status"))
+        assert rc == 1
+        assert "Not logged in" in capsys.readouterr().out
+
+    def test_logged_in_prints_identity(self, tmp_auth, capsys):
+        auth_store.save(
+            token="beril_abc",
+            base_url="https://srv.example.test",
+            orcid_id="0000-0001-2345-6789",
+            display_name="Alice",
+        )
+        rc = run_auth(_ns(action="status"))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Alice" in out
+        assert "0000-0001-2345-6789" in out
+        assert "https://srv.example.test" in out
+        # Never print the raw token in human-facing status.
+        assert "beril_abc" not in out
+
+    def test_status_json_omits_token(self, tmp_auth, capsys):
+        auth_store.save(
+            token="beril_abc",
+            base_url="https://srv.example.test",
+            orcid_id="0000-0001-2345-6789",
+            display_name="Alice",
+        )
+        rc = run_auth(_ns(action="status", json=True))
+        out = capsys.readouterr().out
+        assert rc == 0
+        payload = json.loads(out)
+        assert "token" not in payload
+        assert payload["orcid_id"] == "0000-0001-2345-6789"
+        assert payload["display_name"] == "Alice"
+        assert payload["base_url"] == "https://srv.example.test"
+        assert payload["path"].endswith("auth.json")
+
+
+# ---------------------------------------------------------------------------
+# run_auth logout
+# ---------------------------------------------------------------------------
+
+
+class TestAuthLogout:
+    def test_logout_when_logged_in_removes_file(self, tmp_auth, capsys):
+        auth_store.save(
+            token="t", base_url="u", orcid_id="0", display_name=None
+        )
+        rc = run_auth(_ns(action="logout"))
+        assert rc == 0
+        assert "Logged out" in capsys.readouterr().out
+        assert auth_store.load() is None
+
+    def test_logout_when_not_logged_in_is_noop(self, tmp_auth, capsys):
+        rc = run_auth(_ns(action="logout"))
+        assert rc == 0
+        assert "nothing to do" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch smoke test (goes through main())
+# ---------------------------------------------------------------------------
+
+
+class TestCliDispatch:
+    def test_beril_auth_login_dispatches(self, tmp_auth, tmp_config):
+        from beril_cli.cli import main
+
+        response = _mock_whoami_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
+        )
+        with patch(
+            "beril_cli.auth_cmd.urllib.request.urlopen", return_value=response
+        ):
+            rc = main(
+                [
+                    "auth",
+                    "login",
+                    "--token",
+                    "beril_abc",
+                    "--base-url",
+                    "https://srv.example.test",
+                ]
+            )
+        assert rc == 0
+        assert auth_store.load()["token"] == "beril_abc"
+
+    def test_beril_auth_status_dispatches(self, tmp_auth, capsys):
+        from beril_cli.cli import main
+
+        rc = main(["auth", "status"])
+        assert rc == 1
+        assert "Not logged in" in capsys.readouterr().out
+
+    def test_beril_auth_logout_dispatches(self, tmp_auth):
+        from beril_cli.cli import main
+
+        rc = main(["auth", "logout"])
+        assert rc == 0

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -1,8 +1,7 @@
-"""Tests for `beril auth` subcommand and its supporting modules."""
+"""Tests for `beril login` / `beril logout` and their supporting modules."""
 
 from __future__ import annotations
 
-import argparse
 import json
 import stat
 import sys
@@ -12,7 +11,7 @@ import httpx
 import pytest
 
 from beril_cli import auth_cmd, auth_store, config
-from beril_cli.auth_cmd import run_auth
+from beril_cli.auth_cmd import run_login, run_logout
 
 
 # ---------------------------------------------------------------------------
@@ -41,13 +40,6 @@ def tmp_config(tmp_path, monkeypatch):
     # Also clear any base-url env var so tests start from a known baseline.
     monkeypatch.delenv("BERIL_BASE_URL", raising=False)
     return cfg_path
-
-
-def _ns(**kwargs) -> argparse.Namespace:
-    """Build a Namespace with the flags run_auth expects."""
-    defaults = {"action": None, "token": None, "base_url": None, "json": False}
-    defaults.update(kwargs)
-    return argparse.Namespace(**defaults)
 
 
 def _httpx_response(body: dict | str, status: int = 200) -> httpx.Response:
@@ -81,10 +73,10 @@ class TestAuthStore:
         )
         record = auth_store.load()
         assert record is not None
-        assert record["token"] == "beril_abc"
-        assert record["base_url"] == "https://example.test"
-        assert record["orcid_id"] == "0000-0001-2345-6789"
-        assert record["display_name"] == "Alice"
+        assert record.token == "beril_abc"
+        assert record.base_url == "https://example.test"
+        assert record.orcid_id == "0000-0001-2345-6789"
+        assert record.display_name == "Alice"
 
     def test_save_creates_parent_dir(self, tmp_auth):
         assert not tmp_auth.parent.exists()
@@ -104,7 +96,7 @@ class TestAuthStore:
     def test_save_overwrites_existing(self, tmp_auth):
         auth_store.save(token="t1", base_url="u", orcid_id="0", display_name=None)
         auth_store.save(token="t2", base_url="u", orcid_id="0", display_name=None)
-        assert auth_store.load()["token"] == "t2"
+        assert auth_store.load().token == "t2"
 
     def test_load_returns_none_for_corrupt_json(self, tmp_auth):
         tmp_auth.parent.mkdir(parents=True)
@@ -123,7 +115,7 @@ class TestAuthStore:
         )
         record = auth_store.load()
         assert record is not None
-        assert record["display_name"] is None
+        assert record.display_name is None
 
     def test_clear_is_idempotent_when_missing(self, tmp_auth):
         # Should not raise
@@ -179,7 +171,7 @@ class TestBaseUrlResolution:
 
 
 # ---------------------------------------------------------------------------
-# run_auth login
+# run_login
 # ---------------------------------------------------------------------------
 
 
@@ -191,12 +183,9 @@ class TestAuthLogin:
             {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
         )
         with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
-            rc = run_auth(
-                _ns(
-                    action="login",
-                    token="beril_abc",
-                    base_url="https://srv.example.test",
-                )
+            rc = run_login(
+                token="beril_abc",
+                base_url="https://srv.example.test",
             )
         out = capsys.readouterr().out
         assert rc == 0
@@ -205,21 +194,18 @@ class TestAuthLogin:
 
         record = auth_store.load()
         assert record is not None
-        assert record["token"] == "beril_abc"
-        assert record["base_url"] == "https://srv.example.test"
-        assert record["orcid_id"] == "0000-0001-2345-6789"
+        assert record.token == "beril_abc"
+        assert record.base_url == "https://srv.example.test"
+        assert record.orcid_id == "0000-0001-2345-6789"
 
     def test_login_persists_base_url_flag(self, tmp_auth, tmp_config):
         response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": None}
         )
         with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
-            run_auth(
-                _ns(
-                    action="login",
-                    token="beril_abc",
-                    base_url="https://srv.example.test/",
-                )
+            run_login(
+                token="beril_abc",
+                base_url="https://srv.example.test/",
             )
         # The base URL should now be persisted (trailing slash stripped).
         assert config.get_base_url() == "https://srv.example.test"
@@ -233,12 +219,9 @@ class TestAuthLogin:
         with patch(
             "beril_cli.auth_cmd.httpx.get", return_value=response
         ) as mock_get:
-            run_auth(
-                _ns(
-                    action="login",
-                    token="beril_abc",
-                    base_url="https://srv.example.test",
-                )
+            run_login(
+                token="beril_abc",
+                base_url="https://srv.example.test",
             )
         # httpx.get(url, headers=..., timeout=...) — url is positional.
         call = mock_get.call_args
@@ -250,12 +233,9 @@ class TestAuthLogin:
     ):
         response = _httpx_response({"detail": "Unauthorized"}, status=401)
         with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
-            rc = run_auth(
-                _ns(
-                    action="login",
-                    token="bad",
-                    base_url="https://srv.example.test",
-                )
+            rc = run_login(
+                token="bad",
+                base_url="https://srv.example.test",
             )
         captured = capsys.readouterr()
         assert rc == 1
@@ -267,12 +247,9 @@ class TestAuthLogin:
     ):
         response = _httpx_response("blocked by upstream", status=403)
         with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
-            rc = run_auth(
-                _ns(
-                    action="login",
-                    token="beril_abc",
-                    base_url="https://srv.example.test",
-                )
+            rc = run_login(
+                token="beril_abc",
+                base_url="https://srv.example.test",
             )
         captured = capsys.readouterr()
         assert rc == 1
@@ -284,12 +261,9 @@ class TestAuthLogin:
     ):
         response = _httpx_response("upstream broken", status=502)
         with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
-            rc = run_auth(
-                _ns(
-                    action="login",
-                    token="beril_abc",
-                    base_url="https://srv.example.test",
-                )
+            rc = run_login(
+                token="beril_abc",
+                base_url="https://srv.example.test",
             )
         assert rc == 1
         assert "502" in capsys.readouterr().err
@@ -300,12 +274,9 @@ class TestAuthLogin:
     ):
         err = httpx.ConnectError("connection refused")
         with patch("beril_cli.auth_cmd.httpx.get", side_effect=err):
-            rc = run_auth(
-                _ns(
-                    action="login",
-                    token="beril_abc",
-                    base_url="https://srv.example.test",
-                )
+            rc = run_login(
+                token="beril_abc",
+                base_url="https://srv.example.test",
             )
         captured = capsys.readouterr()
         assert rc == 1
@@ -317,12 +288,9 @@ class TestAuthLogin:
     ):
         err = httpx.ConnectTimeout("connect timeout")
         with patch("beril_cli.auth_cmd.httpx.get", side_effect=err):
-            rc = run_auth(
-                _ns(
-                    action="login",
-                    token="beril_abc",
-                    base_url="https://srv.example.test",
-                )
+            rc = run_login(
+                token="beril_abc",
+                base_url="https://srv.example.test",
             )
         captured = capsys.readouterr()
         assert rc == 1
@@ -332,12 +300,9 @@ class TestAuthLogin:
     def test_login_bad_json_response_fails(self, tmp_auth, tmp_config, capsys):
         response = _httpx_response("not json", status=200)
         with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
-            rc = run_auth(
-                _ns(
-                    action="login",
-                    token="beril_abc",
-                    base_url="https://srv.example.test",
-                )
+            rc = run_login(
+                token="beril_abc",
+                base_url="https://srv.example.test",
             )
         captured = capsys.readouterr()
         assert rc == 1
@@ -349,12 +314,9 @@ class TestAuthLogin:
     ):
         response = _httpx_response({"display_name": "Alice"})
         with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
-            rc = run_auth(
-                _ns(
-                    action="login",
-                    token="beril_abc",
-                    base_url="https://srv.example.test",
-                )
+            rc = run_login(
+                token="beril_abc",
+                base_url="https://srv.example.test",
             )
         assert rc == 1
         assert auth_store.load() is None
@@ -367,24 +329,18 @@ class TestAuthLogin:
         )
         monkeypatch.setattr(auth_cmd.getpass, "getpass", lambda _prompt: "beril_pasted")
         with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
-            rc = run_auth(
-                _ns(
-                    action="login",
-                    token=None,
-                    base_url="https://srv.example.test",
-                )
-            )
-        assert rc == 0
-        assert auth_store.load()["token"] == "beril_pasted"
-
-    def test_login_empty_paste_exits_1(self, tmp_auth, tmp_config, monkeypatch, capsys):
-        monkeypatch.setattr(auth_cmd.getpass, "getpass", lambda _prompt: "")
-        rc = run_auth(
-            _ns(
-                action="login",
+            rc = run_login(
                 token=None,
                 base_url="https://srv.example.test",
             )
+        assert rc == 0
+        assert auth_store.load().token == "beril_pasted"
+
+    def test_login_empty_paste_exits_1(self, tmp_auth, tmp_config, monkeypatch, capsys):
+        monkeypatch.setattr(auth_cmd.getpass, "getpass", lambda _prompt: "")
+        rc = run_login(
+            token=None,
+            base_url="https://srv.example.test",
         )
         assert rc == 1
         assert "No token provided" in capsys.readouterr().err
@@ -392,24 +348,28 @@ class TestAuthLogin:
 
 
 # ---------------------------------------------------------------------------
-# run_auth status
+# run_login(status=True) — validates the stored token against whoami
 # ---------------------------------------------------------------------------
 
 
 class TestAuthStatus:
     def test_not_logged_in_returns_1(self, tmp_auth, capsys):
-        rc = run_auth(_ns(action="status"))
+        rc = run_login(status=True)
         assert rc == 1
         assert "Not logged in" in capsys.readouterr().out
 
-    def test_logged_in_prints_identity(self, tmp_auth, capsys):
+    def test_valid_token_prints_identity(self, tmp_auth, tmp_config, capsys):
         auth_store.save(
             token="beril_abc",
             base_url="https://srv.example.test",
             orcid_id="0000-0001-2345-6789",
             display_name="Alice",
         )
-        rc = run_auth(_ns(action="status"))
+        response = _httpx_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
+        )
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_login(status=True)
         out = capsys.readouterr().out
         assert rc == 0
         assert "Alice" in out
@@ -418,26 +378,59 @@ class TestAuthStatus:
         # Never print the raw token in human-facing status.
         assert "beril_abc" not in out
 
-    def test_status_json_omits_token(self, tmp_auth, capsys):
+    def test_rejected_token_returns_1_and_keeps_file(
+        self, tmp_auth, tmp_config, capsys
+    ):
         auth_store.save(
             token="beril_abc",
             base_url="https://srv.example.test",
             orcid_id="0000-0001-2345-6789",
             display_name="Alice",
         )
-        rc = run_auth(_ns(action="status", json=True))
-        out = capsys.readouterr().out
-        assert rc == 0
-        payload = json.loads(out)
-        assert "token" not in payload
-        assert payload["orcid_id"] == "0000-0001-2345-6789"
-        assert payload["display_name"] == "Alice"
-        assert payload["base_url"] == "https://srv.example.test"
-        assert payload["path"].endswith("auth.json")
+        response = _httpx_response({"detail": "Unauthorized"}, status=401)
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_login(status=True)
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "no longer valid" in captured.err
+        # status inspects, it does not mutate — the credentials stay on disk.
+        assert auth_store.load() is not None
+
+    def test_unreachable_server_returns_2_and_keeps_file(
+        self, tmp_auth, tmp_config, capsys
+    ):
+        auth_store.save(
+            token="beril_abc",
+            base_url="https://srv.example.test",
+            orcid_id="0000-0001-2345-6789",
+            display_name="Alice",
+        )
+        err = httpx.ConnectError("connection refused")
+        with patch("beril_cli.auth_cmd.httpx.get", side_effect=err):
+            rc = run_login(status=True)
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "unreachable" in captured.err
+        assert auth_store.load() is not None
+
+    def test_unexpected_server_error_returns_2_and_keeps_file(
+        self, tmp_auth, tmp_config, capsys
+    ):
+        auth_store.save(
+            token="beril_abc",
+            base_url="https://srv.example.test",
+            orcid_id="0000-0001-2345-6789",
+            display_name="Alice",
+        )
+        response = _httpx_response("upstream broken", status=502)
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_login(status=True)
+        assert rc == 2
+        assert auth_store.load() is not None
 
 
 # ---------------------------------------------------------------------------
-# run_auth logout
+# run_logout
 # ---------------------------------------------------------------------------
 
 
@@ -446,13 +439,13 @@ class TestAuthLogout:
         auth_store.save(
             token="t", base_url="u", orcid_id="0", display_name=None
         )
-        rc = run_auth(_ns(action="logout"))
+        rc = run_logout()
         assert rc == 0
         assert "Logged out" in capsys.readouterr().out
         assert auth_store.load() is None
 
     def test_logout_when_not_logged_in_is_noop(self, tmp_auth, capsys):
-        rc = run_auth(_ns(action="logout"))
+        rc = run_logout()
         assert rc == 0
         assert "nothing to do" in capsys.readouterr().out
 
@@ -463,7 +456,7 @@ class TestAuthLogout:
 
 
 class TestCliDispatch:
-    def test_beril_auth_login_dispatches(self, tmp_auth, tmp_config):
+    def test_beril_login_dispatches(self, tmp_auth, tmp_config):
         from beril_cli.cli import main
 
         response = _httpx_response(
@@ -472,7 +465,6 @@ class TestCliDispatch:
         with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
             rc = main(
                 [
-                    "auth",
                     "login",
                     "--token",
                     "beril_abc",
@@ -481,17 +473,17 @@ class TestCliDispatch:
                 ]
             )
         assert rc == 0
-        assert auth_store.load()["token"] == "beril_abc"
+        assert auth_store.load().token == "beril_abc"
 
-    def test_beril_auth_status_dispatches(self, tmp_auth, capsys):
+    def test_beril_login_status_dispatches(self, tmp_auth, capsys):
         from beril_cli.cli import main
 
-        rc = main(["auth", "status"])
+        rc = main(["login", "--status"])
         assert rc == 1
         assert "Not logged in" in capsys.readouterr().out
 
-    def test_beril_auth_logout_dispatches(self, tmp_auth):
+    def test_beril_logout_dispatches(self, tmp_auth):
         from beril_cli.cli import main
 
-        rc = main(["auth", "logout"])
+        rc = main(["logout"])
         assert rc == 0

--- a/tests/test_cli_ov_client.py
+++ b/tests/test_cli_ov_client.py
@@ -1,0 +1,170 @@
+"""Tests for beril_cli.ov_client — the Bearer-authed OV credential exchange."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from beril_cli import ov_client
+from beril_cli.ov_client import OvLinkError, fetch_ov_credential
+
+
+def _client_from_handler(handler):
+    """Return an httpx.Client whose requests are served by ``handler``.
+
+    ``handler`` maps (method, path) -> httpx.Response. We patch
+    ``ov_client.httpx.Client`` so the module builds this mocked client but keeps
+    the real headers/base-url/timeout wiring it passes in.
+    """
+    def _route(request: httpx.Request) -> httpx.Response:
+        return handler(request.method, request.url.path, request)
+
+    transport = httpx.MockTransport(_route)
+
+    real_client = httpx.Client
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    return _factory
+
+
+def _json(body: dict, status: int = 200) -> httpx.Response:
+    return httpx.Response(status, content=json.dumps(body).encode())
+
+
+class TestFetchOvCredential:
+    def test_happy_path_returns_proxy_url_and_key(self):
+        calls = []
+
+        def handler(method, path, request):
+            calls.append((method, path))
+            if path == "/api/ov/user":
+                return _json({"created": True}, status=201)
+            if path == "/api/ov/credentials":
+                # Response ov_url is BERIL's INTERNAL address — must be ignored.
+                return _json(
+                    {"ov_url": "http://openviking:1933", "user_key": "ovk_secret"}
+                )
+            return _json({"detail": "unexpected"}, status=500)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            url, key = fetch_ov_credential("https://srv", "tok")
+
+        # URL is derived from base_url (the proxy path), NOT the response.
+        assert url == "https://srv/ov"
+        assert key == "ovk_secret"
+        # POST /api/ov/user then GET /api/ov/credentials.
+        assert ("POST", "/api/ov/user") in calls
+        assert ("GET", "/api/ov/credentials") in calls
+
+    def test_response_ov_url_is_ignored_even_if_absent(self):
+        # Credentials response with no ov_url at all still works — we don't need it.
+        def handler(method, path, request):
+            if path == "/api/ov/user":
+                return _json({"created": True}, status=201)
+            return _json({"user_key": "k"})
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            url, key = fetch_ov_credential("https://beril.kbase.us", "tok")
+
+        assert url == "https://beril.kbase.us/ov"
+        assert key == "k"
+
+    def test_sends_bearer_header(self):
+        seen = {}
+
+        def handler(method, path, request):
+            seen["auth"] = request.headers.get("Authorization")
+            if path == "/api/ov/user":
+                return _json({}, status=201)
+            return _json({"ov_url": "https://srv/ov", "user_key": "k"})
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            fetch_ov_credential("https://srv", "tok123")
+
+        assert seen["auth"] == "Bearer tok123"
+
+    def test_regenerate_hits_regenerate_endpoint(self):
+        calls = []
+
+        def handler(method, path, request):
+            calls.append((method, path))
+            if path == "/api/ov/user/regenerate":
+                return _json({}, status=200)
+            if path == "/api/ov/credentials":
+                return _json({"ov_url": "https://srv/ov", "user_key": "fresh"})
+            return _json({"detail": "unexpected"}, status=500)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            url, key = fetch_ov_credential("https://srv", "tok", regenerate=True)
+
+        assert key == "fresh"
+        assert ("POST", "/api/ov/user/regenerate") in calls
+        assert ("POST", "/api/ov/user") not in calls
+
+    def test_409_raises_needs_regenerate(self):
+        def handler(method, path, request):
+            if path == "/api/ov/user":
+                return _json({"detail": "already exists"}, status=409)
+            return _json({}, status=500)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            with pytest.raises(OvLinkError) as exc:
+                fetch_ov_credential("https://srv", "tok")
+
+        assert exc.value.needs_regenerate is True
+
+    def test_401_raises_link_error(self):
+        def handler(method, path, request):
+            return _json({"detail": "Unauthorized"}, status=401)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            with pytest.raises(OvLinkError) as exc:
+                fetch_ov_credential("https://srv", "tok")
+
+        assert "rejected" in str(exc.value).lower()
+        assert exc.value.needs_regenerate is False
+
+    def test_missing_key_in_credentials_raises(self):
+        def handler(method, path, request):
+            if path == "/api/ov/user":
+                return _json({}, status=201)
+            return _json({"ov_url": "https://srv/ov"})  # no user_key
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            with pytest.raises(OvLinkError) as exc:
+                fetch_ov_credential("https://srv", "tok")
+
+        assert "user_key" in str(exc.value)
+
+    def test_transport_error_raises_link_error(self):
+        def handler(method, path, request):
+            raise httpx.ConnectError("connection refused", request=request)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            with pytest.raises(OvLinkError) as exc:
+                fetch_ov_credential("https://srv", "tok")
+
+        assert "could not reach" in str(exc.value)
+
+    def test_base_url_trailing_slash_is_stripped(self):
+        seen = []
+
+        def handler(method, path, request):
+            seen.append(str(request.url))
+            if path == "/api/ov/user":
+                return _json({}, status=201)
+            return _json({"user_key": "k"})
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            url, _ = fetch_ov_credential("https://srv/", "tok")
+
+        # No double slash in the constructed request URLs...
+        assert all("//api" not in u.replace("https://", "") for u in seen)
+        # ...nor in the derived proxy URL.
+        assert url == "https://srv/ov"

--- a/tests/test_cli_ov_client.py
+++ b/tests/test_cli_ov_client.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 
 from beril_cli import ov_client
-from beril_cli.ov_client import OvLinkError, fetch_ov_credential
+from beril_cli.ov_client import OvLinkError, fetch_ov_credential, ov_health
 
 
 def _client_from_handler(handler):
@@ -168,3 +168,23 @@ class TestFetchOvCredential:
         assert all("//api" not in u.replace("https://", "") for u in seen)
         # ...nor in the derived proxy URL.
         assert url == "https://srv/ov"
+
+
+class TestOvHealth:
+    def test_health_returns_body(self):
+        def handler(method, path, request):
+            assert path == "/api/ov/health"
+            return _json({"status": "ok", "ov_url": "https://srv/ov"})
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            body = ov_health("https://srv", "tok")
+
+        assert body["status"] == "ok"
+
+    def test_health_401_raises(self):
+        def handler(method, path, request):
+            return _json({"detail": "Unauthorized"}, status=401)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            with pytest.raises(OvLinkError):
+                ov_health("https://srv", "tok")

--- a/tests/test_cli_ov_cmd.py
+++ b/tests/test_cli_ov_cmd.py
@@ -1,0 +1,170 @@
+"""Tests for `beril ov` (ov_cmd) and its CLI dispatch."""
+
+from __future__ import annotations
+
+import pytest
+
+from beril_cli import auth_store, ov_cmd
+from beril_cli.cli import main
+from beril_cli.ov_client import OvLinkError
+
+
+@pytest.fixture
+def tmp_auth(tmp_path, monkeypatch):
+    """Redirect auth_store's on-disk location into tmp_path."""
+    auth_dir = tmp_path / ".beril"
+    auth_path = auth_dir / "auth.json"
+    monkeypatch.setattr(auth_store, "AUTH_DIR", auth_dir)
+    monkeypatch.setattr(auth_store, "AUTH_PATH", auth_path)
+    return auth_path
+
+
+def _login(*, ov=False):
+    """Seed a stored BERIL login, optionally already OV-linked."""
+    auth_store.save(
+        token="beril_abc",
+        base_url="https://srv.example.test",
+        orcid_id="0000-0001-2345-6789",
+        display_name="Alice",
+        ov_url="https://srv.example.test/ov" if ov else None,
+        ov_user_key="ov_key_1234" if ov else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# beril ov setup
+# ---------------------------------------------------------------------------
+
+
+class TestOvSetup:
+    def test_setup_requires_login(self, tmp_auth, capsys):
+        rc = main(["ov", "setup"])
+        assert rc == 1
+        assert "Not logged in" in capsys.readouterr().err
+
+    def test_setup_links_and_caches(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=False)
+
+        def _fake(base_url, token, *, regenerate=False):
+            assert base_url == "https://srv.example.test"
+            assert token == "beril_abc"
+            assert regenerate is False
+            return ("https://srv.example.test/ov", "fresh_key_9999")
+
+        monkeypatch.setattr(ov_cmd, "fetch_ov_credential", _fake)
+        rc = main(["ov", "setup"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "linked" in out
+        assert "fresh_key_9999" not in out  # masked
+
+        record = auth_store.load()
+        assert record.ov_user_key == "fresh_key_9999"
+        # BERIL identity is preserved, not clobbered.
+        assert record.token == "beril_abc"
+        assert record.orcid_id == "0000-0001-2345-6789"
+
+    def test_setup_regenerate_passes_flag(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=True)
+        seen = {}
+
+        def _fake(base_url, token, *, regenerate=False):
+            seen["regenerate"] = regenerate
+            return ("https://srv.example.test/ov", "rotated_key")
+
+        monkeypatch.setattr(ov_cmd, "fetch_ov_credential", _fake)
+        rc = main(["ov", "setup", "--regenerate"])
+        assert rc == 0
+        assert seen["regenerate"] is True
+        assert "regenerated" in capsys.readouterr().out
+        assert auth_store.load().ov_user_key == "rotated_key"
+
+    def test_setup_409_points_at_regenerate(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=False)
+
+        def _fake(base_url, token, *, regenerate=False):
+            raise OvLinkError("already exists", needs_regenerate=True)
+
+        monkeypatch.setattr(ov_cmd, "fetch_ov_credential", _fake)
+        rc = main(["ov", "setup"])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "--regenerate" in err
+        # Nothing cached on failure.
+        assert auth_store.load().ov_user_key is None
+
+    def test_setup_generic_failure_returns_1(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=False)
+
+        def _fake(base_url, token, *, regenerate=False):
+            raise OvLinkError("could not reach OpenViking.")
+
+        monkeypatch.setattr(ov_cmd, "fetch_ov_credential", _fake)
+        rc = main(["ov", "setup"])
+        assert rc == 1
+        assert "could not reach" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# beril ov status
+# ---------------------------------------------------------------------------
+
+
+class TestOvStatus:
+    def test_status_requires_login(self, tmp_auth, capsys):
+        rc = main(["ov", "status"])
+        assert rc == 1
+        assert "Not logged in" in capsys.readouterr().err
+
+    def test_status_when_unlinked(self, tmp_auth, capsys):
+        _login(ov=False)
+        rc = main(["ov", "status"])
+        assert rc == 1
+        assert "not linked" in capsys.readouterr().out.lower()
+
+    def test_status_prints_masked_key_and_health(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=True)
+        monkeypatch.setattr(ov_cmd, "ov_health", lambda b, t: {"status": "ok"})
+        rc = main(["ov", "status"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "https://srv.example.test/ov" in out
+        assert "ok" in out
+        # Full key never printed.
+        assert "ov_key_1234" not in out
+
+    def test_status_survives_health_probe_failure(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=True)
+
+        def _boom(base_url, token):
+            raise OvLinkError("unreachable")
+
+        monkeypatch.setattr(ov_cmd, "ov_health", _boom)
+        rc = main(["ov", "status"])
+        out = capsys.readouterr().out
+        assert rc == 0  # health failure must not fail status
+        assert "unknown" in out
+
+
+# ---------------------------------------------------------------------------
+# beril ov print-env
+# ---------------------------------------------------------------------------
+
+
+class TestOvPrintEnv:
+    def test_print_env_when_unlinked_fails(self, tmp_auth, capsys):
+        _login(ov=False)
+        rc = main(["ov", "print-env"])
+        assert rc == 1
+        assert "not linked" in capsys.readouterr().err.lower()
+
+    def test_print_env_emits_valid_lines(self, tmp_auth, capsys):
+        _login(ov=True)
+        rc = main(["ov", "print-env"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "OPENVIKING_URL=https://srv.example.test/ov" in out
+        assert "OPENVIKING_API_KEY=ov_key_1234" in out
+        # Parseable as KEY=value lines.
+        for line in out.strip().splitlines():
+            assert "=" in line and line.split("=", 1)[0].isupper()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -243,6 +243,10 @@ wheels = [
 name = "beril-cli"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "certifi" },
+    { name = "httpx" },
+]
 
 [package.dev-dependencies]
 knowledge = [
@@ -256,6 +260,10 @@ test = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "certifi" },
+    { name = "httpx" },
+]
 
 [package.metadata.requires-dev]
 knowledge = [


### PR DESCRIPTION
## Summary

Final phase of the PAT flow. Adds `beril auth login/status/logout` so
agents running from a terminal — locally, on JupyterHub, wherever — can
hold a BERIL server credential and act on the user's behalf without a
browser session.

### Commands

```
beril login [--token TOKEN] [--base-url URL] [--status]
```
1. If `--base-url` given, use and persist it under `[beril].base_url`
   in `~/.config/beril/config.toml` so future runs don't need it.
2. If `--token` given, use it directly (scriptable / headless).
   Otherwise print instructions ("open `<base>/account/tokens`, create
   a token, paste it") and read via `getpass` so it does not echo.
3. Validate by calling `GET /api/user/whoami` with
   `Authorization: Bearer <token>`. On 2xx, persist token + resolved
   ORCiD + display name to `~/.beril/auth.json` at mode `0600`. On
   failure, print a specific error and exit 1 without writing anything.
4. If `--status` given, do not update the token, just check the current login status and validate the existing token, if one is there.

```
beril logout
```
Removes `~/.beril/auth.json`. Idempotent (still exits 0 when already
logged out, but says so).

### Design notes

- **`httpx` for HTTP.** urllib was the first attempt (to keep the CLI
  dep-free) but the prod deployment sits behind Cloudflare, which
  rejects the default `Python-urllib/*` User-Agent with a 403. httpx's
  default UA sails through. Also added `certifi` so a freshly-installed
  python.org Python does not fail cert verification against the prod
  cert chain.
- **Mode 0600 at file-creation time.** `auth_store.save` uses
  `os.open(..., O_CREAT | O_WRONLY | O_TRUNC, 0o600)` so the file is
  never briefly world-readable — a `write_text` + `chmod` sequence
  would race with any process that stat's the file between the two
  calls.
- **Base URL resolution order**: `BERIL_BASE_URL` env var →
  `[beril].base_url` in config → compiled-in default
  (`https://beril.kbase.us`). Trailing slashes stripped consistently so
  path concatenation is safe.
- **Distinct error messages** for 401, 403, generic 4xx/5xx, timeout,
  transport error, invalid-JSON, and missing-`orcid_id` responses — so
  a failing `login` tells the user exactly which layer said no.

Verified end-to-end against `https://beril.kbase.us`.

## Test plan

- [ ] `uv run pytest tests/ -q` from repo root — 302 pass.
- [ ] `beril login --base-url https://beril.kbase.us`, paste a
      token from `/account/tokens`, confirm `beril auth status` shows
      the right identity.
- [ ] `curl -H "Authorization: Bearer $(python -c 'import json,pathlib;
      print(json.loads(pathlib.Path.home().joinpath(".beril/auth.json").read_text())["token"])')"
      https://beril.kbase.us/api/user/whoami` — returns the same
      identity.
- [ ] `beril logout` — file gone, `beril auth status` exits 1.
- [ ] `beril login --token X` (bad token) — prints 401 error,
      does not overwrite an existing auth.json.