### PR TITLE
Update general docs from Delta to Iceberg lakehouse terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The **Microbial Discovery Forge** is an AI co-scientist and research observatory, enabling researchers to interface with large-scale biological data through natural language, reusable skills, and shared knowledge.  You can browse the Forge through the [Observatory UI](https://beril.kbase.us/), or engage with it through an AI agent.
 
-Currently, it connects to the KBase BER Data Lakehouse (K-BERDL), a curated Delta Lakehouse spanning pangenomics, fitness, biochemistry, metagenomics, and more.
+Currently, it connects to the KBase BER Data Lakehouse (K-BERDL), a curated Iceberg Lakehouse spanning pangenomics, fitness, biochemistry, metagenomics, and more.
 
 Through the Microbial Discovery Forge, users can:
 
@@ -16,7 +16,7 @@ Through the Microbial Discovery Forge, users can:
 
 ## What is BERDL?
 
-The **KBase BER Data Lakehouse (K-BERDL)** is a Delta Lakehouse containing curated scientific datasets for computational biology research. It hosts more than 35 databases across tenants:
+The **KBase BER Data Lakehouse (K-BERDL)** is an Iceberg Lakehouse containing curated scientific datasets for computational biology research. It hosts more than 35 databases across tenants:
 
 | Tenant | Databases | Highlights |
 |--------|-----------|------------|

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -27,7 +27,7 @@ We also have functional profiling from **GapMind**, run on all genomes, which pr
 | **Pathway profiling**            | GapMind                                                                                                                    | pathway-level confidence scores + per-step mapping to pangenome gene families                 |
 | **Phylogenetic trees**           | Single-copy core genes → FastTree                                                                                          | one tree per clade                                                                            |
 | **Metadata harvest**             | GTDB & NCBI Biosample                                                                                                      | quality metrics + environment fields                                                          |
-| **Storage**                      | On-prem Delta Lakehouse (Spark SQL)                                                                                        | gene-level rows queryable via Spark                                                           |
+| **Storage**                      | On-prem Iceberg Lakehouse (Spark SQL)                                                                                      | gene-level rows queryable via Spark                                                           |
 
 For current row counts and the live accessible inventory, run `berdl_notebook_utils.get_databases(return_json=False)` and use `SELECT COUNT(*)` or `DESCRIBE EXTENDED` against the relevant tables — the lakehouse is the source of truth.
 
@@ -75,7 +75,7 @@ For current row counts and the live accessible inventory, run `berdl_notebook_ut
 
 ### 6  Data Access
 
-- **Location:** On-prem Delta Lakehouse cluster (Spark 3.x).
+- **Location:** On-prem Iceberg Lakehouse cluster (Spark 3.x).
 - **Interfaces:** Spark SQL, PySpark, or JDBC.
 - **Primary schema docs:** `/schemas/pangenome_schema_v2025-05-12.sql` (matches tables above).
 - Contact Alcy (or data-engineering slack channel) for credentials, example notebooks, or protocol details.


### PR DESCRIPTION
Closes #313.

Scoped narrowly to \`README.md\` and \`docs/overview.md\` — the general architecture-level docs, both still saying "Delta Lakehouse" since the 2026-05-19/20 migration to Iceberg-on-Polaris (already documented in \`docs/pitfalls.md\`).

Deliberately left alone: individual project write-ups (\`RESEARCH_PLAN.md\`, \`MANUSCRIPT.md\`, etc.) and specific-dataset references like \`docs/research_ideas.md\`'s "bakta_reannotation Delta Lake tables" — those describe what was actually true/used at the time, not the current general architecture. The deeper skill-doc audit (namespace conventions, API calls, examples) is already tracked in #276, don't want to duplicate that scope here.