### PR TITLE
docs(readme): accurate, durable "What is BERDL" description + discovery pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,25 +16,44 @@ Through the Microbial Discovery Forge, users can:
 
 ## What is BERDL?
 
-The **KBase BER Data Lakehouse (K-BERDL)** is an Iceberg Lakehouse containing curated scientific datasets for computational biology research. It hosts more than 35 databases across tenants:
+The **KBase BER Data Lakehouse (K-BERDL)** is an Iceberg Lakehouse of curated
+scientific datasets for computational biology research. It holds dozens of
+databases across 20+ tenants (plus per-user scratch spaces), with individual
+tables ranging from thousands to well over a billion rows. New datasets are
+added over time, so treat the lakehouse itself as the source of truth for exact,
+current figures rather than the approximate volumes below (see
+[Discovering what's available](#discovering-whats-available)). Major tenants:
 
-| Tenant | Databases | Highlights |
-|--------|-----------|------------|
-| **KBase** | 9 | Pangenome (293K genomes, 1B genes), Genomes (253M proteins), Biochemistry (56K reactions), Phenotype, UniProt/UniRef, RefSeq Taxonomy  |
-| **KE Science** | 9 | AlphaFold (~241M structures), PDB (250K entries), Fitness Browser (48 organisms, 27M fitness scores), Web of Microbes (589 metabolites), BacDive (97K strains), Structural Biology |
-| **ENIGMA** | 1 | Environmental microbiology (3K taxa, 7K genomes, communities, strains) |
-| **NMDC** | 2 | Multi-omics (48 studies, 3M+ metabolomics records), harmonized BioSamples |
-| **PhageFoundry** | 5 | Species-specific genome browsers for phage research |
-| **PlanetMicrobe** | 2 | Marine microbial ecology (2K samples, 6K experiments) |
-| **PROTECT** | 1 | Pathogen genome browser |
+| Tenant | Highlights (approximate volumes) |
+|--------|----------------------------------|
+| **KBase** | Pangenome (293K genomes, 1B genes), Genomes (253M proteins), Biochemistry (56K reactions), Phenotype, UniProt/UniRef, RefSeq Taxonomy |
+| **KE Science** | AlphaFold (~241M structures), PDB (250K entries), Fitness Browser (48 organisms, 27M fitness scores), Web of Microbes (589 metabolites), BacDive (97K strains), structural biology |
+| **ENIGMA** | Environmental microbiology (3K taxa, 7K genomes, communities, strains) |
+| **NMDC** | Multi-omics: harmonized NCBI BioSamples (52M samples, 756M attributes), 1.8B+ KEGG annotation rows, 54M functional annotations, 3M+ metabolomics records |
+| **PhageFoundry** | Species-specific genome browsers for phage research |
+| **PlanetMicrobe** | Marine microbial ecology (2K samples, 6K experiments) |
+| **PROTECT** | Pathogen genome browser |
 
-Use the access-aware BERDL notebook helpers to discover the databases and
-tables available to your account. Schema documentation for commonly used
-collections lives in [docs/schemas/](docs/schemas/).
+This list is illustrative, not exhaustive. Additional tenants (for example
+ArkinLab, BERVO, PlantMicrobeInterfaces, Pangenome, RefData) are present, and the
+set grows over time.
 
-Access-sensitive discovery uses the BERDL notebook helpers. Queries run through
-Spark SQL, either directly on JupyterHub or through the local Spark wrapper when
-off-cluster.
+### Discovering what's available
+
+The lakehouse is authoritative for the current databases, tables, and row
+counts. To see what your account can access:
+
+- **In a BERDL notebook:** use the access-aware helpers (`get_databases()`,
+  `get_tables()`, `get_table_schema()`) or the `/berdl-discover` skill. See
+  [docs/getting_started.md](docs/getting_started.md).
+- **With Spark SQL:** `SHOW NAMESPACES`, `SHOW TABLES IN <namespace>`,
+  `DESCRIBE <namespace>.<table>`, and `SELECT COUNT(*) FROM <namespace>.<table>`,
+  via the `/berdl` skill on JupyterHub or `scripts/run_sql.py` off-cluster.
+- **Full inventory:** `scripts/berdl_inventory.py` writes a per-database report
+  to `data/berdl_inventory.md`.
+
+Table-level schema is best read live with `get_table_schema()` or `DESCRIBE`
+(above), since it tracks the lakehouse rather than a static doc.
 
 ## Running the AI agent
 


### PR DESCRIPTION
Closes #314.

The "What is BERDL" counts were stale and internally inconsistent (prose said "more than 35 databases", the table summed to 29), while the live lakehouse now spans ~21 curated tenants and 50+ databases. Exact counts are also muddied by duplicate Delta/underscore vs Iceberg/dotted namespace registrations (see #322), so a single hardcoded total would be both wrong and fragile.

This keeps the data-volume indicators (they convey real scale) but makes them durable and honest:

- Opening describes scale that will not rot: dozens of databases across 20+ tenants, individual tables from thousands to over a billion rows (verified against live queries).
- Per-tenant highlights are retained but labeled **approximate volumes**; the NMDC row is refreshed with figures verified live this cycle (52M biosamples, 756M attributes, 1.8B+ KEGG annotation rows, 54M functional annotations).
- The tenant table is marked illustrative, not exhaustive, and names major omitted tenants (ArkinLab, BERVO, PlantMicrobeInterfaces, Pangenome, RefData).
- Adds a "Discovering what's available" section pointing to the live-discovery mechanisms already in the repo (docs/getting_started.md, /berdl-discover, scripts/run_sql.py, scripts/berdl_inventory.py) as the source of truth for exact current figures.

Schema note: this points schema discovery at the live helpers (`get_table_schema()`/`DESCRIBE`) rather than the old `docs/schemas/` link. Per Copilot, that link is broken repo-wide (`docs/schema.md` is superseded and points to a `docs/schemas/` directory that does not exist; the README references it again at lines 218/226/282). Fixing that whole story is out of scope here and is tracked in https://github.com/kbaseincubator/BERIL-research-observatory/issues/337.