### PR TITLE
beril login: link and cache the OpenViking credential

### DIFF
--- a/.claude/skills/knowledge-context/SKILL.md
+++ b/.claude/skills/knowledge-context/SKILL.md
@@ -19,8 +19,12 @@ OpenViking holds an indexed context layer over BERIL projects and central docs. 
 ## Picking the right primitive
 
 ```
-QUERY="uv run --env-file .env knowledge/scripts/knowledge_query.py"
+QUERY="uv run knowledge/scripts/knowledge_query.py"
 ```
+
+Credentials resolve from `~/.beril` after `beril login` (see § Configuration) —
+no `--env-file` needed. To override, set `OPENVIKING_URL` / `OPENVIKING_API_KEY`
+in the env or prepend `--env-file .env`.
 
 | Question | Use | Why |
 |---|---|---|
@@ -216,7 +220,7 @@ For everything else (project→doc, doc→doc, file-level links), use the `link`
 ## Refreshing context
 
 ```bash
-INGEST="uv run --env-file .env knowledge/scripts/ingest_context.py"
+INGEST="uv run knowledge/scripts/ingest_context.py"   # creds from ~/.beril; see § Configuration
 $INGEST --project <project_id>     # after editing one project
 $INGEST --changed                  # after mixed edits — diffs against state manifest
 $INGEST --all                      # full refresh
@@ -228,22 +232,36 @@ $INGEST --docs                     # central docs only
 
 ## Configuration
 
-`.env` (copy from `.env.example`):
+**Remote server (recommended for most users):** BERIL runs a shared OpenViking
+server (currently the dev host `https://beril-dev.kbase.us`). The one-call setup
+is `beril login` — it validates your token and links + caches your OpenViking
+credential in `~/.beril`, so the query CLI resolves it automatically:
+
+```bash
+beril login                 # links OpenViking too; no browser cookie needed
+$QUERY doctor               # verify (no --env-file required once cached)
+```
+
+If login couldn't reach OpenViking (or you logged in before this was wired up),
+link it separately against the same stored token:
+
+```bash
+beril ov setup              # or `beril ov setup --regenerate` to rotate the key
+beril ov status             # show the cached credential + server health
+```
+
+`ContextConfig.from_env` precedence is: explicit env vars → the `~/.beril`
+cached credential → the local default URL. So `OPENVIKING_URL` /
+`OPENVIKING_API_KEY` (in `.env` or the shell) still override the cache when set
+— useful for CI or pointing at a different server. `beril ov print-env` emits
+those two lines if you'd rather populate `.env` (`eval "$(beril ov print-env)"`).
+
+`.env` keys (copy from `.env.example`), when you set them explicitly:
 
 - `OPENVIKING_URL` — defaults to `http://127.0.0.1:1933`
 - `OPENVIKING_API_KEY` — only when the server enforces auth (remote deployments)
 
-**Remote server (recommended for most users):** BERIL runs a shared OpenViking
-server (currently the dev host `https://beril-dev.kbase.us`). Get a one-time API
-key and write it into `.env` with the helper, then verify:
-
-```bash
-uv run knowledge/scripts/setup_remote_ov.py --cookie '<beril_session cookie>'
-$QUERY doctor
-```
-
-Full walkthrough (how to copy the cookie, rotation, troubleshooting):
-`docs/remote-openviking-setup.md`.
+Full walkthrough (rotation, troubleshooting): `docs/remote-openviking-setup.md`.
 
 **Local server:** copy `knowledge/openviking/ov.conf.example` → `knowledge/openviking/ov.conf` and set the OpenRouter key in `embedding` and the CBORG key in `vlm`. The local `ov.conf` is gitignored.
 

--- a/beril_cli/auth_cmd.py
+++ b/beril_cli/auth_cmd.py
@@ -32,6 +32,7 @@ import sys
 import httpx
 
 from beril_cli import auth_store, config
+from beril_cli.ov_client import OvLinkError, fetch_ov_credential
 
 _WHOAMI_PATH = "/api/user/whoami"
 _HTTP_TIMEOUT_SECONDS = 15.0
@@ -77,14 +78,39 @@ def run_login(token: str|None = None, base_url: str|None = None, status:bool=Fal
         print(f"Login failed: {e}", file=sys.stderr)
         return 1
 
+    # Link OpenViking in the same step. This is best-effort: a valid BERIL
+    # login must still succeed (and be saved) even if OpenViking is
+    # unreachable or the 409 "key exists but BERIL holds none" case fires —
+    # the user can repair it later with `beril ov setup [--regenerate]`.
+    ov_url: str | None = None
+    ov_user_key: str | None = None
+    ov_warning: str | None = None
+    try:
+        ov_url, ov_user_key = fetch_ov_credential(base_url, token)
+    except OvLinkError as e:
+        if e.needs_regenerate:
+            ov_warning = (
+                f"OpenViking not linked: {e} "
+                "Run `beril ov setup --regenerate` to mint a fresh key."
+            )
+        else:
+            ov_warning = (
+                f"OpenViking not linked: {e} "
+                "Run `beril ov setup` to link it later."
+            )
+
     auth_store.save(
         token=token,
         base_url=base_url,
         orcid_id=identity["orcid_id"],
         display_name=identity.get("display_name"),
+        ov_url=ov_url,
+        ov_user_key=ov_user_key,
     )
     name = identity.get("display_name") or identity["orcid_id"]
     print(f"Logged in to {base_url} as {name} ({identity['orcid_id']}).")
+    if not ov_user_key:
+        print(ov_warning, file=sys.stderr)
     return 0
 
 

--- a/beril_cli/auth_store.py
+++ b/beril_cli/auth_store.py
@@ -23,11 +23,19 @@ AUTH_PATH = AUTH_DIR / "auth.json"
 
 @dataclass
 class AuthRecord:
-    """Shape of the persisted auth blob."""
+    """Shape of the persisted auth blob.
+
+    ``ov_url`` / ``ov_user_key`` cache the user's OpenViking credential so a
+    single ``beril login`` links both BERIL and OpenViking. They are optional:
+    an old auth.json predating them, or a login where OpenViking couldn't be
+    reached, reads as logged-in-but-OV-unlinked (both None).
+    """
     token: str
     base_url: str
     orcid_id: str
     display_name: str | None
+    ov_url: str | None = None
+    ov_user_key: str | None = None
 
 
 def save(
@@ -36,19 +44,27 @@ def save(
     base_url: str,
     orcid_id: str,
     display_name: str | None,
+    ov_url: str | None = None,
+    ov_user_key: str | None = None,
 ) -> None:
     """Write auth.json with mode 0600 (POSIX).
 
     Uses os.open with O_CREAT | O_WRONLY | O_TRUNC so the mode is set at
     creation time — a Path.write_text + chmod dance would briefly expose
     a 0644 file to any process racing us.
+
+    ``ov_url`` / ``ov_user_key`` are the cached OpenViking credential; pass
+    both when a login (or ``beril ov setup``) successfully links OpenViking,
+    or leave them None to record a BERIL-only login.
     """
     AUTH_DIR.mkdir(parents=True, exist_ok=True)
     payload: AuthRecord = AuthRecord(
         token=token,
         base_url=base_url,
         orcid_id = orcid_id,
-        display_name=display_name
+        display_name=display_name,
+        ov_url=ov_url,
+        ov_user_key=ov_user_key,
     )
     # 0o600 on POSIX; ignored (no-op) on Windows. This intentionally
     # replaces any existing file.
@@ -93,6 +109,9 @@ def load() -> AuthRecord | None:
             base_url=raw["base_url"],
             orcid_id=raw["orcid_id"],
             display_name=raw.get("display_name"),
+            # Optional — absent in older files or a BERIL-only login.
+            ov_url=raw.get("ov_url"),
+            ov_user_key=raw.get("ov_user_key"),
         )
     except KeyError:
         return None
@@ -101,6 +120,19 @@ def load() -> AuthRecord | None:
         if not getattr(data, key):
             return None
     return data
+
+
+def load_ov() -> tuple[str, str] | None:
+    """Return the cached ``(ov_url, ov_user_key)``, or None if not linked.
+
+    Convenience for consumers (the query CLI, ``beril ov``) that only need
+    the OpenViking credential. Returns None when not logged in or when the
+    login didn't link OpenViking (either field missing).
+    """
+    record = load()
+    if record is None or not record.ov_url or not record.ov_user_key:
+        return None
+    return (record.ov_url, record.ov_user_key)
 
 
 def clear() -> None:

--- a/beril_cli/cli.py
+++ b/beril_cli/cli.py
@@ -103,6 +103,31 @@ def main(argv: list[str] | None = None) -> int:
         help = "Log out of BERIL server, deletes local BERIL auth credentials"
     )
 
+    # ov — link/inspect/export the OpenViking credential (login links it too)
+    ov_parser = sub.add_parser(
+        "ov",
+        help="Link, inspect, or export your OpenViking credential",
+    )
+    ov_sub = ov_parser.add_subparsers(dest="ov_action", required=True)
+    ov_setup = ov_sub.add_parser(
+        "setup",
+        help="Link OpenViking against your stored login (repair / rotation path)",
+    )
+    ov_setup.add_argument(
+        "--regenerate",
+        action="store_true",
+        default=False,
+        help="Mint a fresh OpenViking key, invalidating the old one",
+    )
+    ov_sub.add_parser(
+        "status",
+        help="Show the cached OpenViking credential and probe server health",
+    )
+    ov_sub.add_parser(
+        "print-env",
+        help='Emit OPENVIKING_URL / OPENVIKING_API_KEY (eval "$(beril ov print-env)")',
+    )
+
     # runtime-snapshot (settings.json SessionStart hook; reads the hook payload from stdin)
     sub.add_parser(
         "runtime-snapshot",
@@ -152,6 +177,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "logout":
         from beril_cli.auth_cmd import run_logout
         return run_logout()
+
+    if args.command == "ov":
+        from beril_cli.ov_cmd import run_ov
+        return run_ov(args)
 
     if args.command == "runtime-snapshot":
         from beril_cli.audit_cmd import run_runtime_snapshot

--- a/beril_cli/ov_client.py
+++ b/beril_cli/ov_client.py
@@ -1,0 +1,126 @@
+"""Fetch a user's OpenViking (OV) credential from BERIL with a Bearer PAT.
+
+BERIL brokers OV credentials: an authenticated user POSTs ``/api/ov/user`` to
+provision their OV account (idempotent) and GETs ``/api/ov/credentials`` to read
+back the OV url + user_key. This module wraps that two-step exchange using the
+stored personal access token, so ``beril login`` and ``beril ov`` share one
+implementation instead of each re-deriving the endpoint/error handling.
+
+Auth is ``Authorization: Bearer <token>`` — the same header ``_whoami`` uses.
+This is the headless replacement for the browser-cookie flow in
+``knowledge/scripts/setup_remote_ov.py``.
+
+Uses httpx (already a beril-cli dependency) for the same Cloudflare-UA reason
+documented in ``auth_cmd``.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+_USER_PATH = "/api/ov/user"
+_REGENERATE_PATH = "/api/ov/user/regenerate"
+_CREDENTIALS_PATH = "/api/ov/credentials"
+_HTTP_TIMEOUT_SECONDS = 15.0
+
+
+class OvLinkError(Exception):
+    """An OpenViking credential exchange failed. Message is user-facing.
+
+    ``needs_regenerate`` marks the specific recoverable case where OpenViking
+    already has a user for this ORCiD but BERIL holds no key for it (HTTP 409
+    from ``POST /api/ov/user``) — the caller should point the user at
+    ``beril ov setup --regenerate``.
+    """
+
+    def __init__(self, msg: str, *, needs_regenerate: bool = False) -> None:
+        super().__init__(msg)
+        self.needs_regenerate = needs_regenerate
+
+
+def fetch_ov_credential(
+    base_url: str, token: str, *, regenerate: bool = False
+) -> tuple[str, str]:
+    """Provision (or rotate) and return ``(ov_url, ov_user_key)``.
+
+    With ``regenerate=False`` (default), POSTs ``/api/ov/user`` — idempotent, so
+    a user who already has a stored key just gets it back. With
+    ``regenerate=True``, POSTs ``/api/ov/user/regenerate`` to mint a fresh key
+    (invalidating the old one) — the recovery path for the 409 case and for key
+    rotation. Either way, the key is then read via ``GET /api/ov/credentials``.
+
+    The returned ``ov_url`` is always ``{base_url}/ov`` — the public proxy path
+    the client already reached BERIL on. We deliberately ignore the ``ov_url``
+    in BERIL's response: that field is ``settings.ov_url``, the address BERIL
+    uses to reach OpenViking *server-to-server* (e.g. ``http://openviking:1933``
+    inside a compose/SPIN network), which is not resolvable from the client.
+
+    Raises :class:`OvLinkError` on any failure, with a message suitable for
+    printing to the user.
+    """
+    base = base_url.rstrip("/")
+    ov_url = f"{base}/ov"
+    with httpx.Client(
+        timeout=_HTTP_TIMEOUT_SECONDS,
+        headers={"Authorization": f"Bearer {token}"},
+    ) as client:
+        if regenerate:
+            resp = _request(client, "POST", base + _REGENERATE_PATH)
+            _guard(resp, action="regenerate your OpenViking key")
+        else:
+            resp = _request(client, "POST", base + _USER_PATH)
+            if resp.status_code == 409:
+                raise OvLinkError(
+                    "OpenViking already has a user for your ORCiD, but BERIL "
+                    "holds no key for it.",
+                    needs_regenerate=True,
+                )
+            _guard(resp, action="create your OpenViking account")
+
+        creds = _request(client, "GET", base + _CREDENTIALS_PATH)
+        _guard(creds, action="fetch your OpenViking credentials")
+
+    try:
+        body = creds.json()
+    except ValueError as e:
+        raise OvLinkError("BERIL returned invalid JSON for OpenViking credentials.") from e
+
+    # Only the key comes from the response; the URL is the proxy path derived
+    # from base_url above (BERIL's response ov_url is its internal address).
+    user_key = (body or {}).get("user_key")
+    if not user_key:
+        raise OvLinkError(
+            "BERIL did not return an OpenViking user_key."
+        )
+    return (ov_url, user_key)
+
+
+def _request(client: httpx.Client, method: str, url: str) -> httpx.Response:
+    try:
+        return client.request(method, url)
+    except httpx.TimeoutException as e:
+        raise OvLinkError(f"timed out talking to {url}.") from e
+    except httpx.TransportError as e:
+        raise OvLinkError(f"could not reach {url}: {e}") from e
+
+
+def _guard(response: httpx.Response, *, action: str) -> None:
+    """Raise :class:`OvLinkError` unless the response is a success."""
+    if response.is_success:
+        return
+    if response.status_code == 401:
+        raise OvLinkError(
+            f"your token was rejected (401) while trying to {action}."
+        )
+    raise OvLinkError(f"failed to {action}: {_detail(response)}")
+
+
+def _detail(response: httpx.Response) -> str:
+    """Best-effort human-readable reason from a failed response body."""
+    try:
+        body = response.json()
+    except ValueError:
+        return response.text.strip()[:200] or f"HTTP {response.status_code}"
+    if isinstance(body, dict) and body.get("detail"):
+        return str(body["detail"])
+    return f"HTTP {response.status_code}"

--- a/beril_cli/ov_client.py
+++ b/beril_cli/ov_client.py
@@ -21,6 +21,7 @@ import httpx
 _USER_PATH = "/api/ov/user"
 _REGENERATE_PATH = "/api/ov/user/regenerate"
 _CREDENTIALS_PATH = "/api/ov/credentials"
+_HEALTH_PATH = "/api/ov/health"
 _HTTP_TIMEOUT_SECONDS = 15.0
 
 
@@ -93,6 +94,26 @@ def fetch_ov_credential(
             "BERIL did not return an OpenViking user_key."
         )
     return (ov_url, user_key)
+
+
+def ov_health(base_url: str, token: str) -> dict:
+    """Return BERIL's view of OpenViking health via ``GET /api/ov/health``.
+
+    The route always answers 200 with ``{"status": "ok"|"unreachable", ...}``
+    when the caller is authenticated. Raises :class:`OvLinkError` on transport
+    failure or a non-2xx (e.g. 401).
+    """
+    base = base_url.rstrip("/")
+    with httpx.Client(
+        timeout=_HTTP_TIMEOUT_SECONDS,
+        headers={"Authorization": f"Bearer {token}"},
+    ) as client:
+        resp = _request(client, "GET", base + _HEALTH_PATH)
+        _guard(resp, action="check OpenViking health")
+    try:
+        return resp.json()
+    except ValueError as e:
+        raise OvLinkError("BERIL returned invalid JSON for OpenViking health.") from e
 
 
 def _request(client: httpx.Client, method: str, url: str) -> httpx.Response:

--- a/beril_cli/ov_cmd.py
+++ b/beril_cli/ov_cmd.py
@@ -1,0 +1,123 @@
+"""beril ov — link, inspect, and export the OpenViking (OV) credential.
+
+`beril login` already links OV in the happy path (see auth_cmd). This command
+covers the cases login intentionally doesn't force:
+
+  beril ov setup                re-link OV against the stored PAT (repair path:
+                                login couldn't reach OV, or an old auth.json
+                                predates OV linking).
+  beril ov setup --regenerate   mint a fresh OV key (invalidates the old one) —
+                                the recovery path for the 409 "key exists but
+                                BERIL holds none" case, and for key rotation.
+  beril ov status               show the cached OV credential and probe health.
+  beril ov print-env            emit OPENVIKING_URL / OPENVIKING_API_KEY lines
+                                for `.env` or `eval "$(beril ov print-env)"`.
+
+All of these reuse the stored BERIL PAT (~/.beril/auth.json) — no browser
+cookie. The credential exchange itself lives in ov_client, shared with login.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from beril_cli import auth_store
+from beril_cli.ov_client import OvLinkError, fetch_ov_credential, ov_health
+
+
+def run_ov(args: argparse.Namespace) -> int:
+    action = getattr(args, "ov_action", None)
+    if action == "setup":
+        return _run_setup(regenerate=args.regenerate)
+    if action == "status":
+        return _run_status()
+    if action == "print-env":
+        return _run_print_env()
+    # argparse is configured with required subcommands, so this is unreachable
+    # in normal dispatch; guard anyway.
+    print("Usage: beril ov {setup|status|print-env}", file=sys.stderr)
+    return 1
+
+
+def _require_login() -> auth_store.AuthRecord | None:
+    record = auth_store.load()
+    if record is None:
+        print("Not logged in. Run `beril login` first.", file=sys.stderr)
+        return None
+    return record
+
+
+def _run_setup(*, regenerate: bool) -> int:
+    record = _require_login()
+    if record is None:
+        return 1
+
+    try:
+        ov_url, ov_user_key = fetch_ov_credential(
+            record.base_url, record.token, regenerate=regenerate
+        )
+    except OvLinkError as e:
+        print(f"OpenViking setup failed: {e}", file=sys.stderr)
+        if e.needs_regenerate:
+            print(
+                "Run `beril ov setup --regenerate` to mint a fresh key.",
+                file=sys.stderr,
+            )
+        return 1
+
+    # Re-persist the full record so the BERIL token/identity are preserved and
+    # only the OV fields change.
+    auth_store.save(
+        token=record.token,
+        base_url=record.base_url,
+        orcid_id=record.orcid_id,
+        display_name=record.display_name,
+        ov_url=ov_url,
+        ov_user_key=ov_user_key,
+    )
+    verb = "regenerated" if regenerate else "linked"
+    print(f"OpenViking {verb} ({_mask(ov_user_key)}). URL: {ov_url}")
+    return 0
+
+
+def _run_status() -> int:
+    record = _require_login()
+    if record is None:
+        return 1
+
+    if not record.ov_url or not record.ov_user_key:
+        print("OpenViking is not linked. Run `beril ov setup` to link it.")
+        # Not an error state per se, but scripts should be able to tell.
+        return 1
+
+    print(f"OpenViking URL: {record.ov_url}")
+    print(f"API key:        {_mask(record.ov_user_key)}")
+
+    # Best-effort health probe — never let it fail the command.
+    try:
+        body = ov_health(record.base_url, record.token)
+        status = body.get("status", "unknown")
+        print(f"Server health:  {status}")
+    except OvLinkError as e:
+        print(f"Server health:  unknown ({e})")
+    return 0
+
+
+def _run_print_env() -> int:
+    creds = auth_store.load_ov()
+    if creds is None:
+        print(
+            "OpenViking is not linked. Run `beril login` or `beril ov setup` first.",
+            file=sys.stderr,
+        )
+        return 1
+    ov_url, ov_user_key = creds
+    print(f"OPENVIKING_URL={ov_url}")
+    print(f"OPENVIKING_API_KEY={ov_user_key}")
+    return 0
+
+
+def _mask(secret: str) -> str:
+    """Show only the last 4 chars of a secret for confirmation output."""
+    return f"…{secret[-4:]}" if len(secret) > 4 else "set"

--- a/docs/remote-openviking-setup.md
+++ b/docs/remote-openviking-setup.md
@@ -1,106 +1,81 @@
 # Remote OpenViking — New User Setup
 
 The BERIL knowledge context layer (project reports + central docs, searchable
-with `knowledge_query.py`) runs on a shared **remote OpenViking server**. This
-is a one-time setup: you exchange your BERIL login for an OpenViking API key,
-put it in `.env`, and then query freely — you don't need to run a local server.
+with `knowledge_query.py`) runs on a shared **remote OpenViking server**. Setup
+is a single command: `beril login` validates your BERIL token and, in the same
+step, provisions and caches your OpenViking credential — after that you can
+query freely without running a local server.
 
 > ⚠️ **The server currently runs on the dev host `https://beril-dev.kbase.us`.**
 > This is temporary. When OpenViking moves to production, substitute the new
-> base URL everywhere below (or pass `--server <url>` to the helper). Every
-> example uses a single `SERVER=` line so there's exactly one place to change.
-
-```bash
-SERVER=https://beril-dev.kbase.us     # ← the only host-specific value
-```
+> base URL (or pass `--base-url <url>` to `beril login`).
 
 ## Prerequisites
 
-- The repo cloned, with `uv` installed.
-- A `.env` file: `cp .env.example .env` if you don't have one.
-- An ORCiD you can log in with.
+- The repo cloned, with `uv` installed, and the `beril` CLI available.
+- An ORCiD you can log in with, and a BERIL personal access token (create one at
+  `https://beril-dev.kbase.us/account/tokens`).
 
 ## Step 1 — Log in
 
-Open **`https://beril-dev.kbase.us`** in your browser and log in with your
-ORCiD. Logging in sets a session cookie named **`beril_session`**.
-
-## Step 2 — Copy your `beril_session` cookie
-
-The server identifies you by that cookie. It's `HttpOnly` (not readable from
-JavaScript), but you can copy it from your browser's dev tools:
-
-- **Chrome/Edge:** DevTools (`F12` / `Cmd-Opt-I`) → **Application** tab →
-  **Storage → Cookies → `https://beril-dev.kbase.us`** → click `beril_session`
-  → copy its **Value**.
-- **Firefox:** DevTools → **Storage** tab → **Cookies** → select the site →
-  copy the `beril_session` value.
-
-The value is a long opaque string — copy the whole thing.
-
-## Step 3 — Get your API key
-
-### Option A — helper script (recommended)
-
 ```bash
-uv run knowledge/scripts/setup_remote_ov.py --cookie '<paste beril_session value>'
+beril login --base-url https://beril-dev.kbase.us
 ```
 
-It creates your OpenViking account (idempotent), fetches your key, writes
-`OPENVIKING_URL` and `OPENVIKING_API_KEY` into `.env`, and verifies the
-connection. Useful flags:
+Paste your personal access token when prompted (input doesn't echo), or pass it
+with `--token`. `beril login` then:
 
-- `--server "$SERVER"` — point at a different host (default is beril-dev).
-- `--regenerate` — mint a fresh key, invalidating the old one (rotation, or the
-  recovery path if you hit the 409 case below).
-- `--print-only` — print the two env lines instead of writing `.env`.
-- The cookie can also come from `$BERIL_SESSION` or an interactive prompt.
+1. validates the token against BERIL, and
+2. provisions your OpenViking account (idempotent) and **caches the OpenViking
+   URL + key in `~/.beril`** alongside your BERIL login.
 
-### Option B — manual (curl)
+That cached credential is what the query CLI reads — no browser cookie, no
+manual `.env` editing.
 
-The key comes from **two** calls: create the account, then read the credential.
-
-```bash
-COOKIE='<paste beril_session value>'
-
-# 1. Create your OpenViking account (idempotent — safe to re-run).
-curl -X POST "$SERVER/api/ov/user" -H "Cookie: beril_session=$COOKIE"
-
-# 2. Read your key (note: GET, not POST).
-curl "$SERVER/api/ov/credentials" -H "Cookie: beril_session=$COOKIE" \
-  | jq -r .user_key
-```
-
-> The key is **not** returned by `POST /api/ov/user` (that returns
-> `{"created": true}`). You always retrieve it with **`GET /api/ov/credentials`**.
-
-Then put both values in `.env` (note the `/ov` suffix on the URL):
-
-```bash
-OPENVIKING_URL=https://beril-dev.kbase.us/ov
-OPENVIKING_API_KEY=<the user_key from step 2>
-```
-
-## Step 4 — Verify
+## Step 2 — Verify
 
 ```bash
 # Reachability + auth check — tells server-down apart from a bad key.
-uv run --env-file .env knowledge/scripts/knowledge_query.py doctor
+uv run knowledge/scripts/knowledge_query.py doctor
 
 # A real query.
-uv run --env-file .env knowledge/scripts/knowledge_query.py find "metal resistance"
+uv run knowledge/scripts/knowledge_query.py find "metal resistance"
 ```
 
-A healthy `doctor` prints `OpenViking: OK`. After this, you never need the cookie
-again — queries talk directly to the server with your API key, which is
-long-lived until you regenerate it.
+A healthy `doctor` prints `OpenViking: OK`. No `--env-file` is required — the
+query CLI resolves the credential from `~/.beril`.
+
+## If OpenViking wasn't linked at login
+
+`beril login` links OpenViking best-effort: if the server was briefly
+unreachable (or you logged in before this was wired up), the login still
+succeeds but OpenViking is left unlinked. Link it separately against your stored
+token:
+
+```bash
+beril ov setup              # link now (idempotent)
+beril ov status             # show the cached credential + server health
+```
 
 ## Recovery & rotation
 
-- **Lost your key?** Re-run the helper (or `GET /api/ov/credentials`) — it
-  returns the same stored key; nothing is invalidated.
-- **Rotate / force a fresh key?** `setup_remote_ov.py --cookie '...' --regenerate`
-  (this invalidates the old key everywhere it's in use).
+- **Check what's cached:** `beril ov status`.
+- **Rotate / force a fresh key:** `beril ov setup --regenerate` (this
+  invalidates the old key everywhere it's in use). This is also the recovery
+  path for the 409 case below.
+- **Populate `.env` instead** (CI, or a tool that reads env vars):
+  `eval "$(beril ov print-env)"`, or paste the `beril ov print-env` output into
+  `.env`.
+
+## Configuration precedence
+
+`ContextConfig.from_env` resolves the OpenViking credential in this order:
+
+1. **Explicit env vars** — `OPENVIKING_URL` / `OPENVIKING_API_KEY` (from the
+   shell or an `--env-file`). These always win, so CI and "point at a different
+   server" keep working.
+2. **The `~/.beril` cached credential** from `beril login` / `beril ov setup`.
+3. **The local default URL** (`http://127.0.0.1:1933`) with no key.
 
 ## Troubleshooting
 
@@ -109,27 +84,29 @@ Run `knowledge_query.py doctor` first — its verdict tells you what's wrong:
 | Verdict | Meaning | Fix |
 |---|---|---|
 | `OK` | Reachable, key valid | — |
-| `UNREACHABLE` | Server down or wrong URL | Check `OPENVIKING_URL` ends in `/ov`; confirm `$SERVER/ov/health` responds in a browser; check network/VPN |
-| `NO API KEY` | Reachable, but `OPENVIKING_API_KEY` unset | Run the setup helper (Step 3) |
-| `AUTH FAILED` | Reachable, but your key was rejected | Key expired/invalid → `setup_remote_ov.py --regenerate` |
+| `UNREACHABLE` | Server down or wrong URL | Confirm `$SERVER/ov/health` responds in a browser; check network/VPN |
+| `NO API KEY` | Reachable, but no key resolved | Run `beril ov setup` (or `beril login`) |
+| `AUTH FAILED` | Reachable, but your key was rejected | Key expired/invalid → `beril ov setup --regenerate` |
 | `UNHEALTHY` | Reachable, but the server reports itself unhealthy | Server-side — flag a maintainer / check the OV deployment |
 | `ERROR` | Reachable, but an authenticated call failed unexpectedly | Retry; if it persists, check the OV server logs |
 
 Other cases:
 
-- **`HTTP 401` from a curl/helper call** — your `beril_session` cookie is
-  missing or expired. Log in again (Step 1) and re-copy it (Step 2).
-- **`HTTP 409` on `POST /api/ov/user`** — OpenViking already has a user for your
-  ORCiD but BERIL holds no key for it. Run `setup_remote_ov.py --regenerate` (or
-  `POST /api/ov/user/regenerate` then `GET /api/ov/credentials`).
+- **`Not logged in`** — run `beril login` first.
+- **OpenViking not linked after login** — the server was unreachable during
+  login; run `beril ov setup`.
+- **`HTTP 409` / "key exists but BERIL holds none"** — OpenViking already has a
+  user for your ORCiD but BERIL holds no key for it. Run
+  `beril ov setup --regenerate` to mint and store a fresh key.
 - **Quick server liveness, no auth needed:** `curl "$SERVER/ov/health"` should
   return `{"status":"ok","healthy":true,...}`.
 
 ## Security
 
-`OPENVIKING_API_KEY` is a secret. `.env` and `*.env` are gitignored — keep the
-key there, never commit it, and **never paste it into a chat**. If it leaks,
-rotate it with `--regenerate`.
+`OPENVIKING_API_KEY` is a secret. The cached copy in `~/.beril/auth.json` is
+written mode `0600`. If you populate `.env`, note that `.env` and `*.env` are
+gitignored — never commit the key, and **never paste it into a chat**. If it
+leaks, rotate it with `beril ov setup --regenerate`.
 
 ## See also
 

--- a/knowledge/tests/test_config.py
+++ b/knowledge/tests/test_config.py
@@ -1,0 +1,93 @@
+"""Tests for ContextConfig.from_env credential resolution.
+
+Precedence: explicit env vars win, then the credential cached by
+`beril login` / `beril ov setup` in ~/.beril, then the local default URL.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from observatory_context import config as ovcfg
+from observatory_context.config import DEFAULT_OPENVIKING_URL, ContextConfig
+
+
+@pytest.fixture(autouse=True)
+def clear_ov_env(monkeypatch):
+    """Start each test from a known state — no OV env vars set."""
+    monkeypatch.delenv("OPENVIKING_URL", raising=False)
+    monkeypatch.delenv("OPENVIKING_API_KEY", raising=False)
+
+
+def _patch_cache(monkeypatch, value):
+    """Stub the ~/.beril cached-credential lookup."""
+    monkeypatch.setattr(ovcfg, "_cached_ov_credential", lambda: value)
+
+
+class TestFromEnvPrecedence:
+    def test_env_vars_win(self, monkeypatch):
+        monkeypatch.setenv("OPENVIKING_URL", "https://env/ov")
+        monkeypatch.setenv("OPENVIKING_API_KEY", "env_key")
+        _patch_cache(monkeypatch, ("https://cached/ov", "cached_key"))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == "https://env/ov"
+        assert cfg.openviking_api_key == "env_key"
+
+    def test_falls_back_to_cached_credential(self, monkeypatch):
+        _patch_cache(monkeypatch, ("https://cached/ov", "cached_key"))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == "https://cached/ov"
+        assert cfg.openviking_api_key == "cached_key"
+
+    def test_default_url_when_nothing_available(self, monkeypatch):
+        _patch_cache(monkeypatch, (None, None))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == DEFAULT_OPENVIKING_URL
+        assert cfg.openviking_api_key is None
+
+    def test_env_url_with_cached_key_do_not_mix_when_both_env_present(
+        self, monkeypatch
+    ):
+        # If only the URL is set in the env, the key is drawn from the cache —
+        # partial env config still gets completed from ~/.beril.
+        monkeypatch.setenv("OPENVIKING_URL", "https://env/ov")
+        _patch_cache(monkeypatch, ("https://cached/ov", "cached_key"))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == "https://env/ov"
+        assert cfg.openviking_api_key == "cached_key"
+
+
+class TestCachedCredentialImportGuard:
+    def test_returns_none_pair_when_beril_cli_absent(self, monkeypatch):
+        # Simulate an environment where beril_cli isn't importable.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name.startswith("beril_cli"):
+                raise ImportError("no beril_cli here")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+        assert ovcfg._cached_ov_credential() == (None, None)
+
+    def test_returns_none_pair_when_not_linked(self, monkeypatch):
+        from beril_cli import auth_store
+
+        monkeypatch.setattr(auth_store, "load_ov", lambda: None)
+        assert ovcfg._cached_ov_credential() == (None, None)
+
+    def test_returns_pair_from_auth_store(self, monkeypatch):
+        from beril_cli import auth_store
+
+        monkeypatch.setattr(
+            auth_store, "load_ov", lambda: ("https://srv/ov", "k")
+        )
+        assert ovcfg._cached_ov_credential() == ("https://srv/ov", "k")

--- a/observatory_context/config.py
+++ b/observatory_context/config.py
@@ -10,6 +10,23 @@ PROJECTS_TARGET_URI = "viking://resources/projects/"
 DOCS_TARGET_URI = "viking://resources/docs/"
 
 
+def _cached_ov_credential() -> tuple[str | None, str | None]:
+    """Return ``(ov_url, ov_user_key)`` cached by ``beril login`` / ``beril ov``.
+
+    Reads ~/.beril/auth.json via ``beril_cli.auth_store``. The import is guarded
+    so ``observatory_context`` keeps working in environments where ``beril_cli``
+    isn't on the path (returns ``(None, None)`` — same as no cached credential).
+    """
+    try:
+        from beril_cli import auth_store
+    except ImportError:
+        return (None, None)
+    creds = auth_store.load_ov()
+    if creds is None:
+        return (None, None)
+    return creds
+
+
 @dataclass(frozen=True)
 class ContextConfig:
     repo_root: Path
@@ -19,10 +36,22 @@ class ContextConfig:
     @classmethod
     def from_env(cls, repo_root: Path | None = None) -> "ContextConfig":
         root = repo_root or Path(__file__).resolve().parents[1]
+
+        # Precedence: explicit env vars win (CI, `--env-file .env`, manual
+        # export), then fall back to the credential `beril login` / `beril ov
+        # setup` cached in ~/.beril. This lets the query CLI work with no
+        # env-file once the user has logged in.
+        url = os.getenv("OPENVIKING_URL")
+        key = os.getenv("OPENVIKING_API_KEY")
+        if not url or not key:
+            cached_url, cached_key = _cached_ov_credential()
+            url = url or cached_url
+            key = key or cached_key
+
         return cls(
             repo_root=root,
-            openviking_url=os.getenv("OPENVIKING_URL", DEFAULT_OPENVIKING_URL),
-            openviking_api_key=os.getenv("OPENVIKING_API_KEY"),
+            openviking_url=url or DEFAULT_OPENVIKING_URL,
+            openviking_api_key=key,
         )
 
     def __post_init__(self) -> None:

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -12,6 +12,7 @@ import pytest
 
 from beril_cli import auth_cmd, auth_store, config
 from beril_cli.auth_cmd import run_login, run_logout
+from beril_cli.ov_client import OvLinkError
 
 
 # ---------------------------------------------------------------------------
@@ -40,6 +41,20 @@ def tmp_config(tmp_path, monkeypatch):
     # Also clear any base-url env var so tests start from a known baseline.
     monkeypatch.delenv("BERIL_BASE_URL", raising=False)
     return cfg_path
+
+
+@pytest.fixture
+def stub_ov(monkeypatch):
+    """Stub OpenViking linking during login so the tests that only care about
+    BERIL auth don't reach the (real) OV endpoints. Returns a fixed credential.
+
+    auth_cmd imports ``fetch_ov_credential`` by name, so we patch it there.
+    """
+    def _fake(base_url, token, *, regenerate=False):
+        return ("https://srv.example.test/ov", "ov_key_1234")
+
+    monkeypatch.setattr(auth_cmd, "fetch_ov_credential", _fake)
+    return _fake
 
 
 def _httpx_response(body: dict | str, status: int = 200) -> httpx.Response:
@@ -117,6 +132,62 @@ class TestAuthStore:
         assert record is not None
         assert record.display_name is None
 
+    def test_save_then_load_round_trips_ov_fields(self, tmp_auth):
+        auth_store.save(
+            token="t",
+            base_url="u",
+            orcid_id="0",
+            display_name=None,
+            ov_url="https://srv/ov",
+            ov_user_key="ovk",
+        )
+        record = auth_store.load()
+        assert record.ov_url == "https://srv/ov"
+        assert record.ov_user_key == "ovk"
+
+    def test_ov_fields_default_to_none(self, tmp_auth):
+        auth_store.save(token="t", base_url="u", orcid_id="0", display_name=None)
+        record = auth_store.load()
+        assert record.ov_url is None
+        assert record.ov_user_key is None
+
+    def test_old_file_without_ov_fields_still_loads(self, tmp_auth):
+        # Pre-OV auth.json — must remain readable (logged-in, OV unlinked).
+        tmp_auth.parent.mkdir(parents=True)
+        tmp_auth.write_text(
+            json.dumps(
+                {
+                    "token": "t",
+                    "base_url": "u",
+                    "orcid_id": "0",
+                    "display_name": "Alice",
+                }
+            )
+        )
+        record = auth_store.load()
+        assert record is not None
+        assert record.token == "t"
+        assert record.ov_url is None
+        assert record.ov_user_key is None
+
+    def test_load_ov_returns_pair_when_present(self, tmp_auth):
+        auth_store.save(
+            token="t",
+            base_url="u",
+            orcid_id="0",
+            display_name=None,
+            ov_url="https://srv/ov",
+            ov_user_key="ovk",
+        )
+        assert auth_store.load_ov() == ("https://srv/ov", "ovk")
+
+    def test_load_ov_returns_none_when_not_logged_in(self, tmp_auth):
+        assert auth_store.load_ov() is None
+
+    def test_load_ov_returns_none_when_ov_unlinked(self, tmp_auth):
+        auth_store.save(token="t", base_url="u", orcid_id="0", display_name=None)
+        assert auth_store.load_ov() is None
+
     def test_clear_is_idempotent_when_missing(self, tmp_auth):
         # Should not raise
         auth_store.clear()
@@ -177,7 +248,7 @@ class TestBaseUrlResolution:
 
 class TestAuthLogin:
     def test_login_with_token_flag_saves_record(
-        self, tmp_auth, tmp_config, capsys
+        self, tmp_auth, tmp_config, stub_ov, capsys
     ):
         response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
@@ -198,7 +269,7 @@ class TestAuthLogin:
         assert record.base_url == "https://srv.example.test"
         assert record.orcid_id == "0000-0001-2345-6789"
 
-    def test_login_persists_base_url_flag(self, tmp_auth, tmp_config):
+    def test_login_persists_base_url_flag(self, tmp_auth, tmp_config, stub_ov):
         response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": None}
         )
@@ -211,7 +282,7 @@ class TestAuthLogin:
         assert config.get_base_url() == "https://srv.example.test"
 
     def test_login_hits_correct_whoami_url_with_bearer_header(
-        self, tmp_auth, tmp_config
+        self, tmp_auth, tmp_config, stub_ov
     ):
         response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": None}
@@ -227,6 +298,62 @@ class TestAuthLogin:
         call = mock_get.call_args
         assert call.args[0] == "https://srv.example.test/api/user/whoami"
         assert call.kwargs["headers"]["Authorization"] == "Bearer beril_abc"
+
+    def test_login_caches_ov_credential(
+        self, tmp_auth, tmp_config, stub_ov, capsys
+    ):
+        response = _httpx_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
+        )
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_login(token="beril_abc", base_url="https://srv.example.test")
+        assert rc == 0
+        record = auth_store.load()
+        assert record.ov_url == "https://srv.example.test/ov"
+        assert record.ov_user_key == "ov_key_1234"
+        out = capsys.readouterr().out
+        # The full key is never printed — only a masked suffix.
+        assert "ov_key_1234" not in out
+
+    def test_login_when_ov_unreachable_still_succeeds(
+        self, tmp_auth, tmp_config, monkeypatch, capsys
+    ):
+        def _boom(base_url, token, *, regenerate=False):
+            raise OvLinkError("could not reach OpenViking.")
+
+        monkeypatch.setattr(auth_cmd, "fetch_ov_credential", _boom)
+        response = _httpx_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
+        )
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_login(token="beril_abc", base_url="https://srv.example.test")
+        captured = capsys.readouterr()
+        # BERIL login still succeeds and is saved; OV fields are None.
+        assert rc == 0
+        record = auth_store.load()
+        assert record is not None
+        assert record.token == "beril_abc"
+        assert record.ov_url is None
+        assert record.ov_user_key is None
+        assert "OpenViking not linked" in captured.err
+        assert "beril ov setup" in captured.err
+
+    def test_login_409_points_at_regenerate(
+        self, tmp_auth, tmp_config, monkeypatch, capsys
+    ):
+        def _conflict(base_url, token, *, regenerate=False):
+            raise OvLinkError("already exists", needs_regenerate=True)
+
+        monkeypatch.setattr(auth_cmd, "fetch_ov_credential", _conflict)
+        response = _httpx_response(
+            {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
+        )
+        with patch("beril_cli.auth_cmd.httpx.get", return_value=response):
+            rc = run_login(token="beril_abc", base_url="https://srv.example.test")
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert auth_store.load().ov_user_key is None
+        assert "--regenerate" in captured.err
 
     def test_login_401_prints_error_and_does_not_save(
         self, tmp_auth, tmp_config, capsys
@@ -322,7 +449,7 @@ class TestAuthLogin:
         assert auth_store.load() is None
 
     def test_login_prompts_for_token_when_not_given(
-        self, tmp_auth, tmp_config, monkeypatch
+        self, tmp_auth, tmp_config, stub_ov, monkeypatch
     ):
         response = _httpx_response(
             {"orcid_id": "0000-0001-2345-6789", "display_name": "Alice"}
@@ -456,7 +583,7 @@ class TestAuthLogout:
 
 
 class TestCliDispatch:
-    def test_beril_login_dispatches(self, tmp_auth, tmp_config):
+    def test_beril_login_dispatches(self, tmp_auth, tmp_config, stub_ov):
         from beril_cli.cli import main
 
         response = _httpx_response(

--- a/tests/test_cli_ov_client.py
+++ b/tests/test_cli_ov_client.py
@@ -1,0 +1,170 @@
+"""Tests for beril_cli.ov_client — the Bearer-authed OV credential exchange."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from beril_cli import ov_client
+from beril_cli.ov_client import OvLinkError, fetch_ov_credential
+
+
+def _client_from_handler(handler):
+    """Return an httpx.Client whose requests are served by ``handler``.
+
+    ``handler`` maps (method, path) -> httpx.Response. We patch
+    ``ov_client.httpx.Client`` so the module builds this mocked client but keeps
+    the real headers/base-url/timeout wiring it passes in.
+    """
+    def _route(request: httpx.Request) -> httpx.Response:
+        return handler(request.method, request.url.path, request)
+
+    transport = httpx.MockTransport(_route)
+
+    real_client = httpx.Client
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    return _factory
+
+
+def _json(body: dict, status: int = 200) -> httpx.Response:
+    return httpx.Response(status, content=json.dumps(body).encode())
+
+
+class TestFetchOvCredential:
+    def test_happy_path_returns_proxy_url_and_key(self):
+        calls = []
+
+        def handler(method, path, request):
+            calls.append((method, path))
+            if path == "/api/ov/user":
+                return _json({"created": True}, status=201)
+            if path == "/api/ov/credentials":
+                # Response ov_url is BERIL's INTERNAL address — must be ignored.
+                return _json(
+                    {"ov_url": "http://openviking:1933", "user_key": "ovk_secret"}
+                )
+            return _json({"detail": "unexpected"}, status=500)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            url, key = fetch_ov_credential("https://srv", "tok")
+
+        # URL is derived from base_url (the proxy path), NOT the response.
+        assert url == "https://srv/ov"
+        assert key == "ovk_secret"
+        # POST /api/ov/user then GET /api/ov/credentials.
+        assert ("POST", "/api/ov/user") in calls
+        assert ("GET", "/api/ov/credentials") in calls
+
+    def test_response_ov_url_is_ignored_even_if_absent(self):
+        # Credentials response with no ov_url at all still works — we don't need it.
+        def handler(method, path, request):
+            if path == "/api/ov/user":
+                return _json({"created": True}, status=201)
+            return _json({"user_key": "k"})
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            url, key = fetch_ov_credential("https://beril.kbase.us", "tok")
+
+        assert url == "https://beril.kbase.us/ov"
+        assert key == "k"
+
+    def test_sends_bearer_header(self):
+        seen = {}
+
+        def handler(method, path, request):
+            seen["auth"] = request.headers.get("Authorization")
+            if path == "/api/ov/user":
+                return _json({}, status=201)
+            return _json({"ov_url": "https://srv/ov", "user_key": "k"})
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            fetch_ov_credential("https://srv", "tok123")
+
+        assert seen["auth"] == "Bearer tok123"
+
+    def test_regenerate_hits_regenerate_endpoint(self):
+        calls = []
+
+        def handler(method, path, request):
+            calls.append((method, path))
+            if path == "/api/ov/user/regenerate":
+                return _json({}, status=200)
+            if path == "/api/ov/credentials":
+                return _json({"ov_url": "https://srv/ov", "user_key": "fresh"})
+            return _json({"detail": "unexpected"}, status=500)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            url, key = fetch_ov_credential("https://srv", "tok", regenerate=True)
+
+        assert key == "fresh"
+        assert ("POST", "/api/ov/user/regenerate") in calls
+        assert ("POST", "/api/ov/user") not in calls
+
+    def test_409_raises_needs_regenerate(self):
+        def handler(method, path, request):
+            if path == "/api/ov/user":
+                return _json({"detail": "already exists"}, status=409)
+            return _json({}, status=500)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            with pytest.raises(OvLinkError) as exc:
+                fetch_ov_credential("https://srv", "tok")
+
+        assert exc.value.needs_regenerate is True
+
+    def test_401_raises_link_error(self):
+        def handler(method, path, request):
+            return _json({"detail": "Unauthorized"}, status=401)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            with pytest.raises(OvLinkError) as exc:
+                fetch_ov_credential("https://srv", "tok")
+
+        assert "rejected" in str(exc.value).lower()
+        assert exc.value.needs_regenerate is False
+
+    def test_missing_key_in_credentials_raises(self):
+        def handler(method, path, request):
+            if path == "/api/ov/user":
+                return _json({}, status=201)
+            return _json({"ov_url": "https://srv/ov"})  # no user_key
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            with pytest.raises(OvLinkError) as exc:
+                fetch_ov_credential("https://srv", "tok")
+
+        assert "user_key" in str(exc.value)
+
+    def test_transport_error_raises_link_error(self):
+        def handler(method, path, request):
+            raise httpx.ConnectError("connection refused", request=request)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            with pytest.raises(OvLinkError) as exc:
+                fetch_ov_credential("https://srv", "tok")
+
+        assert "could not reach" in str(exc.value)
+
+    def test_base_url_trailing_slash_is_stripped(self):
+        seen = []
+
+        def handler(method, path, request):
+            seen.append(str(request.url))
+            if path == "/api/ov/user":
+                return _json({}, status=201)
+            return _json({"user_key": "k"})
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            url, _ = fetch_ov_credential("https://srv/", "tok")
+
+        # No double slash in the constructed request URLs...
+        assert all("//api" not in u.replace("https://", "") for u in seen)
+        # ...nor in the derived proxy URL.
+        assert url == "https://srv/ov"

--- a/tests/test_cli_ov_client.py
+++ b/tests/test_cli_ov_client.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 
 from beril_cli import ov_client
-from beril_cli.ov_client import OvLinkError, fetch_ov_credential
+from beril_cli.ov_client import OvLinkError, fetch_ov_credential, ov_health
 
 
 def _client_from_handler(handler):
@@ -168,3 +168,23 @@ class TestFetchOvCredential:
         assert all("//api" not in u.replace("https://", "") for u in seen)
         # ...nor in the derived proxy URL.
         assert url == "https://srv/ov"
+
+
+class TestOvHealth:
+    def test_health_returns_body(self):
+        def handler(method, path, request):
+            assert path == "/api/ov/health"
+            return _json({"status": "ok", "ov_url": "https://srv/ov"})
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            body = ov_health("https://srv", "tok")
+
+        assert body["status"] == "ok"
+
+    def test_health_401_raises(self):
+        def handler(method, path, request):
+            return _json({"detail": "Unauthorized"}, status=401)
+
+        with patch.object(ov_client.httpx, "Client", _client_from_handler(handler)):
+            with pytest.raises(OvLinkError):
+                ov_health("https://srv", "tok")

--- a/tests/test_cli_ov_cmd.py
+++ b/tests/test_cli_ov_cmd.py
@@ -1,0 +1,170 @@
+"""Tests for `beril ov` (ov_cmd) and its CLI dispatch."""
+
+from __future__ import annotations
+
+import pytest
+
+from beril_cli import auth_store, ov_cmd
+from beril_cli.cli import main
+from beril_cli.ov_client import OvLinkError
+
+
+@pytest.fixture
+def tmp_auth(tmp_path, monkeypatch):
+    """Redirect auth_store's on-disk location into tmp_path."""
+    auth_dir = tmp_path / ".beril"
+    auth_path = auth_dir / "auth.json"
+    monkeypatch.setattr(auth_store, "AUTH_DIR", auth_dir)
+    monkeypatch.setattr(auth_store, "AUTH_PATH", auth_path)
+    return auth_path
+
+
+def _login(*, ov=False):
+    """Seed a stored BERIL login, optionally already OV-linked."""
+    auth_store.save(
+        token="beril_abc",
+        base_url="https://srv.example.test",
+        orcid_id="0000-0001-2345-6789",
+        display_name="Alice",
+        ov_url="https://srv.example.test/ov" if ov else None,
+        ov_user_key="ov_key_1234" if ov else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# beril ov setup
+# ---------------------------------------------------------------------------
+
+
+class TestOvSetup:
+    def test_setup_requires_login(self, tmp_auth, capsys):
+        rc = main(["ov", "setup"])
+        assert rc == 1
+        assert "Not logged in" in capsys.readouterr().err
+
+    def test_setup_links_and_caches(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=False)
+
+        def _fake(base_url, token, *, regenerate=False):
+            assert base_url == "https://srv.example.test"
+            assert token == "beril_abc"
+            assert regenerate is False
+            return ("https://srv.example.test/ov", "fresh_key_9999")
+
+        monkeypatch.setattr(ov_cmd, "fetch_ov_credential", _fake)
+        rc = main(["ov", "setup"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "linked" in out
+        assert "fresh_key_9999" not in out  # masked
+
+        record = auth_store.load()
+        assert record.ov_user_key == "fresh_key_9999"
+        # BERIL identity is preserved, not clobbered.
+        assert record.token == "beril_abc"
+        assert record.orcid_id == "0000-0001-2345-6789"
+
+    def test_setup_regenerate_passes_flag(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=True)
+        seen = {}
+
+        def _fake(base_url, token, *, regenerate=False):
+            seen["regenerate"] = regenerate
+            return ("https://srv.example.test/ov", "rotated_key")
+
+        monkeypatch.setattr(ov_cmd, "fetch_ov_credential", _fake)
+        rc = main(["ov", "setup", "--regenerate"])
+        assert rc == 0
+        assert seen["regenerate"] is True
+        assert "regenerated" in capsys.readouterr().out
+        assert auth_store.load().ov_user_key == "rotated_key"
+
+    def test_setup_409_points_at_regenerate(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=False)
+
+        def _fake(base_url, token, *, regenerate=False):
+            raise OvLinkError("already exists", needs_regenerate=True)
+
+        monkeypatch.setattr(ov_cmd, "fetch_ov_credential", _fake)
+        rc = main(["ov", "setup"])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "--regenerate" in err
+        # Nothing cached on failure.
+        assert auth_store.load().ov_user_key is None
+
+    def test_setup_generic_failure_returns_1(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=False)
+
+        def _fake(base_url, token, *, regenerate=False):
+            raise OvLinkError("could not reach OpenViking.")
+
+        monkeypatch.setattr(ov_cmd, "fetch_ov_credential", _fake)
+        rc = main(["ov", "setup"])
+        assert rc == 1
+        assert "could not reach" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# beril ov status
+# ---------------------------------------------------------------------------
+
+
+class TestOvStatus:
+    def test_status_requires_login(self, tmp_auth, capsys):
+        rc = main(["ov", "status"])
+        assert rc == 1
+        assert "Not logged in" in capsys.readouterr().err
+
+    def test_status_when_unlinked(self, tmp_auth, capsys):
+        _login(ov=False)
+        rc = main(["ov", "status"])
+        assert rc == 1
+        assert "not linked" in capsys.readouterr().out.lower()
+
+    def test_status_prints_masked_key_and_health(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=True)
+        monkeypatch.setattr(ov_cmd, "ov_health", lambda b, t: {"status": "ok"})
+        rc = main(["ov", "status"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "https://srv.example.test/ov" in out
+        assert "ok" in out
+        # Full key never printed.
+        assert "ov_key_1234" not in out
+
+    def test_status_survives_health_probe_failure(self, tmp_auth, monkeypatch, capsys):
+        _login(ov=True)
+
+        def _boom(base_url, token):
+            raise OvLinkError("unreachable")
+
+        monkeypatch.setattr(ov_cmd, "ov_health", _boom)
+        rc = main(["ov", "status"])
+        out = capsys.readouterr().out
+        assert rc == 0  # health failure must not fail status
+        assert "unknown" in out
+
+
+# ---------------------------------------------------------------------------
+# beril ov print-env
+# ---------------------------------------------------------------------------
+
+
+class TestOvPrintEnv:
+    def test_print_env_when_unlinked_fails(self, tmp_auth, capsys):
+        _login(ov=False)
+        rc = main(["ov", "print-env"])
+        assert rc == 1
+        assert "not linked" in capsys.readouterr().err.lower()
+
+    def test_print_env_emits_valid_lines(self, tmp_auth, capsys):
+        _login(ov=True)
+        rc = main(["ov", "print-env"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "OPENVIKING_URL=https://srv.example.test/ov" in out
+        assert "OPENVIKING_API_KEY=ov_key_1234" in out
+        # Parseable as KEY=value lines.
+        for line in out.strip().splitlines():
+            assert "=" in line and line.split("=", 1)[0].isupper()


### PR DESCRIPTION
## What

Makes `beril login` the **single call** that links a user to both BERIL and OpenViking (OV). After the token is validated, login now provisions the user's OV account (if needed), fetches the OV credential, and caches it alongside the BERIL auth token in `~/.beril/auth.json`. No browser cookie copy, no manual `.env` editing.

This is the first of a stacked series (PR2: `beril ov` repair/rotation command; PR3: query-CLI config fallback + docs).

## Changes

- **`auth_store.py`** — `AuthRecord` gains optional `ov_url` / `ov_user_key`; `save()` persists them; `load()` reads them with `.get()` so **pre-OV `auth.json` files still parse** (read as logged-in / OV-unlinked). New `load_ov()` returns `(url, key)` or `None`.
- **`ov_client.py`** (new) — shared Bearer-authed helper: POST `/api/ov/user` (or `/api/ov/user/regenerate`) then GET `/api/ov/credentials`. Raises `OvLinkError`, flagging the recoverable **409** "OV user exists but BERIL holds no key" case (`needs_regenerate`). This is the headless replacement for the browser-cookie flow in `knowledge/scripts/setup_remote_ov.py`, and is shared so the upcoming `beril ov` command reuses the same endpoint/error logic.
- **`auth_cmd.py`** — `run_login` links OV after `whoami` succeeds.

## Key design decision: OV linking is non-fatal to login

A valid BERIL login must still succeed even if OV is unreachable or returns the 409 case. In those cases login saves the BERIL token with OV fields `None`, exits 0, and prints guidance to run `beril ov setup [--regenerate]` (that command lands in PR2). Only a hard BERIL auth failure is non-zero (unchanged).

## Tests

- `auth_store` OV round-trip, defaults-to-None, old-file-without-OV-fields still loads, `load_ov()` cases.
- `run_login`: caches OV cred + masks the key in output; OV-unreachable still succeeds (exit 0, fields None, warning); 409 points at `--regenerate`.
- `ov_client`: happy path, Bearer header, regenerate endpoint, 409→`needs_regenerate`, 401, missing key, transport error, trailing-slash handling (via `httpx.MockTransport`).

Full suite green (321 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
