### PR TITLE
knowledge query: resolve OV credential from ~/.beril; docs

### DIFF
--- a/.claude/skills/knowledge-context/SKILL.md
+++ b/.claude/skills/knowledge-context/SKILL.md
@@ -19,8 +19,12 @@ OpenViking holds an indexed context layer over BERIL projects and central docs. 
 ## Picking the right primitive
 
 ```
-QUERY="uv run --env-file .env knowledge/scripts/knowledge_query.py"
+QUERY="uv run knowledge/scripts/knowledge_query.py"
 ```
+
+Credentials resolve from `~/.beril` after `beril login` (see § Configuration) —
+no `--env-file` needed. To override, set `OPENVIKING_URL` / `OPENVIKING_API_KEY`
+in the env or prepend `--env-file .env`.
 
 | Question | Use | Why |
 |---|---|---|
@@ -216,7 +220,7 @@ For everything else (project→doc, doc→doc, file-level links), use the `link`
 ## Refreshing context
 
 ```bash
-INGEST="uv run --env-file .env knowledge/scripts/ingest_context.py"
+INGEST="uv run knowledge/scripts/ingest_context.py"   # creds from ~/.beril; see § Configuration
 $INGEST --project <project_id>     # after editing one project
 $INGEST --changed                  # after mixed edits — diffs against state manifest
 $INGEST --all                      # full refresh
@@ -228,22 +232,36 @@ $INGEST --docs                     # central docs only
 
 ## Configuration
 
-`.env` (copy from `.env.example`):
+**Remote server (recommended for most users):** BERIL runs a shared OpenViking
+server (currently the dev host `https://beril-dev.kbase.us`). The one-call setup
+is `beril login` — it validates your token and links + caches your OpenViking
+credential in `~/.beril`, so the query CLI resolves it automatically:
+
+```bash
+beril login                 # links OpenViking too; no browser cookie needed
+$QUERY doctor               # verify (no --env-file required once cached)
+```
+
+If login couldn't reach OpenViking (or you logged in before this was wired up),
+link it separately against the same stored token:
+
+```bash
+beril ov setup              # or `beril ov setup --regenerate` to rotate the key
+beril ov status             # show the cached credential + server health
+```
+
+`ContextConfig.from_env` precedence is: explicit env vars → the `~/.beril`
+cached credential → the local default URL. So `OPENVIKING_URL` /
+`OPENVIKING_API_KEY` (in `.env` or the shell) still override the cache when set
+— useful for CI or pointing at a different server. `beril ov print-env` emits
+those two lines if you'd rather populate `.env` (`eval "$(beril ov print-env)"`).
+
+`.env` keys (copy from `.env.example`), when you set them explicitly:
 
 - `OPENVIKING_URL` — defaults to `http://127.0.0.1:1933`
 - `OPENVIKING_API_KEY` — only when the server enforces auth (remote deployments)
 
-**Remote server (recommended for most users):** BERIL runs a shared OpenViking
-server (currently the dev host `https://beril-dev.kbase.us`). Get a one-time API
-key and write it into `.env` with the helper, then verify:
-
-```bash
-uv run knowledge/scripts/setup_remote_ov.py --cookie '<beril_session cookie>'
-$QUERY doctor
-```
-
-Full walkthrough (how to copy the cookie, rotation, troubleshooting):
-`docs/remote-openviking-setup.md`.
+Full walkthrough (rotation, troubleshooting): `docs/remote-openviking-setup.md`.
 
 **Local server:** copy `knowledge/openviking/ov.conf.example` → `knowledge/openviking/ov.conf` and set the OpenRouter key in `embedding` and the CBORG key in `vlm`. The local `ov.conf` is gitignored.
 

--- a/docs/remote-openviking-setup.md
+++ b/docs/remote-openviking-setup.md
@@ -1,106 +1,81 @@
 # Remote OpenViking — New User Setup
 
 The BERIL knowledge context layer (project reports + central docs, searchable
-with `knowledge_query.py`) runs on a shared **remote OpenViking server**. This
-is a one-time setup: you exchange your BERIL login for an OpenViking API key,
-put it in `.env`, and then query freely — you don't need to run a local server.
+with `knowledge_query.py`) runs on a shared **remote OpenViking server**. Setup
+is a single command: `beril login` validates your BERIL token and, in the same
+step, provisions and caches your OpenViking credential — after that you can
+query freely without running a local server.
 
 > ⚠️ **The server currently runs on the dev host `https://beril-dev.kbase.us`.**
 > This is temporary. When OpenViking moves to production, substitute the new
-> base URL everywhere below (or pass `--server <url>` to the helper). Every
-> example uses a single `SERVER=` line so there's exactly one place to change.
-
-```bash
-SERVER=https://beril-dev.kbase.us     # ← the only host-specific value
-```
+> base URL (or pass `--base-url <url>` to `beril login`).
 
 ## Prerequisites
 
-- The repo cloned, with `uv` installed.
-- A `.env` file: `cp .env.example .env` if you don't have one.
-- An ORCiD you can log in with.
+- The repo cloned, with `uv` installed, and the `beril` CLI available.
+- An ORCiD you can log in with, and a BERIL personal access token (create one at
+  `https://beril-dev.kbase.us/account/tokens`).
 
 ## Step 1 — Log in
 
-Open **`https://beril-dev.kbase.us`** in your browser and log in with your
-ORCiD. Logging in sets a session cookie named **`beril_session`**.
-
-## Step 2 — Copy your `beril_session` cookie
-
-The server identifies you by that cookie. It's `HttpOnly` (not readable from
-JavaScript), but you can copy it from your browser's dev tools:
-
-- **Chrome/Edge:** DevTools (`F12` / `Cmd-Opt-I`) → **Application** tab →
-  **Storage → Cookies → `https://beril-dev.kbase.us`** → click `beril_session`
-  → copy its **Value**.
-- **Firefox:** DevTools → **Storage** tab → **Cookies** → select the site →
-  copy the `beril_session` value.
-
-The value is a long opaque string — copy the whole thing.
-
-## Step 3 — Get your API key
-
-### Option A — helper script (recommended)
-
 ```bash
-uv run knowledge/scripts/setup_remote_ov.py --cookie '<paste beril_session value>'
+beril login --base-url https://beril-dev.kbase.us
 ```
 
-It creates your OpenViking account (idempotent), fetches your key, writes
-`OPENVIKING_URL` and `OPENVIKING_API_KEY` into `.env`, and verifies the
-connection. Useful flags:
+Paste your personal access token when prompted (input doesn't echo), or pass it
+with `--token`. `beril login` then:
 
-- `--server "$SERVER"` — point at a different host (default is beril-dev).
-- `--regenerate` — mint a fresh key, invalidating the old one (rotation, or the
-  recovery path if you hit the 409 case below).
-- `--print-only` — print the two env lines instead of writing `.env`.
-- The cookie can also come from `$BERIL_SESSION` or an interactive prompt.
+1. validates the token against BERIL, and
+2. provisions your OpenViking account (idempotent) and **caches the OpenViking
+   URL + key in `~/.beril`** alongside your BERIL login.
 
-### Option B — manual (curl)
+That cached credential is what the query CLI reads — no browser cookie, no
+manual `.env` editing.
 
-The key comes from **two** calls: create the account, then read the credential.
-
-```bash
-COOKIE='<paste beril_session value>'
-
-# 1. Create your OpenViking account (idempotent — safe to re-run).
-curl -X POST "$SERVER/api/ov/user" -H "Cookie: beril_session=$COOKIE"
-
-# 2. Read your key (note: GET, not POST).
-curl "$SERVER/api/ov/credentials" -H "Cookie: beril_session=$COOKIE" \
-  | jq -r .user_key
-```
-
-> The key is **not** returned by `POST /api/ov/user` (that returns
-> `{"created": true}`). You always retrieve it with **`GET /api/ov/credentials`**.
-
-Then put both values in `.env` (note the `/ov` suffix on the URL):
-
-```bash
-OPENVIKING_URL=https://beril-dev.kbase.us/ov
-OPENVIKING_API_KEY=<the user_key from step 2>
-```
-
-## Step 4 — Verify
+## Step 2 — Verify
 
 ```bash
 # Reachability + auth check — tells server-down apart from a bad key.
-uv run --env-file .env knowledge/scripts/knowledge_query.py doctor
+uv run knowledge/scripts/knowledge_query.py doctor
 
 # A real query.
-uv run --env-file .env knowledge/scripts/knowledge_query.py find "metal resistance"
+uv run knowledge/scripts/knowledge_query.py find "metal resistance"
 ```
 
-A healthy `doctor` prints `OpenViking: OK`. After this, you never need the cookie
-again — queries talk directly to the server with your API key, which is
-long-lived until you regenerate it.
+A healthy `doctor` prints `OpenViking: OK`. No `--env-file` is required — the
+query CLI resolves the credential from `~/.beril`.
+
+## If OpenViking wasn't linked at login
+
+`beril login` links OpenViking best-effort: if the server was briefly
+unreachable (or you logged in before this was wired up), the login still
+succeeds but OpenViking is left unlinked. Link it separately against your stored
+token:
+
+```bash
+beril ov setup              # link now (idempotent)
+beril ov status             # show the cached credential + server health
+```
 
 ## Recovery & rotation
 
-- **Lost your key?** Re-run the helper (or `GET /api/ov/credentials`) — it
-  returns the same stored key; nothing is invalidated.
-- **Rotate / force a fresh key?** `setup_remote_ov.py --cookie '...' --regenerate`
-  (this invalidates the old key everywhere it's in use).
+- **Check what's cached:** `beril ov status`.
+- **Rotate / force a fresh key:** `beril ov setup --regenerate` (this
+  invalidates the old key everywhere it's in use). This is also the recovery
+  path for the 409 case below.
+- **Populate `.env` instead** (CI, or a tool that reads env vars):
+  `eval "$(beril ov print-env)"`, or paste the `beril ov print-env` output into
+  `.env`.
+
+## Configuration precedence
+
+`ContextConfig.from_env` resolves the OpenViking credential in this order:
+
+1. **Explicit env vars** — `OPENVIKING_URL` / `OPENVIKING_API_KEY` (from the
+   shell or an `--env-file`). These always win, so CI and "point at a different
+   server" keep working.
+2. **The `~/.beril` cached credential** from `beril login` / `beril ov setup`.
+3. **The local default URL** (`http://127.0.0.1:1933`) with no key.
 
 ## Troubleshooting
 
@@ -109,27 +84,29 @@ Run `knowledge_query.py doctor` first — its verdict tells you what's wrong:
 | Verdict | Meaning | Fix |
 |---|---|---|
 | `OK` | Reachable, key valid | — |
-| `UNREACHABLE` | Server down or wrong URL | Check `OPENVIKING_URL` ends in `/ov`; confirm `$SERVER/ov/health` responds in a browser; check network/VPN |
-| `NO API KEY` | Reachable, but `OPENVIKING_API_KEY` unset | Run the setup helper (Step 3) |
-| `AUTH FAILED` | Reachable, but your key was rejected | Key expired/invalid → `setup_remote_ov.py --regenerate` |
+| `UNREACHABLE` | Server down or wrong URL | Confirm `$SERVER/ov/health` responds in a browser; check network/VPN |
+| `NO API KEY` | Reachable, but no key resolved | Run `beril ov setup` (or `beril login`) |
+| `AUTH FAILED` | Reachable, but your key was rejected | Key expired/invalid → `beril ov setup --regenerate` |
 | `UNHEALTHY` | Reachable, but the server reports itself unhealthy | Server-side — flag a maintainer / check the OV deployment |
 | `ERROR` | Reachable, but an authenticated call failed unexpectedly | Retry; if it persists, check the OV server logs |
 
 Other cases:
 
-- **`HTTP 401` from a curl/helper call** — your `beril_session` cookie is
-  missing or expired. Log in again (Step 1) and re-copy it (Step 2).
-- **`HTTP 409` on `POST /api/ov/user`** — OpenViking already has a user for your
-  ORCiD but BERIL holds no key for it. Run `setup_remote_ov.py --regenerate` (or
-  `POST /api/ov/user/regenerate` then `GET /api/ov/credentials`).
+- **`Not logged in`** — run `beril login` first.
+- **OpenViking not linked after login** — the server was unreachable during
+  login; run `beril ov setup`.
+- **`HTTP 409` / "key exists but BERIL holds none"** — OpenViking already has a
+  user for your ORCiD but BERIL holds no key for it. Run
+  `beril ov setup --regenerate` to mint and store a fresh key.
 - **Quick server liveness, no auth needed:** `curl "$SERVER/ov/health"` should
   return `{"status":"ok","healthy":true,...}`.
 
 ## Security
 
-`OPENVIKING_API_KEY` is a secret. `.env` and `*.env` are gitignored — keep the
-key there, never commit it, and **never paste it into a chat**. If it leaks,
-rotate it with `--regenerate`.
+`OPENVIKING_API_KEY` is a secret. The cached copy in `~/.beril/auth.json` is
+written mode `0600`. If you populate `.env`, note that `.env` and `*.env` are
+gitignored — never commit the key, and **never paste it into a chat**. If it
+leaks, rotate it with `beril ov setup --regenerate`.
 
 ## See also
 

--- a/knowledge/tests/test_config.py
+++ b/knowledge/tests/test_config.py
@@ -1,0 +1,93 @@
+"""Tests for ContextConfig.from_env credential resolution.
+
+Precedence: explicit env vars win, then the credential cached by
+`beril login` / `beril ov setup` in ~/.beril, then the local default URL.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from observatory_context import config as ovcfg
+from observatory_context.config import DEFAULT_OPENVIKING_URL, ContextConfig
+
+
+@pytest.fixture(autouse=True)
+def clear_ov_env(monkeypatch):
+    """Start each test from a known state — no OV env vars set."""
+    monkeypatch.delenv("OPENVIKING_URL", raising=False)
+    monkeypatch.delenv("OPENVIKING_API_KEY", raising=False)
+
+
+def _patch_cache(monkeypatch, value):
+    """Stub the ~/.beril cached-credential lookup."""
+    monkeypatch.setattr(ovcfg, "_cached_ov_credential", lambda: value)
+
+
+class TestFromEnvPrecedence:
+    def test_env_vars_win(self, monkeypatch):
+        monkeypatch.setenv("OPENVIKING_URL", "https://env/ov")
+        monkeypatch.setenv("OPENVIKING_API_KEY", "env_key")
+        _patch_cache(monkeypatch, ("https://cached/ov", "cached_key"))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == "https://env/ov"
+        assert cfg.openviking_api_key == "env_key"
+
+    def test_falls_back_to_cached_credential(self, monkeypatch):
+        _patch_cache(monkeypatch, ("https://cached/ov", "cached_key"))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == "https://cached/ov"
+        assert cfg.openviking_api_key == "cached_key"
+
+    def test_default_url_when_nothing_available(self, monkeypatch):
+        _patch_cache(monkeypatch, (None, None))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == DEFAULT_OPENVIKING_URL
+        assert cfg.openviking_api_key is None
+
+    def test_env_url_with_cached_key_do_not_mix_when_both_env_present(
+        self, monkeypatch
+    ):
+        # If only the URL is set in the env, the key is drawn from the cache —
+        # partial env config still gets completed from ~/.beril.
+        monkeypatch.setenv("OPENVIKING_URL", "https://env/ov")
+        _patch_cache(monkeypatch, ("https://cached/ov", "cached_key"))
+
+        cfg = ContextConfig.from_env(repo_root=Path("."))
+        assert cfg.openviking_url == "https://env/ov"
+        assert cfg.openviking_api_key == "cached_key"
+
+
+class TestCachedCredentialImportGuard:
+    def test_returns_none_pair_when_beril_cli_absent(self, monkeypatch):
+        # Simulate an environment where beril_cli isn't importable.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name.startswith("beril_cli"):
+                raise ImportError("no beril_cli here")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+        assert ovcfg._cached_ov_credential() == (None, None)
+
+    def test_returns_none_pair_when_not_linked(self, monkeypatch):
+        from beril_cli import auth_store
+
+        monkeypatch.setattr(auth_store, "load_ov", lambda: None)
+        assert ovcfg._cached_ov_credential() == (None, None)
+
+    def test_returns_pair_from_auth_store(self, monkeypatch):
+        from beril_cli import auth_store
+
+        monkeypatch.setattr(
+            auth_store, "load_ov", lambda: ("https://srv/ov", "k")
+        )
+        assert ovcfg._cached_ov_credential() == ("https://srv/ov", "k")

--- a/observatory_context/config.py
+++ b/observatory_context/config.py
@@ -10,6 +10,23 @@ PROJECTS_TARGET_URI = "viking://resources/projects/"
 DOCS_TARGET_URI = "viking://resources/docs/"
 
 
+def _cached_ov_credential() -> tuple[str | None, str | None]:
+    """Return ``(ov_url, ov_user_key)`` cached by ``beril login`` / ``beril ov``.
+
+    Reads ~/.beril/auth.json via ``beril_cli.auth_store``. The import is guarded
+    so ``observatory_context`` keeps working in environments where ``beril_cli``
+    isn't on the path (returns ``(None, None)`` — same as no cached credential).
+    """
+    try:
+        from beril_cli import auth_store
+    except ImportError:
+        return (None, None)
+    creds = auth_store.load_ov()
+    if creds is None:
+        return (None, None)
+    return creds
+
+
 @dataclass(frozen=True)
 class ContextConfig:
     repo_root: Path
@@ -19,10 +36,22 @@ class ContextConfig:
     @classmethod
     def from_env(cls, repo_root: Path | None = None) -> "ContextConfig":
         root = repo_root or Path(__file__).resolve().parents[1]
+
+        # Precedence: explicit env vars win (CI, `--env-file .env`, manual
+        # export), then fall back to the credential `beril login` / `beril ov
+        # setup` cached in ~/.beril. This lets the query CLI work with no
+        # env-file once the user has logged in.
+        url = os.getenv("OPENVIKING_URL")
+        key = os.getenv("OPENVIKING_API_KEY")
+        if not url or not key:
+            cached_url, cached_key = _cached_ov_credential()
+            url = url or cached_url
+            key = key or cached_key
+
         return cls(
             repo_root=root,
-            openviking_url=os.getenv("OPENVIKING_URL", DEFAULT_OPENVIKING_URL),
-            openviking_api_key=os.getenv("OPENVIKING_API_KEY"),
+            openviking_url=url or DEFAULT_OPENVIKING_URL,
+            openviking_api_key=key,
         )
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## What

Closes the loop: the knowledge query CLI now works with **no `--env-file`** once a user has run `beril login`. `ContextConfig.from_env` falls back to the OpenViking credential cached in `~/.beril` when the env vars aren't set.

> **Stacked on #339 → #338.** Base branch is `pr2-beril-ov-command`; review/merge those first. The diff here is only the config-fallback + docs commit.

## Changes

- **`observatory_context/config.py`** — `from_env` precedence:
  1. explicit env vars (`OPENVIKING_URL` / `OPENVIKING_API_KEY`) — always win (CI, `--env-file`, "point at another server"),
  2. the `~/.beril` cached credential via `beril_cli.auth_store.load_ov()`,
  3. the local default URL.

  The `beril_cli` import is guarded (`try/except ImportError`), so `observatory_context` still works in any environment where `beril_cli` isn't on the path — it just behaves as "no cached credential". (In the `uv run --script` query CLI, the repo root is on `sys.path` and `auth_store` is stdlib-only, so the fallback resolves there too.)

- **`knowledge/tests/test_config.py`** (new) — env-wins, cache-fallback, default-URL, partial-env completion from cache, and the import-guard behavior.

- **`.claude/skills/knowledge-context/SKILL.md`** — Configuration section now leads with `beril login` / `beril ov setup` as the primary setup and documents the `from_env` precedence; cookie flow demoted to a fallback mention.

- **`docs/remote-openviking-setup.md`** — rewritten around `beril login`; the browser-cookie walkthrough is **removed**.

## Tests

`knowledge/tests/test_config.py` green (7 tests); full `knowledge/tests` suite green under `uv run --group knowledge` (35 passed). The `beril_cli` CLI suite remains green (334). Verified end-to-end locally: with env vars unset, `ContextConfig.from_env()` resolves the URL + key from a real `~/.beril/auth.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
