### PR TITLE
Add a dev mode to the beril start command

### DIFF
--- a/beril_cli/cli.py
+++ b/beril_cli/cli.py
@@ -43,6 +43,12 @@ def main(argv: list[str] | None = None) -> int:
         metavar="VERSION",
         help="Pin to a specific release tag (e.g. v0.3.4.5). Defaults to the latest tag.",
     )
+    start_parser.add_argument(
+        "--dev",
+        action="store_true",
+        default=False,
+        help="Only run the local BERIL without fetching the latest release. Overrides any value given in --version."
+    )
 
     # user
     user_parser = sub.add_parser(
@@ -104,6 +110,7 @@ def main(argv: list[str] | None = None) -> int:
             extra_args=remaining,
             skip_onboard=args.skip_onboard,
             version=args.version,
+            dev_mode=args.dev,
         )
 
     if args.command == "user":

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -154,6 +154,7 @@ def run_start(
     extra_args: list[str] | None = None,
     skip_onboard: bool = False,
     version: str | None = None,
+    dev_mode: bool = False
 ) -> int:
     """Launch the selected coding agent from the repo root."""
     agent = agent or get_default_agent()
@@ -174,9 +175,10 @@ def run_start(
         return 1
 
     # Check out the requested release (or the latest published tag by default).
-    rc = _checkout_release(repo_root, version)
-    if rc != 0:
-        return rc
+    if not dev_mode:
+        rc = _checkout_release(repo_root, version)
+        if rc != 0:
+            return rc
 
     # Refresh KBASE_AUTH_TOKEN in .env from live environment (tokens expire)
     _sync_auth_token(repo_root / ".env")

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -248,3 +248,74 @@ def test_checkout_release_warns_on_fetch_failure_but_continues(monkeypatch, tmp_
     assert rc == 0
     err = capsys.readouterr().err
     assert "git fetch --tags failed" in err
+
+
+# ── run_start dev mode ────────────────────────────────────
+
+
+class _ExecvpReached(Exception):
+    """Sentinel raised in place of os.execvp so run_start stops before replacing the process."""
+
+
+def test_dev_mode_performs_no_git_checkout_or_fetch(monkeypatch, tmp_path):
+    """`beril start --dev` must not fetch, check out, or otherwise mutate the working tree.
+
+    In dev mode the running code is the code under development, so touching git would be
+    both surprising and destructive to uncommitted work. We record every subprocess.run
+    argv and assert none of them are git commands.
+    """
+    calls = _patch_run(monkeypatch, lambda argv: _completed())
+
+    # Keep run_start on the happy path up to the point it would exec the agent.
+    monkeypatch.setattr(start.shutil, "which", lambda _agent: "/usr/bin/claude")
+    monkeypatch.setattr(start, "_find_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(start.os, "chdir", lambda _path: None)
+    monkeypatch.setattr(start, "print_jupyterhub_path_hint", lambda _root: None)
+    monkeypatch.setattr(start, "get_default_agent", lambda: "claude")
+    monkeypatch.setattr(start, "get_vertex_config", lambda: {"enabled": False})
+    # If _checkout_release ever runs in dev mode, fail loudly rather than silently.
+    monkeypatch.setattr(
+        start,
+        "_checkout_release",
+        lambda *_a, **_kw: pytest.fail("_checkout_release must not run in dev mode"),
+    )
+
+    def _boom(*_a, **_kw):
+        raise _ExecvpReached
+
+    monkeypatch.setattr(start.os, "execvp", _boom)
+
+    with pytest.raises(_ExecvpReached):
+        start.run_start(agent="claude", dev_mode=True)
+
+    git_calls = [argv for argv in calls if argv and argv[0] == "git"]
+    assert git_calls == [], f"dev mode ran git commands: {git_calls}"
+
+
+def test_non_dev_mode_does_check_out_release(monkeypatch, tmp_path):
+    """Guard against the inverse: without --dev, run_start must still check out a release."""
+    _patch_run(monkeypatch, lambda argv: _completed())
+    monkeypatch.setattr(start.shutil, "which", lambda _agent: "/usr/bin/claude")
+    monkeypatch.setattr(start, "_find_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(start.os, "chdir", lambda _path: None)
+    monkeypatch.setattr(start, "print_jupyterhub_path_hint", lambda _root: None)
+    monkeypatch.setattr(start, "get_default_agent", lambda: "claude")
+    monkeypatch.setattr(start, "get_vertex_config", lambda: {"enabled": False})
+
+    checkout_calls: list[str | None] = []
+
+    def _fake_checkout(_root, version):
+        checkout_calls.append(version)
+        return 0
+
+    monkeypatch.setattr(start, "_checkout_release", _fake_checkout)
+
+    def _boom(*_a, **_kw):
+        raise _ExecvpReached
+
+    monkeypatch.setattr(start.os, "execvp", _boom)
+
+    with pytest.raises(_ExecvpReached):
+        start.run_start(agent="claude", version="v0.0.1", dev_mode=False)
+
+    assert checkout_calls == ["v0.0.1"]


### PR DESCRIPTION
Right now running `beril start` will pull some version of the codebase (defaulting on the latest release), which might override some local changes.

This adds a `--dev` flag that skips the version check and makes no changes.

Run with `beril start --dev` to make that work.