### PR TITLE
add BERIL webapp things - login state; webapp and context manager accessibility - to beril doctor command

### DIFF
--- a/beril_cli/doctor.py
+++ b/beril_cli/doctor.py
@@ -9,6 +9,17 @@ import subprocess
 import sys
 from pathlib import Path
 
+import httpx
+
+from beril_cli import auth_store, config
+
+# Public, unauthenticated health endpoints. `/health` is the BERIL webapp's own
+# check; `/ov/health` is the nginx proxy path that forwards to OpenViking's
+# `/health` (the "context manager" users interact with).
+_HEALTH_PATH = "/health"
+_OV_HEALTH_PATH = "/ov/health"
+_HTTP_TIMEOUT_SECONDS = 10.0
+
 
 def _find_repo_root() -> Path | None:
     """Walk up from cwd looking for PROJECT.md (repo marker)."""
@@ -48,6 +59,83 @@ def _run_silent(cmd: list[str], timeout: int = 10, env: dict | None = None) -> t
         return -1, "", f"{cmd[0]}: command not found"
     except subprocess.TimeoutExpired:
         return -1, "", f"{cmd[0]}: timed out"
+
+
+def _get_health(url: str) -> tuple[int | None, dict | None, str]:
+    """GET a public health endpoint. Returns (status_code, json_body, error).
+
+    ``status_code`` is None and ``error`` is populated when the server could
+    not be reached at all (DNS, connection, timeout). Otherwise ``status_code``
+    is the HTTP status and ``error`` is empty; ``json_body`` is the parsed body
+    when the response was JSON, else None.
+    """
+    try:
+        resp = httpx.get(url, timeout=_HTTP_TIMEOUT_SECONDS)
+    except httpx.TimeoutException:
+        return None, None, "timed out"
+    except httpx.HTTPError as exc:
+        return None, None, str(exc) or exc.__class__.__name__
+    try:
+        body = resp.json()
+    except ValueError:
+        body = None
+    return resp.status_code, body if isinstance(body, dict) else None, ""
+
+
+def _check_beril_login() -> tuple[str, str]:
+    """Return (status, detail) describing the stored BERIL login."""
+    record = auth_store.load()
+    if record is None:
+        return "WARN", "not logged in — run `beril login`"
+
+    name = record.display_name or record.orcid_id
+    # Validate the stored token so an expired/revoked login is caught, not just
+    # reported as "logged in" from a stale file.
+    url = record.base_url.rstrip("/") + "/api/user/whoami"
+    try:
+        resp = httpx.get(
+            url,
+            headers={"Authorization": f"Bearer {record.token}"},
+            timeout=_HTTP_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError:
+        # Can't reach the server to validate — the login may still be fine.
+        return "WARN", f"{name} (stored token; server unreachable to verify)"
+
+    if resp.status_code in (401, 403):
+        return "FAIL", f"stored token rejected ({resp.status_code}) — run `beril login`"
+    if resp.status_code >= 400:
+        return "WARN", f"{name} (could not verify token: HTTP {resp.status_code})"
+    return "PASS", f"{name} ({record.orcid_id})"
+
+
+def _check_beril_webapp(base_url: str) -> tuple[str, str]:
+    """Return (status, detail) for the BERIL webapp's public /health endpoint."""
+    code, body, error = _get_health(base_url + _HEALTH_PATH)
+    if code is None:
+        return "FAIL", f"unreachable at {base_url} ({error})"
+    if code != 200:
+        return "FAIL", f"HTTP {code} from {base_url}{_HEALTH_PATH}"
+    health = (body or {}).get("status")
+    if health == "healthy":
+        return "PASS", f"healthy ({base_url})"
+    if health:
+        # e.g. "degraded" — reachable but a subservice (like the DB) is down.
+        return "WARN", f"{health} ({base_url})"
+    return "PASS", f"reachable ({base_url})"
+
+
+def _check_context_manager(base_url: str) -> tuple[str, str]:
+    """Return (status, detail) for OpenViking (the "context manager") via /ov/health."""
+    code, body, error = _get_health(base_url + _OV_HEALTH_PATH)
+    if code is None:
+        return "FAIL", f"unreachable ({error})"
+    if code != 200:
+        return "FAIL", f"HTTP {code} from {base_url}{_OV_HEALTH_PATH}"
+    status = (body or {}).get("status")
+    if status in ("ok", "healthy", None):
+        return "PASS", f"reachable ({base_url}{_OV_HEALTH_PATH})"
+    return "WARN", f"{status} ({base_url}{_OV_HEALTH_PATH})"
 
 
 def run_doctor() -> int:
@@ -119,7 +207,21 @@ def run_doctor() -> int:
     else:
         checks.append(("Agent CLIs", "WARN", "none found (claude, codex, gemini)"))
 
-    # 7. BERDL environment
+    # 7. BERIL webapp: login state + service availability. These are
+    # informational (WARN, not FAIL) so a transient outage doesn't make doctor
+    # exit non-zero for an otherwise-fine local setup.
+    base_url = config.get_base_url()
+
+    status, detail = _check_beril_login()
+    checks.append(("BERIL login", status, detail))
+
+    status, detail = _check_beril_webapp(base_url)
+    checks.append(("BERIL webapp", status, detail))
+
+    status, detail = _check_context_manager(base_url)
+    checks.append(("Context manager", status, detail))
+
+    # 8. BERDL environment
     if repo_root:
         detect_script = repo_root / "scripts" / "detect_berdl_environment.py"
         if detect_script.exists():

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,131 @@
+"""Tests for the BERIL webapp health checks added to `beril doctor`.
+
+Covers the three helpers that hit the network — login validation, webapp
+availability, and OpenViking ("context manager") availability — by building
+real ``httpx.Response`` objects and stubbing ``httpx.get``. The higher-level
+``run_doctor`` orchestration and the pre-existing local checks are exercised by
+running the command in the other suites; here we pin the new logic.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+
+from beril_cli import auth_store, doctor
+from beril_cli.auth_store import AuthRecord
+
+BASE_URL = "https://beril.example.test"
+
+
+def _response(body: dict | str, status: int = 200) -> httpx.Response:
+    content = json.dumps(body).encode() if isinstance(body, dict) else body.encode()
+    return httpx.Response(status_code=status, content=content)
+
+
+def _record() -> AuthRecord:
+    return AuthRecord(
+        token="beril_tok",
+        base_url=BASE_URL,
+        orcid_id="0000-0001-2345-6789",
+        display_name="Alice",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _check_beril_login
+# ---------------------------------------------------------------------------
+
+
+class TestCheckLogin:
+    def test_not_logged_in(self):
+        with patch.object(auth_store, "load", return_value=None):
+            status, detail = doctor._check_beril_login()
+        assert status == "WARN"
+        assert "beril login" in detail
+
+    def test_valid_token_passes(self):
+        with patch.object(auth_store, "load", return_value=_record()), \
+             patch.object(doctor.httpx, "get", return_value=_response({"orcid_id": "x"})):
+            status, detail = doctor._check_beril_login()
+        assert status == "PASS"
+        assert "Alice" in detail and "0000-0001-2345-6789" in detail
+
+    def test_rejected_token_fails(self):
+        with patch.object(auth_store, "load", return_value=_record()), \
+             patch.object(doctor.httpx, "get", return_value=_response("nope", status=401)):
+            status, detail = doctor._check_beril_login()
+        assert status == "FAIL"
+        assert "401" in detail
+
+    def test_server_unreachable_warns_not_fails(self):
+        with patch.object(auth_store, "load", return_value=_record()), \
+             patch.object(doctor.httpx, "get", side_effect=httpx.ConnectError("boom")):
+            status, detail = doctor._check_beril_login()
+        # Stored login may still be valid; don't hard-fail on a network blip.
+        assert status == "WARN"
+        assert "Alice" in detail
+
+
+# ---------------------------------------------------------------------------
+# _check_beril_webapp
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWebapp:
+    def test_healthy(self):
+        with patch.object(doctor.httpx, "get", return_value=_response({"status": "healthy"})):
+            status, detail = doctor._check_beril_webapp(BASE_URL)
+        assert status == "PASS"
+        assert "healthy" in detail
+
+    def test_degraded_warns(self):
+        with patch.object(doctor.httpx, "get", return_value=_response({"status": "degraded"})):
+            status, detail = doctor._check_beril_webapp(BASE_URL)
+        assert status == "WARN"
+        assert "degraded" in detail
+
+    def test_non_200_fails(self):
+        with patch.object(doctor.httpx, "get", return_value=_response("down", status=503)):
+            status, detail = doctor._check_beril_webapp(BASE_URL)
+        assert status == "FAIL"
+        assert "503" in detail
+
+    def test_unreachable_fails(self):
+        with patch.object(doctor.httpx, "get", side_effect=httpx.ConnectError("boom")):
+            status, detail = doctor._check_beril_webapp(BASE_URL)
+        assert status == "FAIL"
+        assert "unreachable" in detail
+
+
+# ---------------------------------------------------------------------------
+# _check_context_manager
+# ---------------------------------------------------------------------------
+
+
+class TestCheckContextManager:
+    def test_ok(self):
+        with patch.object(doctor.httpx, "get", return_value=_response({"status": "ok"})):
+            status, detail = doctor._check_context_manager(BASE_URL)
+        assert status == "PASS"
+        assert "/ov/health" in detail
+
+    def test_reachable_without_status_field(self):
+        # OpenViking's own /health may not use a "status" key; a 200 is enough.
+        with patch.object(doctor.httpx, "get", return_value=_response({"uptime": 1})):
+            status, _ = doctor._check_context_manager(BASE_URL)
+        assert status == "PASS"
+
+    def test_non_200_fails(self):
+        with patch.object(doctor.httpx, "get", return_value=_response("down", status=503)):
+            status, detail = doctor._check_context_manager(BASE_URL)
+        assert status == "FAIL"
+        assert "503" in detail
+
+    def test_timeout_fails(self):
+        with patch.object(doctor.httpx, "get", side_effect=httpx.TimeoutException("slow")):
+            status, detail = doctor._check_context_manager(BASE_URL)
+        assert status == "FAIL"
+        assert "timed out" in detail


### PR DESCRIPTION
As the title says, this does a quick check to see if you're logged in to BERIL and if the webapp is available or not, depending on your config.

