### PR TITLE
feat(dashboard): show when the agent is waiting on you

### DIFF
--- a/.claude/hooks/agent_state.py
+++ b/.claude/hooks/agent_state.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Record whether the agent is blocked on a human, for the live dashboard.
+
+Writes `projects/<id>/.agent-state.json`. One dashboard, one project, one file;
+`tools/dashboard.py` reads it in `scan()` and renders a chip, a strip, a title
+marker and a favicon dot from it. Nothing else consumes it.
+
+Registered on four events, and **which four is a measured result, not the
+documented shape**. The hook docs list a `Notification` matcher over
+`permission_prompt | agent_needs_input | idle_prompt | agent_completed` and give
+no payload schema, so this was derived by registering a logging hook against
+Claude Code 2.1.220 and driving a real session through a pty:
+
+- `PermissionRequest` fires ~2s after the blocking tool call and carries
+  `tool_name` + the full `tool_input`. It does **not** fire for a call the
+  permission rules auto-allow (verified by allowlisting `Bash(sw_vers:*)` and
+  watching it go silent), so its presence alone means a human is being asked.
+  It is the only event that carries what the agent is asking *for*.
+- `Notification/permission_prompt` fires ~6s *later* and its message is the
+  compile-time constant "Claude needs your permission" — no tool, no argument.
+  It is kept because it is the only signal for the notification types that never
+  reach `PermissionRequest`, and because `agent_needs_input` puts a real detail
+  in its message. It never overwrites a detail `PermissionRequest` already
+  recorded for the same prompt: generic text must not displace specific text.
+- `Stop` carries `last_assistant_message`, which is the closing line the reader
+  would otherwise have to switch tabs to see.
+- `UserPromptSubmit` means the human is back at the keyboard, whatever the file
+  said.
+
+`agent_needs_input` and `agent_completed` never fired for the main session in
+any probe: in the bundle they are emitted from the background-agent fleet
+tracker, labelled per sub-agent. They cost nothing to keep listening for.
+
+Best-effort, like every other hook here: it always exits 0 and it prints
+nothing. A `UserPromptSubmit` hook's stdout is appended to the agent's context,
+so a stray `print` here would feed the dashboard's plumbing back into the
+conversation.
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+STATE_FILE = ".agent-state.json"
+
+# "leave the file exactly as it is", which None cannot mean — None clears it.
+UNCHANGED = object()
+
+# Long enough for a real `Bash` command line, short enough that the amber strip
+# stays one line in the header. The renderer escapes it; it does not trim it.
+MAX_DETAIL = 200
+
+# The argument that identifies a tool call to a human, in falling order of
+# usefulness. Searched at any depth because `AskUserQuestion` — the single most
+# important case, the agent literally asking a question — nests its text under
+# `questions[0].question` while `Bash` puts it flat in `command`.
+DETAIL_KEYS = ("command", "question", "file_path", "path", "url", "pattern", "prompt")
+
+# Fixed strings Claude Code sends as a Notification `message`. They carry no
+# information a `state` of `waiting` does not already carry, so they are dropped
+# rather than shown — "waiting · Claude needs your permission" is two words for
+# one fact. A message that is *not* on this list (`agent_needs_input` formats
+# "<label> needs your input: <what>") is real detail and is kept.
+GENERIC = {"Claude needs your permission", "Claude is waiting for your input"}
+
+# absolute(), not resolve(): resolve() follows a symlinked copy of this hook back
+# to wherever it really lives, which in a test tree is the wrong repo. Same
+# reasoning as dash_stop.py, which is the other half of this file's lifecycle.
+ROOT = Path(__file__).absolute().parent.parent.parent
+
+
+def find_detail(value, keys=DETAIL_KEYS) -> "str | None":
+    """The first non-empty string under any of `keys`, at any depth.
+
+    Keys are tried in priority order at each level before descending, so a
+    `command` two levels down still loses to a `question` at the top.
+    """
+    if isinstance(value, dict):
+        for key in keys:
+            found = value.get(key)
+            if isinstance(found, str) and found.strip():
+                return found.strip()
+        for child in value.values():
+            found = find_detail(child, keys)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            found = find_detail(child, keys)
+            if found:
+                return found
+    return None
+
+
+def read_state(project: Path) -> dict:
+    try:
+        current = json.loads((project / STATE_FILE).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return current if isinstance(current, dict) else {}
+
+
+def write_state(project: Path, record: "dict | None") -> None:
+    """Replace the state file, or remove it when `record` is None.
+
+    Atomically, via a sibling and `os.replace`. The dashboard polls this
+    directory every 4s and `scan()` walks every file in it, so a reader landing
+    mid-write is the expected interleaving rather than a rare one — writing in
+    place is a bug already fixed once in `_write_snapshot`, and it would surface
+    here as a `waiting` banner flickering off and on.
+    """
+    target = project / STATE_FILE
+    if record is None:
+        try:
+            target.unlink()
+        except OSError:
+            pass
+        return
+    staging = target.with_name(STATE_FILE + ".tmp")
+    staging.write_text(json.dumps(record), encoding="utf-8")
+    os.replace(staging, target)
+
+
+def resolve(payload: dict) -> "Path | None":
+    """The project this session is working on, or None.
+
+    `beril_cli.project_resolution` is imported rather than reimplemented: this
+    would be the fourth copy of the lookup, and the previous duplication put the
+    same first-match-wins bug in two places at once.
+    """
+    sys.path.insert(0, str(ROOT))
+    try:
+        from beril_cli.project_resolution import project_from_runtime, resolve_project
+    except Exception:
+        return None
+
+    try:
+        # Explicit binding, then a path in the payload, then cwd, then branch.
+        project_id = resolve_project(payload, repo_root=ROOT)
+    except Exception:
+        project_id = None  # a shelled-out git call can fail; runtime.json answers
+    if not project_id:
+        # The signal the others cannot supply: a project created *during* this
+        # session has no cwd, branch or path to be found by.
+        project_id = project_from_runtime(payload.get("session_id"), ROOT)
+    if not project_id:
+        return None
+    project = ROOT / "projects" / project_id
+    return project if project.is_dir() else None
+
+
+def record_for(payload: dict, project: Path):
+    """The new state file contents: a dict, None to clear, or UNCHANGED."""
+    event = payload.get("hook_event_name")
+
+    if event == "UserPromptSubmit":
+        return None
+
+    if event == "PermissionRequest":
+        tool = str(payload.get("tool_name") or "a tool")
+        argument = find_detail(payload.get("tool_input"))
+        detail = f"{tool}: {argument}" if argument else tool
+    elif event == "Notification":
+        # `PermissionRequest` fires ~6s earlier and knows the tool; this event
+        # does not. Restating `waiting` here would blank that detail out and
+        # reset `since`, which is the key the browser debounces notifications on
+        # — so the reader would be told twice about one prompt.
+        if read_state(project).get("state") == "waiting":
+            return UNCHANGED
+        message = str(payload.get("message") or "")
+        detail = "" if message in GENERIC else message
+    elif event == "Stop":
+        detail = str(payload.get("last_assistant_message") or "")
+    else:
+        return UNCHANGED
+
+    return {
+        "state": "turn_ended" if event == "Stop" else "waiting",
+        "detail": detail[:MAX_DETAIL],
+        "since": time.time(),
+        # Cross-checked against runtime.json by the renderer: a state file left
+        # behind by a session that is long gone must not read as `waiting`.
+        "session_id": payload.get("session_id") or "",
+    }
+
+
+def main() -> None:
+    payload = json.load(sys.stdin)
+    project = resolve(payload)
+    if project is None:
+        return
+    record = record_for(payload, project)
+    if record is not UNCHANGED:
+        write_state(project, record)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass  # a hook that blocks the agent is worse than a stale dashboard

--- a/.claude/hooks/agent_state.py
+++ b/.claude/hooks/agent_state.py
@@ -48,6 +48,11 @@ STATE_FILE = ".agent-state.json"
 # "leave the file exactly as it is", which None cannot mean — None clears it.
 UNCHANGED = object()
 
+# The only events that may write a state. Everything else — every tool call, and
+# every event Claude Code adds after this was written — means the agent moved on,
+# which it does only once a human has unblocked it, so it clears. See `main`.
+SETS_STATE = {"PermissionRequest", "Notification", "Stop", "UserPromptSubmit"}
+
 # Long enough for a real `Bash` command line, short enough that the amber strip
 # stays one line in the header. The renderer escapes it; it does not trim it.
 MAX_DETAIL = 200
@@ -218,14 +223,21 @@ def record_for(payload: dict, project: Path):
         argument = find_detail(payload.get("tool_input"))
         detail = f"{tool}: {argument}" if argument else tool
     elif event == "Notification":
-        # `PermissionRequest` fires ~6s earlier and knows the tool; this event
-        # does not. Restating `waiting` here would blank that detail out and
-        # reset `since`, which is the key the browser debounces notifications on
-        # — so the reader would be told twice about one prompt.
-        if read_state(project).get("state") == "waiting":
-            return UNCHANGED
+        # A `Notification` only ever *adds* information, never replaces it.
+        #
+        # Its two common messages are fixed strings that say nothing a `state`
+        # does not already say, and acting on them is actively wrong in both
+        # directions. `permission_prompt` arrives ~6s after `PermissionRequest`
+        # already recorded the tool, so writing would blank that detail and
+        # reset `since` — the browser's debounce key — and announce one prompt
+        # twice. `idle_prompt` arrives 60s after *every* `Stop`, so writing
+        # turned a finished turn into a detail-less "waiting for you" a minute
+        # later, every single turn, notification and all. That is precisely how
+        # this feature would have got itself muted.
         message = str(payload.get("message") or "")
-        detail = "" if message in GENERIC else message
+        if message in GENERIC or read_state(project).get("state") == "waiting":
+            return UNCHANGED
+        detail = message
     elif event == "Stop":
         detail = str(payload.get("last_assistant_message") or "")
     else:
@@ -243,9 +255,23 @@ def record_for(payload: dict, project: Path):
 
 def main() -> None:
     payload = json.load(sys.stdin)
-    # Before `resolve`, because this is the one event that fires on every single
-    # tool call and it does not need a project to do its job.
-    if payload.get("hook_event_name") == "PostToolUse":
+
+    # **Anything that is not one of the four above means the agent moved on, and
+    # the agent only moves on because a human unblocked it.** So the default is
+    # to clear rather than to ignore: it needs no list of which events count as
+    # progress, it covers the ones Claude Code has not shipped yet, and it
+    # cannot be wrong in the dangerous direction — the failure mode of clearing
+    # early is a strip that vanishes, and of clearing late is a strip that lies.
+    #
+    # `Notification` has to stay out of it despite looking like progress, and
+    # this is the whole reason the rule is "not a setter" rather than "anything
+    # fired": it arrives ~6s *into* an unanswered prompt, so treating it as
+    # movement would blank the strip six seconds after it appeared, every time.
+    #
+    # Cheap on purpose. This branch takes `PostToolUse`, which fires on every
+    # tool call, so it resolves no project at all — the state file already
+    # records whose it is.
+    if payload.get("hook_event_name") not in SETS_STATE:
         return clear_waiting(payload.get("session_id"))
 
     project = resolve(payload)

--- a/.claude/hooks/agent_state.py
+++ b/.claude/hooks/agent_state.py
@@ -56,7 +56,14 @@ MAX_DETAIL = 200
 # usefulness. Searched at any depth because `AskUserQuestion` — the single most
 # important case, the agent literally asking a question — nests its text under
 # `questions[0].question` while `Bash` puts it flat in `command`.
-DETAIL_KEYS = ("command", "question", "file_path", "path", "url", "pattern", "prompt")
+#
+# `skill` and `query` are here because a bare tool name is a poor answer for the
+# two that ask most often: "Skill" alone says nothing, and an MCP search tool is
+# only meaningful as what it is searching for.
+DETAIL_KEYS = (
+    "command", "question", "skill", "query",
+    "file_path", "path", "url", "pattern", "prompt",
+)
 
 # Fixed strings Claude Code sends as a Notification `message`. They carry no
 # information a `state` of `waiting` does not already carry, so they are dropped
@@ -121,6 +128,54 @@ def write_state(project: Path, record: "dict | None") -> None:
     staging = target.with_name(STATE_FILE + ".tmp")
     staging.write_text(json.dumps(record), encoding="utf-8")
     os.replace(staging, target)
+
+
+def clear_waiting(session_id) -> None:
+    """Drop this session's `waiting`, wherever it is. The answer arrived.
+
+    Claude Code emits **no event for "the prompt was answered"** — measured, by
+    logging every hook across an approved prompt. `PreToolUse` fires *before*
+    `PermissionRequest`, so it cannot mean granted; the first thing that happens
+    only because a human said yes is `PostToolUse`, when the tool has run.
+
+    Without it the strip clears at `Stop`, which is the end of the whole turn.
+    Approving a `Skill` and then watching the agent work for ten minutes under a
+    banner saying it is still blocked on you is the bug this fixes, and it is
+    worse than showing nothing: the reader learns to distrust the strip.
+
+    **No project resolution here, deliberately.** This runs after *every* tool
+    call, so it skips the git subprocess and the `beril_cli` import that
+    `resolve` needs — the state file already records which session wrote it, and
+    that is the only question being asked. Session-scoped, so two sessions in
+    one clone cannot clear each other's.
+
+    That still leaves 59ms against the resolving path's 78ms, and 36ms of it is
+    bare `python3` startup — so `settings.json` wraps this one in the same kind
+    of shell guard `beril-runtime.sh` uses, and never starts an interpreter when
+    no state file exists at all (6ms). The guard is nearly free here rather than
+    a compromise: between `UserPromptSubmit` clearing the file and `Stop`
+    writing the next one, a state file exists *only* while a prompt is genuinely
+    pending, which is exactly when this needs to run.
+
+    Only `waiting` is cleared. `turn_ended` is a fact about the past that the
+    next `UserPromptSubmit` retires; a tool call has nothing to say about it.
+    """
+    if not session_id:
+        return
+    for path in (ROOT / "projects").glob("*/" + STATE_FILE):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if (
+            isinstance(record, dict)
+            and record.get("state") == "waiting"
+            and record.get("session_id") == session_id
+        ):
+            try:
+                path.unlink()
+            except OSError:
+                pass
 
 
 def resolve(payload: dict) -> "Path | None":
@@ -188,6 +243,11 @@ def record_for(payload: dict, project: Path):
 
 def main() -> None:
     payload = json.load(sys.stdin)
+    # Before `resolve`, because this is the one event that fires on every single
+    # tool call and it does not need a project to do its job.
+    if payload.get("hook_event_name") == "PostToolUse":
+        return clear_waiting(payload.get("session_id"))
+
     project = resolve(payload)
     if project is None:
         return

--- a/.claude/hooks/dash_stop.py
+++ b/.claude/hooks/dash_stop.py
@@ -72,6 +72,18 @@ def main() -> None:
     if not projects:
         return
 
+    # The clean half of "refuse to claim the agent is waiting when it is not".
+    # `.agent-state.json` is written by `.claude/hooks/agent_state.py` and has no
+    # natural end: a session that exits while a permission prompt is open leaves
+    # `waiting` on disk with nobody left to answer it. Removing it here covers
+    # every exit Claude Code gets to announce; the renderer expires the file on
+    # age and session id for the exits it does not (pod culled, SIGKILL).
+    for name in projects:
+        try:
+            (ROOT / "projects" / name / ".agent-state.json").unlink()
+        except OSError:
+            pass
+
     # Match the process's argv, not the port: tools/dashboard.py rejects pidfiles
     # because they misfire on a recycled PID, and killing whatever holds 87xx has
     # the same failure mode against an unrelated process that grabbed it.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,46 @@
         ]
       }
     ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/agent_state.py"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/agent_state.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/agent_state.py"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/agent_state.py"
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,14 @@
             "command": "bash .claude/hooks/beril-runtime.sh"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'cd \"${CLAUDE_PROJECT_DIR:-.}\" 2>/dev/null; if ls projects/*/.agent-state.json >/dev/null 2>&1; then python3 .claude/hooks/agent_state.py; else cat >/dev/null; fi; exit 0'"
+          }
+        ]
       }
     ],
     "PermissionRequest": [

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,10 @@ projects/*/dashboard.html
 # Session pin marker — see PROJECT.md "Telling the tools which project"
 projects/*/.beril-pin
 projects/*/.dash.log
+# Whether the agent is blocked on a human right now — true for seconds, and
+# only ever about the machine it was written on.
+projects/*/.agent-state.json
+projects/*/.agent-state.json.tmp
 
 # UI application
 ui/data/cache.json

--- a/docs/live-dashboard-design.md
+++ b/docs/live-dashboard-design.md
@@ -158,6 +158,23 @@ a `Skill` and watching the agent work for ten minutes under "the agent is waitin
 for you" was the reported symptom. A banner that is wrong for minutes is worse
 than no banner; the reader learns to ignore it.
 
+The rule is therefore **"anything that is not one of the four writers clears"**,
+not a list of events that count as progress: the agent only moves on once a
+human unblocked it, so clearing by default also covers whatever Claude Code
+ships next. `Notification` is the exception that forces it to be phrased that
+way rather than as "any event fired" — it arrives ~6s *into* an unanswered
+prompt, so treating it as movement would blank the strip six seconds after it
+appeared, every time.
+
+`Notification` never replaces information for the same reason its two common
+messages are dropped. Both are fixed strings that restate the state they are
+attached to, and acting on either is wrong in a different direction:
+`permission_prompt` would blank the tool `PermissionRequest` already recorded
+and reset the debounce key, announcing one prompt twice; `idle_prompt`, which
+fires 60s after *every* `Stop`, turned each finished turn into a detail-less
+"waiting for you" a minute later, notification included — this feature muting
+itself, on a timer.
+
 That clear needs no project resolution: the state file records which session
 wrote it, which is the whole question, and keeps one session from clearing
 another's. It still costs 59ms against the resolving path's 78ms, of which 36ms

--- a/docs/live-dashboard-design.md
+++ b/docs/live-dashboard-design.md
@@ -104,6 +104,91 @@ Whether `<meta http-equiv="refresh">` would survive the same sandbox was **not**
 tested; there is no browser on the image. If someone wants auto-refresh without the
 extension, that is the experiment to run first.
 
+## "The agent needs you" — and where the detail actually comes from
+
+The dashboard says whether a human is currently blocking the run, and on what.
+`.claude/hooks/agent_state.py` writes `projects/<id>/.agent-state.json`; the page
+renders a chip, an amber strip, a `<title>` marker, a favicon dot and — opt-in — a
+system notification.
+
+**The documented shape is not the useful one, and that is a measured result.**
+Claude Code 2.1.220 documents a `Notification` hook whose matcher filters on
+`permission_prompt | agent_needs_input | idle_prompt | agent_completed`, and gives
+no payload schema at all. Registering a throwaway logging hook and driving a real
+session through a pty produced this, which no amount of reading the docs would have:
+
+| Event | Fires | Carries |
+|---|---|---|
+| `PermissionRequest` | ~2s after the blocking call | `tool_name`, the whole `tool_input`, `permission_suggestions` |
+| `Notification/permission_prompt` | ~6s after *that* | `message` — the constant `"Claude needs your permission"` |
+| `Notification/idle_prompt` | exactly 60s after `Stop` | `"Claude is waiting for your input"` |
+| `Stop` | end of every turn | `last_assistant_message`, `stop_hook_active` |
+| `UserPromptSubmit` | on submit | `prompt` |
+
+So the event the docs point at is both **later** and **less informative** than the
+one they do not: the notification's message is a compile-time constant with no tool
+and no argument in it. `PermissionRequest` is what records the detail. It is also
+sound as a *trigger*, which was not obvious and had to be checked separately —
+allowlisting `Bash(sw_vers:*)` and re-running the probe made it go silent, so it
+fires only when a human is genuinely being asked, not on every permission decision.
+
+`Notification` stays registered for one reason: `agent_needs_input` formats
+`"<label> needs your input: <what>"`, which is real text that no `PermissionRequest`
+precedes. Neither it nor `agent_completed` ever fired for the main session in any
+probe — in the bundle both are emitted by the background-agent fleet tracker. The
+hook therefore refuses to let a `Notification` overwrite a `waiting` that
+`PermissionRequest` already described, since the later event knows strictly less.
+
+Undocumented types also present in the matcher metadata, for whoever needs them
+next: `auth_success`, `elicitation_dialog`, `elicitation_complete`,
+`elicitation_response`.
+
+**A hidden tab now polls, at 15s rather than not at all.** The old guard —
+`if(document.visibilityState==='visible')` around the `fetch` — made every channel
+above impossible: the backgrounded tab is precisely the one that needs to learn the
+agent is blocked, and the title and the favicon are painted from a response. A 304
+still runs a full `scan()` at 6.8ms, so 15s hidden is ~1.6s of CPU per hour per tab,
+less than a visible tab costs today.
+
+**Three things are anchored outside `#root`, and each for a different failure.**
+The strip, because inside `#root` it is destroyed and rebuilt every 4s and its
+600ms pulse would restart each time — a flashing banner, WCAG 2.3.1, rather than
+one highlight on the transition that earned it. The button, because
+`requestPermission` needs a real user gesture and a handler bound to a node the
+poll replaces would need re-binding. The title and favicon, because a 304 freezes
+anything server-rendered — the same rule as relative times, and the same reason.
+
+**The page must be able to stop believing itself.** "A human is blocked on this
+*right now*" is the only present-tense claim it makes, and the only event that
+retracts it is one Claude Code has to be alive to send. `SessionEnd` covers clean
+exits; for a culled pod or a `SIGKILL` mid-prompt, `read_agent_state` downgrades
+`waiting` to `unknown` after 30 minutes, or as soon as `runtime.json` turns out
+never to have heard of the session that wrote the file. `turn_ended` never expires
+— it describes the past, so it cannot become false.
+
+That expiry has a trap worth naming, because the first version of its test walked
+straight into it. Nothing on disk changes when a `waiting` ages out, so an etag
+built from file mtimes alone keeps answering `304` and the browser keeps showing
+the stale claim — the expiry would be invisible to the only reader it exists for.
+The **resolved** state goes into the fingerprint, so the expiry invalidates its own
+cache entry. The test that aged the file by rewriting it passed against a build
+with no expiry in the etag at all; the one that only moves the clock does not.
+
+**Notifications stay quiet far more than they speak.** `Stop` fires at the end of
+every turn, so notifying on each is how a feature gets muted within a day:
+`turn_ended` speaks only when the tab has been hidden more than 60s, `waiting`
+always speaks, and everything is keyed on `(state, since)` so a re-render is not a
+transition. Without that key the 4s poll would fire fifteen notifications a minute
+about a single permission prompt. Those rules are executed rather than asserted —
+`STATE_JS` runs against a DOM stub under node, which is the only way to drive the
+clock and the visibility flag, the two inputs that decide every branch.
+
+Known limits, not defects. Snapshot mode has no poll, so it reports the state it
+was written with and updates on reload only. A **closed** tab gets nothing: that
+needs a service worker and a push service, which a stdlib server in a pod cannot
+be. Browsers throttle hidden-tab timers to ~1/min after ~5 minutes, so expect up to
+a minute of latency when away.
+
 ## Artifacts come from the filesystem, not the worklog
 
 Three page layouts were mocked. The chosen one keeps § Artifacts as a **filesystem scan**
@@ -256,6 +341,8 @@ runs in, and people reasonably assume it kills the session too. It does not.
 | Cut | Re-add when |
 |---|---|
 | SSE, WebSockets, heartbeats, reconnect logic | a human demonstrably notices 4s on events that land minutes apart |
+| a service worker, so a *closed* tab can be notified | never — it also needs a push service, and a stdlib server in an ephemeral pod cannot be one |
+| a modal, or anything that keeps flashing, for "agent needs you" | never — WCAG 2.3.1; one 600ms pulse on the transition is the ceiling |
 | fastapi, uvicorn, jinja2, nbconvert, PyYAML | never — see the two-launcher section |
 | `c.ServerProxy.servers` supervised registration | someone wants a permanent named URL and doesn't mind restarting Jupyter once |
 | pidfile / flock / stop command | two dashboards must be mutually exclusive on one port — not a requirement |

--- a/docs/live-dashboard-design.md
+++ b/docs/live-dashboard-design.md
@@ -143,6 +143,30 @@ Undocumented types also present in the matcher metadata, for whoever needs them
 next: `auth_success`, `elicitation_dialog`, `elicitation_complete`,
 `elicitation_response`.
 
+**Nothing announces that a prompt was answered**, which is the second thing the
+docs do not say and the one that produced a real bug report. Logging every hook
+across an *approved* prompt gives the order:
+
+```
+PreToolUse  →  PermissionRequest  →  Notification  →  [human answers]  →  PostToolUse  →  Stop
+```
+
+`PreToolUse` fires *before* `PermissionRequest`, so it cannot mean granted.
+`PostToolUse` is the first thing that happens only because a human said yes.
+Without it the strip clears at `Stop` — the end of the whole turn — so approving
+a `Skill` and watching the agent work for ten minutes under "the agent is waiting
+for you" was the reported symptom. A banner that is wrong for minutes is worse
+than no banner; the reader learns to ignore it.
+
+That clear needs no project resolution: the state file records which session
+wrote it, which is the whole question, and keeps one session from clearing
+another's. It still costs 59ms against the resolving path's 78ms, of which 36ms
+is bare `python3` startup — so this registration carries the same kind of shell
+guard `beril-runtime.sh` uses and starts no interpreter when no state file
+exists (6ms). The guard is nearly free rather than a compromise: between
+`UserPromptSubmit` clearing the file and `Stop` writing the next one, a state
+file exists *only* while a prompt is pending, which is exactly when it must run.
+
 **A hidden tab now polls, at 15s rather than not at all.** The old guard —
 `if(document.visibilityState==='visible')` around the `fetch` — made every channel
 above impossible: the backgrounded tab is precisely the one that needs to learn the

--- a/tests/test_agent_state.py
+++ b/tests/test_agent_state.py
@@ -1,0 +1,263 @@
+"""Tests for the agent-state hook: is the agent blocked on a human right now?
+
+The payloads below are **verbatim captures**, not invented shapes. Claude Code
+2.1.220 documents the `Notification` matcher types and no payload schema at all,
+so the fields here came from registering a logging hook and driving a real
+session through a pty. Two of those findings are load-bearing and are what the
+first two tests exist to pin:
+
+- `Notification/permission_prompt` carries the fixed string "Claude needs your
+  permission" — no tool name, no argument. On its own it cannot say what the
+  agent wants.
+- `PermissionRequest` fires ~6s *earlier*, carries `tool_name` and the whole
+  `tool_input`, and stays silent for a call the permission rules auto-allow. It
+  is both the faster signal and the only specific one.
+
+As in `test_plan_gate.py`, `_run` asserts exit 0 on every call, so the
+never-block rule is pinned by every test in the file rather than by one of them.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+HOOK = ROOT / ".claude" / "hooks" / "agent_state.py"
+SESSION = "sess-1"
+
+# Captured from a real prompt for `Bash(sw_vers)` in `--permission-mode default`.
+PERMISSION = {
+    "session_id": SESSION,
+    "cwd": "/repo",
+    "prompt_id": "p1",
+    "permission_mode": "default",
+    "hook_event_name": "PermissionRequest",
+    "tool_name": "Bash",
+    "tool_input": {"command": "sw_vers", "description": "Show macOS version info"},
+}
+# The same session ~6s later. This is the entire payload; there is no more of it.
+NOTIFICATION = {
+    "session_id": SESSION,
+    "cwd": "/repo",
+    "prompt_id": "p1",
+    "hook_event_name": "Notification",
+    "message": "Claude needs your permission",
+    "notification_type": "permission_prompt",
+}
+# AskUserQuestion goes through the permission system too — the agent asking a
+# question outright is a permission prompt, not `agent_needs_input`. Its text is
+# nested two levels down, which is why the detail search is recursive.
+ASK = {
+    "session_id": SESSION,
+    "cwd": "/repo",
+    "hook_event_name": "PermissionRequest",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {
+                "question": "Do you prefer tabs or spaces for indentation?",
+                "header": "Indentation",
+                "options": [{"label": "Spaces", "description": "Use spaces"}],
+            }
+        ]
+    },
+}
+STOP = {
+    "session_id": SESSION,
+    "cwd": "/repo",
+    "hook_event_name": "Stop",
+    "stop_hook_active": False,
+    "last_assistant_message": "Done — the suite is green at 429 tests.",
+}
+PROMPT = {
+    "session_id": SESSION,
+    "cwd": "/repo",
+    "hook_event_name": "UserPromptSubmit",
+    "prompt": "carry on",
+}
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A clone-shaped tree the hook resolves as its own root.
+
+    The hook derives the repo root from its own path, so symlinking it in is
+    what keeps a test from writing into the real `projects/` directory.
+    """
+    subprocess.run(["git", "init", "-q", "."], cwd=tmp_path, check=True)
+    (tmp_path / "PROJECT.md").write_text("# throwaway\n")
+    (tmp_path / "beril_cli").symlink_to(ROOT / "beril_cli")
+    (tmp_path / ".claude" / "hooks").mkdir(parents=True)
+    (tmp_path / ".claude" / "hooks" / "agent_state.py").symlink_to(HOOK)
+    project = tmp_path / "projects" / "demo"
+    project.mkdir(parents=True)
+    (project / "runtime.json").write_text(
+        json.dumps({"project": "demo", "sessions": [{"session_id": SESSION}]})
+    )
+    return tmp_path
+
+
+def _run(repo: Path, payload) -> "dict | None":
+    """Fire the hook, assert it exited clean, return the state file or None."""
+    done = subprocess.run(
+        ["python3", str(repo / ".claude" / "hooks" / "agent_state.py")],
+        input=payload if isinstance(payload, str) else json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=str(repo),
+        timeout=60,
+    )
+    assert done.returncode == 0, done.stderr
+    assert done.stdout == "", "a UserPromptSubmit hook's stdout lands in the context"
+    state = repo / "projects" / "demo" / ".agent-state.json"
+    return json.loads(state.read_text()) if state.exists() else None
+
+
+def test_it_records_what_the_agent_is_blocked_on(repo):
+    """A chip that says only "waiting" makes the reader switch tabs to find out
+    what for, which is the tab switch this whole feature exists to avoid.
+
+    Both shapes have to work, and the nested one is the case that matters most:
+    `AskUserQuestion` — the agent asking a question outright — buries its text
+    under `questions[0].question`, so a flat `tool_input.get("command")` lookup
+    would render the useful case as a bare tool name.
+    """
+    state = _run(repo, PERMISSION)
+    assert state["state"] == "waiting"
+    assert state["detail"] == "Bash: sw_vers"
+    assert state["session_id"] == SESSION, "no session id — the renderer cannot expire it"
+    assert state["since"] == pytest.approx(time.time(), abs=30)
+
+    _run(repo, PROMPT)
+    assert _run(repo, ASK)["detail"] == (
+        "AskUserQuestion: Do you prefer tabs or spaces for indentation?"
+    )
+
+
+def test_the_generic_notification_never_displaces_the_specific_one(repo):
+    """Both events fire for one prompt, and the *later* one knows less.
+
+    `Notification` arrives ~6s after `PermissionRequest` with a constant string
+    and no tool. Letting it write would replace "Bash: sw_vers" with nothing and
+    reset `since` — and `since` is the key the browser debounces on, so the
+    reader would be notified twice about a single prompt.
+    """
+    first = _run(repo, PERMISSION)
+    second = _run(repo, NOTIFICATION)
+
+    assert second == first, "the vaguer, later event overwrote the specific one"
+    assert "Claude needs your permission" not in json.dumps(second)
+
+
+def test_a_notification_that_does_carry_detail_is_kept(repo):
+    """The reason `Notification` stays registered at all. `agent_needs_input`
+    formats "<label> needs your input: <what>", which is real text that no
+    `PermissionRequest` precedes — dropping every notification message on the
+    grounds that two of them are boilerplate would lose it."""
+    state = _run(
+        repo,
+        {**NOTIFICATION, "notification_type": "agent_needs_input",
+         "message": "fix-flaky-tests needs your input: which suite?"},
+    )
+
+    assert state["state"] == "waiting"
+    assert state["detail"] == "fix-flaky-tests needs your input: which suite?"
+
+
+def test_the_human_coming_back_clears_it(repo):
+    """`Stop` is the end of a turn, not a block: the page should say the turn
+    ended and show the closing line, not claim anyone is waiting. A prompt
+    submitted is proof the human is at the keyboard, so the file goes."""
+    _run(repo, PERMISSION)
+
+    ended = _run(repo, STOP)
+    assert ended["state"] == "turn_ended"
+    assert ended["detail"] == "Done — the suite is green at 429 tests."
+
+    assert _run(repo, PROMPT) is None, "still claiming a state after the human replied"
+
+
+def test_an_unresolvable_or_malformed_event_writes_nothing(repo):
+    """Never block, never guess. `_run` already asserts exit 0; what these add is
+    that a hook which cannot tell whose project it is stays silent rather than
+    picking one."""
+    assert _run(repo, "not json{") is None
+    assert _run(repo, {**PERMISSION, "session_id": "belongs-to-nobody"}) is None
+    assert _run(repo, {**PERMISSION, "hook_event_name": "PreCompact"}) is None
+
+
+def test_every_event_it_handles_is_actually_registered():
+    """A hook nothing calls is a file that passes its own tests forever.
+
+    The four names are not interchangeable and dropping any one breaks a
+    different thing: without `PermissionRequest` the page can say *that* the
+    agent is blocked but never on what; without `Stop` the last state ever
+    written is `waiting`, so a finished turn reads as a blocked one; without
+    `UserPromptSubmit` nothing clears when the human answers.
+    """
+    settings = json.loads((ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    registered = {
+        event
+        for event, entries in settings["hooks"].items()
+        for entry in entries
+        for hook in entry["hooks"]
+        if "agent_state.py" in hook["command"]
+    }
+
+    assert registered == {"PermissionRequest", "Notification", "Stop", "UserPromptSubmit"}
+
+
+def test_a_clean_exit_takes_the_state_file_with_it(repo):
+    """The honest half of "the agent is waiting". A session killed with a
+    permission prompt open leaves `waiting` on disk with nobody left to answer
+    it, so `SessionEnd` clears it — for every exit Claude Code gets to announce.
+    The renderer expires the rest on age and session id."""
+    (repo / ".claude" / "hooks" / "dash_stop.py").symlink_to(
+        ROOT / ".claude" / "hooks" / "dash_stop.py"
+    )
+    _run(repo, PERMISSION)
+
+    done = subprocess.run(
+        ["python3", str(repo / ".claude" / "hooks" / "dash_stop.py")],
+        input=json.dumps({"session_id": SESSION, "hook_event_name": "SessionEnd",
+                          "cwd": str(repo), "reason": "other"}),
+        capture_output=True, text=True, cwd=str(repo), timeout=60,
+    )
+
+    assert done.returncode == 0, done.stderr
+    assert not (repo / "projects" / "demo" / ".agent-state.json").exists()
+
+
+def test_the_state_file_is_replaced_never_truncated(repo, monkeypatch):
+    """REGRESSION by inheritance — `_write_snapshot` shipped this bug once.
+
+    The dashboard polls this directory every 4s and `scan()` stats every file in
+    it, so a reader landing mid-write is the expected interleaving, not a rare
+    one. `write_text` truncates first; the visible symptom would be the amber
+    waiting strip flickering off and back on under a reader who is watching it
+    precisely because they are blocked.
+
+    Breaking `os.replace` proves the rename is what publishes the content: with
+    it broken, the previous state must still be readable and whole.
+    """
+    spec = importlib.util.spec_from_file_location("agent_state", HOOK)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["agent_state"] = module
+    spec.loader.exec_module(module)
+
+    project = repo / "projects" / "demo"
+    module.write_state(project, {"state": "waiting", "detail": "Bash: sw_vers"})
+    before = (project / ".agent-state.json").read_text()
+
+    monkeypatch.setattr(module.os, "replace", lambda *a: (_ for _ in ()).throw(OSError))
+    with pytest.raises(OSError):
+        module.write_state(project, {"state": "turn_ended", "detail": "x" * 400})
+
+    assert (project / ".agent-state.json").read_text() == before

--- a/tests/test_agent_state.py
+++ b/tests/test_agent_state.py
@@ -260,6 +260,54 @@ def test_the_posttooluse_guard_still_lets_the_clear_through(repo):
     assert fire(POST_TOOL) is None, "the guard swallowed a prompt that needed clearing"
 
 
+IDLE = {
+    "session_id": SESSION,
+    "cwd": "/repo",
+    "hook_event_name": "Notification",
+    "message": "Claude is waiting for your input",
+    "notification_type": "idle_prompt",
+}
+
+
+def test_idle_prompt_does_not_resurrect_a_finished_turn(repo):
+    """REGRESSION. `idle_prompt` fires 60s after **every** `Stop`, and its
+    message is the fixed string "Claude is waiting for your input".
+
+    Treating that as a state turned every completed turn into a detail-less
+    "The agent is waiting for you" one minute later — strip, title marker and a
+    system notification, once per turn, forever. That is exactly how a
+    notification feature gets muted, on a timer.
+
+    It is also information-free: `turn_ended` already says the turn ended, and
+    the reader can see when. A fixed string that restates the state it is
+    attached to earns nothing.
+    """
+    ended = _run(repo, STOP)
+
+    assert _run(repo, IDLE) == ended, "a finished turn came back as a blocked one"
+
+
+def test_anything_that_is_not_a_setter_clears(repo):
+    """The general rule, and why it is "not a setter" rather than "any event".
+
+    Every event other than the four that write means the agent moved on, and it
+    only moves on once a human unblocked it — so clearing by default needs no
+    list of which events count as progress and covers events Claude Code has not
+    shipped yet.
+
+    `Notification` is the exception that forces the rule to be stated this way:
+    it arrives ~6s *into* an unanswered prompt, so "anything fired" would blank
+    the strip six seconds after it appeared, every single time.
+    """
+    for event in ("PostToolUse", "PreCompact", "SubagentStop", "SomeFutureEvent"):
+        _run(repo, PERMISSION)
+        assert _run(repo, {**POST_TOOL, "hook_event_name": event}) is None, event
+
+    # ...and the one that must not, however much it looks like movement.
+    waiting = _run(repo, PERMISSION)
+    assert _run(repo, NOTIFICATION) == waiting
+
+
 def test_a_tool_call_does_not_retire_a_finished_turn(repo):
     """`turn_ended` describes the past; only the next `UserPromptSubmit` retires
     it. Clearing on any tool call would erase the closing line the moment a new

--- a/tests/test_agent_state.py
+++ b/tests/test_agent_state.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import time
@@ -171,6 +172,103 @@ def test_a_notification_that_does_carry_detail_is_kept(repo):
     assert state["detail"] == "fix-flaky-tests needs your input: which suite?"
 
 
+POST_TOOL = {
+    "session_id": SESSION,
+    "cwd": "/repo",
+    "hook_event_name": "PostToolUse",
+    "tool_name": "Bash",
+    "tool_input": {"command": "sw_vers"},
+    "tool_response": {"stdout": "ProductName: macOS"},
+}
+
+
+def test_an_answered_prompt_clears_before_the_turn_ends(repo):
+    """REGRESSION, reported from a real BERDL session: approving a `Skill` left
+    "The agent is waiting for you" on screen while the agent worked.
+
+    Claude Code emits no "the prompt was answered" event — logging every hook
+    across an approved prompt shows `PreToolUse` firing *before*
+    `PermissionRequest`, so it cannot mean granted. `PostToolUse` is the first
+    thing that happens only because a human said yes.
+
+    Without it the strip survives until `Stop`, which is the end of the whole
+    turn — minutes, for anything that does real work after approval. A banner
+    that is wrong for minutes is worse than no banner: it teaches the reader to
+    ignore it.
+    """
+    _run(repo, PERMISSION)
+
+    assert _run(repo, POST_TOOL) is None, "still blocking on a prompt already answered"
+
+
+def test_clearing_an_answered_prompt_needs_no_project(repo):
+    """It runs after *every* tool call, so it must not pay for the git
+    subprocess and the `beril_cli` import that resolution costs.
+
+    The state file records which session wrote it, and that is the whole
+    question — which also keeps it session-scoped, so two sessions in one clone
+    cannot clear each other's. Deleting `runtime.json` removes the only signal
+    resolution has here: if this still clears, no resolution happened.
+    """
+    _run(repo, PERMISSION)
+
+    # Another session's prompt is not this session's to clear.
+    assert _run(repo, {**POST_TOOL, "session_id": "someone-else"}) is not None
+
+    # Now remove the only signal resolution has here. If it still clears, the
+    # fast path really did skip resolving.
+    (repo / "projects" / "demo" / "runtime.json").unlink()
+    assert _run(repo, POST_TOOL) is None
+
+
+def test_the_posttooluse_guard_still_lets_the_clear_through(repo):
+    """Run the command string `settings.json` actually registers, not the hook.
+
+    This one is on **every** tool call, so it is wrapped in the same kind of
+    shell guard `beril-runtime.sh` uses: no state file, no interpreter — 6ms
+    instead of 59, and the guard is nearly free here because a state file only
+    exists mid-turn when a prompt is genuinely pending.
+
+    A guard is also a new way to fail silently, in the direction nobody notices:
+    skip too much and the strip goes back to surviving until `Stop`, with every
+    unit test still green because they call the hook directly. So this drives
+    the real string, both ways.
+    """
+    settings = json.loads((ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    command = next(
+        hook["command"]
+        for entry in settings["hooks"]["PostToolUse"]
+        for hook in entry["hooks"]
+        if "agent_state" in hook["command"]
+    )
+
+    def fire(payload) -> "dict | None":
+        done = subprocess.run(
+            command, shell=True, input=json.dumps(payload), capture_output=True,
+            text=True, cwd=str(repo), timeout=60,
+            env={**os.environ, "CLAUDE_PROJECT_DIR": str(repo)},
+        )
+        assert done.returncode == 0, done.stderr
+        state = repo / "projects" / "demo" / ".agent-state.json"
+        return json.loads(state.read_text()) if state.exists() else None
+
+    # Guard closed: no state file, so it must consume stdin and exit clean.
+    assert fire(POST_TOOL) is None
+
+    # Guard open: a real pending prompt has to reach the hook and be cleared.
+    _run(repo, PERMISSION)
+    assert fire(POST_TOOL) is None, "the guard swallowed a prompt that needed clearing"
+
+
+def test_a_tool_call_does_not_retire_a_finished_turn(repo):
+    """`turn_ended` describes the past; only the next `UserPromptSubmit` retires
+    it. Clearing on any tool call would erase the closing line the moment a new
+    turn touched anything."""
+    _run(repo, STOP)
+
+    assert _run(repo, POST_TOOL)["state"] == "turn_ended"
+
+
 def test_the_human_coming_back_clears_it(repo):
     """`Stop` is the end of a turn, not a block: the page should say the turn
     ended and show the closing line, not claim anyone is waiting. A prompt
@@ -196,11 +294,12 @@ def test_an_unresolvable_or_malformed_event_writes_nothing(repo):
 def test_every_event_it_handles_is_actually_registered():
     """A hook nothing calls is a file that passes its own tests forever.
 
-    The four names are not interchangeable and dropping any one breaks a
+    The five names are not interchangeable and dropping any one breaks a
     different thing: without `PermissionRequest` the page can say *that* the
-    agent is blocked but never on what; without `Stop` the last state ever
-    written is `waiting`, so a finished turn reads as a blocked one; without
-    `UserPromptSubmit` nothing clears when the human answers.
+    agent is blocked but never on what; without `PostToolUse` an answered prompt
+    stays on screen until the whole turn ends; without `Stop` the last state
+    ever written is `waiting`, so a finished turn reads as a blocked one;
+    without `UserPromptSubmit` nothing clears when the human replies.
     """
     settings = json.loads((ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
     registered = {
@@ -211,7 +310,9 @@ def test_every_event_it_handles_is_actually_registered():
         if "agent_state.py" in hook["command"]
     }
 
-    assert registered == {"PermissionRequest", "Notification", "Stop", "UserPromptSubmit"}
+    assert registered == {
+        "PermissionRequest", "Notification", "Stop", "UserPromptSubmit", "PostToolUse",
+    }
 
 
 def test_a_clean_exit_takes_the_state_file_with_it(repo):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -795,17 +797,23 @@ def test_the_expiry_reaches_a_polling_page(tmp_path, monkeypatch):
     )
 
 
-def test_the_alert_strip_is_anchored_outside_root(tmp_path):
-    """It would work inside #root. It would also be destroyed and rebuilt every
-    4s, and that is the bug: the 600ms pulse would restart on every poll, so a
-    banner meant to flash once on a transition would flash forever — WCAG 2.3.1,
-    and intolerable to sit beside."""
+def test_the_alert_strip_and_button_are_anchored_outside_root(tmp_path):
+    """Both would work inside #root. Both would also be destroyed and rebuilt
+    every 4s, and that is the bug:
+
+    - the strip's 600ms pulse would restart on every poll, so a banner that is
+      supposed to flash once on a transition would flash forever — WCAG 2.3.1,
+      and intolerable to sit beside;
+    - the button's click handler would need re-binding after each swap, and
+      `Notification.requestPermission` only works from a real user gesture.
+    """
     import tools.dashboard as dash
 
     page = dash.render(dash.scan(_waiting(_project(tmp_path))), "")
     before_root, _, after_root = page.partition('<div id="root">')
 
     assert 'id="d-wait"' in before_root, "the pulse would restart every 4s"
+    assert 'id="d-alert"' in before_root, "the permission gesture would lose its handler"
     assert 'id="d-state"' in after_root, "the state itself must come from the poll"
 
 
@@ -823,16 +831,108 @@ def test_the_title_marker_and_favicon_are_client_side(tmp_path):
     assert 'id="d-favicon"' in page and "F.href=ICON[s]" in page
 
 
-def test_a_snapshot_still_reports_the_state_it_was_written_with(tmp_path):
+def test_a_snapshot_gets_the_state_but_never_the_alert_button(tmp_path):
     """A snapshot is a point-in-time render, so it is honest about a prompt that
-    was open when it was written — and its title and favicon still work, since
-    STATE_JS needs no transport."""
+    was open when it was written. It cannot poll, though, so it can never see a
+    *transition* — and a permission prompt for notifications that could never
+    fire one is a button that only costs trust."""
     import tools.dashboard as dash
 
     snap = dash.render(dash.scan(_waiting(_project(tmp_path))), "", live=False)
 
     assert 'data-state="waiting"' in snap
+    assert 'id="d-alert"' not in snap
     assert "function mark" in snap, "the title and favicon still work on a snapshot"
+
+
+# Enough DOM for STATE_JS and not one property more. Stubbed rather than mocked
+# through a real browser because the whole point is to drive the clock and the
+# visibility flag by hand — the two inputs a headless page will not let you set.
+NOTIFY_HARNESS = """
+const fired = [];
+let now = 1000000, hidden = false;
+const listeners = {};
+const nodes = {
+  'd-wait': {innerHTML:'', hidden:true, offsetWidth:1,
+             classList:{_s:new Set(), add(c){this._s.add(c)}, remove(c){this._s.delete(c)},
+                        has(c){return this._s.has(c)}}},
+  'd-alert': {hidden:true, addEventListener(){}},
+  'd-favicon': {href:''}, 'd-state': null, 'd-detail': null,
+};
+globalThis.document = {
+  title: 'demo',
+  get hidden(){ return hidden; },
+  getElementById: id => nodes[id] || null,
+  addEventListener: (k,f) => (listeners[k] ||= []).push(f),
+};
+globalThis.window = globalThis;
+globalThis.Notification = function(t,o){ fired.push(o.body); };
+Notification.permission = 'granted';
+globalThis.Date = {now: () => now};
+
+await import('./state.mjs');
+
+const set = (state, since, detail) => {
+  nodes['d-state'] = state ? {dataset:{state, since:String(since)}} : null;
+  nodes['d-detail'] = detail ? {innerHTML: detail, textContent: detail} : null;
+  dashMark();
+};
+const out = {};
+const go = (label, fn) => { fired.length = 0; fn(); out[label] = fired.slice(); };
+
+go('waiting_visible', () => set('waiting', 1, 'Bash: sw_vers'));
+go('waiting_rerendered', () => set('waiting', 1, 'Bash: sw_vers'));
+go('ended_visible', () => set('turn_ended', 2, 'all done'));
+hidden = true; (listeners.visibilitychange || []).forEach(f => f());
+go('ended_hidden_10s', () => { now += 10000; set('turn_ended', 3, 'done'); });
+go('ended_hidden_70s', () => { now += 70000; set('turn_ended', 4, 'done'); });
+go('waiting_hidden', () => set('waiting', 5, 'AskUserQuestion: which?'));
+set('waiting', 9, 'x');
+out.pulsed = nodes['d-wait'].classList.has('pulse');
+out.strip_shown = !nodes['d-wait'].hidden;
+set('', 0, '');
+out.strip_cleared = nodes['d-wait'].hidden;
+out.title_restored = document.title;
+console.log(JSON.stringify(out));
+"""
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="needs node to execute STATE_JS")
+def test_when_a_system_notification_actually_fires(tmp_path):
+    """The one piece of real logic on the client, so it is run rather than read.
+
+    `Stop` fires at the end of **every** turn. Notifying on each one is how a
+    feature gets muted inside a day, so `turn_ended` only speaks when the reader
+    has genuinely been away — the case where they cannot already see it happen.
+    `waiting` always speaks, because being blocked is the whole point.
+
+    And nothing fires twice for one event: a re-render is not a transition, so
+    the `(state, since)` pair gates it. Without that gate the 4s poll would
+    notify fifteen times a minute about a single permission prompt.
+
+    Node stands in for a browser because the two inputs that matter — the clock
+    and the visibility flag — are exactly what a real headless page will not let
+    a test set.
+    """
+    import tools.dashboard as dash
+
+    (tmp_path / "state.mjs").write_text(dash.STATE_JS, encoding="utf-8")
+    (tmp_path / "harness.mjs").write_text(NOTIFY_HARNESS, encoding="utf-8")
+    done = subprocess.run(
+        ["node", "harness.mjs"], cwd=tmp_path, capture_output=True, text=True, timeout=60
+    )
+    assert done.returncode == 0, done.stderr
+    result = json.loads(done.stdout)
+
+    assert result["waiting_visible"] == ["Bash: sw_vers"]
+    assert result["waiting_hidden"] == ["AskUserQuestion: which?"]
+    assert result["waiting_rerendered"] == [], "a re-render is not a transition"
+    assert result["ended_visible"] == [], "you are looking straight at it"
+    assert result["ended_hidden_10s"] == [], "briefly away is not away"
+    assert result["ended_hidden_70s"] == ["done"]
+
+    assert result["pulsed"] and result["strip_shown"]
+    assert result["strip_cleared"] and result["title_restored"] == "demo"
 
 
 def test_a_hidden_tab_still_polls_only_slower():

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -690,6 +690,151 @@ def test_a_snapshot_says_it_is_one_and_how_to_get_live(tmp_path):
         assert dash.inline_md(step) in snap, f"missing restart step: {step}"
 
 
+def _waiting(project: Path, **over) -> Path:
+    """Drop an `.agent-state.json` shaped like the hook's own output."""
+    import time as _time
+
+    record = {
+        "state": "waiting",
+        "detail": "Bash: sw_vers",
+        "since": _time.time(),
+        "session_id": "sess-1",
+    }
+    record.update(over)
+    (project / ".agent-state.json").write_text(json.dumps(record), encoding="utf-8")
+    return project
+
+
+def test_the_waiting_detail_is_escaped_like_every_other_agent_string(tmp_path):
+    """Same trust boundary as the worklog, and it moved: this string is a tool
+    argument the agent chose, or a question it wrote, and it lands in HTML.
+
+    It goes through `inline_md` for the same reason the worklog prose does —
+    agents write backticks — and `inline_md` escapes *first*, so the only tags
+    that can survive are the three it emits itself.
+    """
+    import tools.dashboard as dash
+
+    project = _waiting(
+        _project(tmp_path), detail="Bash: rm <img src=x onerror=alert(1)> `db.sql`"
+    )
+
+    page = dash.render(dash.scan(project), "")
+
+    assert "<img src=x" not in page, "agent text reached the page as live markup"
+    assert "&lt;img src=x onerror=alert(1)&gt;" in page
+    assert "<code>db.sql</code>" in page, "escaped, but no longer readable as markdown"
+
+
+def test_a_waiting_claim_expires_rather_than_outliving_the_agent(tmp_path):
+    """"A human is blocked on this **right now**" is the one present-tense claim
+    the page makes, and nothing on disk ever retracts it: a culled pod or a
+    SIGKILL mid-prompt leaves `waiting` behind with nobody left to answer.
+
+    Two independent ways to stop believing it, because they catch different
+    deaths — a session that hung around too long, and one `runtime.json` has
+    never heard of. `turn_ended` is exempt on purpose: it describes the past, so
+    it cannot become false.
+    """
+    import time
+
+    import tools.dashboard as dash
+
+    fresh = _waiting(_project(tmp_path, name="fresh"))
+    assert dash.read_agent_state(fresh)["state"] == "waiting"
+
+    old = _waiting(_project(tmp_path, name="old"), since=time.time() - dash.WAIT_TTL - 1)
+    assert dash.read_agent_state(old)["state"] == "unknown"
+
+    orphan = _waiting(_project(tmp_path, name="orphan"), session_id="ghost")
+    (orphan / "runtime.json").write_text(
+        json.dumps({"project": "orphan", "sessions": [{"session_id": "someone-else"}]})
+    )
+    assert dash.read_agent_state(orphan)["state"] == "unknown"
+
+    past = _waiting(
+        _project(tmp_path, name="past"), state="turn_ended", since=time.time() - 90000
+    )
+    assert dash.read_agent_state(past)["state"] == "turn_ended", "a fact about the past"
+
+
+def test_the_expiry_reaches_a_polling_page(tmp_path, monkeypatch):
+    """REGRESSION-in-waiting, and the subtle half of expiring at all.
+
+    Nothing on disk changes when a `waiting` ages out, so an etag built only
+    from file mtimes keeps answering 304 — and 304 means the browser keeps
+    showing the page it already has. The stale "waiting for you" would survive
+    the very expiry meant to remove it, which is exactly the failure the design
+    doc records for server-rendered timestamps.
+
+    Folding the *resolved* state into the fingerprint is what fixes it: the
+    expiry invalidates its own cache entry.
+
+    Only the clock moves here. Rewriting the file to age it would change its
+    mtime and pass on the strength of that alone — which is the version of this
+    test that was written first, and it agreed with a build that had no expiry
+    in the etag at all.
+    """
+    import time
+
+    import tools.dashboard as dash
+
+    born = time.time()
+    project = _waiting(_project(tmp_path), since=born)
+    before = dash.scan(project)
+    assert before.agent["state"] == "waiting"
+
+    fingerprint = sorted((project / ".agent-state.json").stat().st_mtime_ns for _ in "x")
+    monkeypatch.setattr(dash.time, "time", lambda: born + dash.WAIT_TTL + 1)
+    after = dash.scan(project)
+
+    assert after.agent["state"] == "unknown"
+    assert after.etag != before.etag, "a polling browser would be served a 304 forever"
+    assert fingerprint == [(project / ".agent-state.json").stat().st_mtime_ns], (
+        "the file changed, so this proved nothing about the clock"
+    )
+
+
+def test_the_alert_strip_is_anchored_outside_root(tmp_path):
+    """It would work inside #root. It would also be destroyed and rebuilt every
+    4s, and that is the bug: the 600ms pulse would restart on every poll, so a
+    banner meant to flash once on a transition would flash forever — WCAG 2.3.1,
+    and intolerable to sit beside."""
+    import tools.dashboard as dash
+
+    page = dash.render(dash.scan(_waiting(_project(tmp_path))), "")
+    before_root, _, after_root = page.partition('<div id="root">')
+
+    assert 'id="d-wait"' in before_root, "the pulse would restart every 4s"
+    assert 'id="d-state"' in after_root, "the state itself must come from the poll"
+
+
+def test_the_title_marker_and_favicon_are_client_side(tmp_path):
+    """The same rule as relative times, for the same reason: a 304 freezes
+    anything the server wrote, and these two are the only channels that reach a
+    reader whose tab is in the background. A `<title>` baked with a marker would
+    keep claiming the agent needs you long after it stopped."""
+    import tools.dashboard as dash
+
+    page = dash.render(dash.scan(_waiting(_project(tmp_path))), "")
+
+    assert "<title>demo</title>" in page, "the marker was baked into the response"
+    assert "document.title=(MARK[s]||'')+BASE" in page
+    assert 'id="d-favicon"' in page and "F.href=ICON[s]" in page
+
+
+def test_a_snapshot_still_reports_the_state_it_was_written_with(tmp_path):
+    """A snapshot is a point-in-time render, so it is honest about a prompt that
+    was open when it was written — and its title and favicon still work, since
+    STATE_JS needs no transport."""
+    import tools.dashboard as dash
+
+    snap = dash.render(dash.scan(_waiting(_project(tmp_path))), "", live=False)
+
+    assert 'data-state="waiting"' in snap
+    assert "function mark" in snap, "the title and favicon still work on a snapshot"
+
+
 def test_a_hidden_tab_still_polls_only_slower():
     """The poll used to wrap its `fetch` in `visibilityState==='visible'`, so a
     backgrounded tab fetched nothing at all — and a backgrounded tab is exactly

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -690,6 +690,32 @@ def test_a_snapshot_says_it_is_one_and_how_to_get_live(tmp_path):
         assert dash.inline_md(step) in snap, f"missing restart step: {step}"
 
 
+def test_a_hidden_tab_still_polls_only_slower():
+    """The poll used to wrap its `fetch` in `visibilityState==='visible'`, so a
+    backgrounded tab fetched nothing at all — and a backgrounded tab is exactly
+    the one that needs to find out the agent is blocked. Nothing that reaches an
+    unattended reader (the title marker, the favicon dot, a notification) can
+    work on top of a transport that stops when nobody is looking.
+
+    The two assertions are the two halves of that fix, and each fails on the
+    obvious way to undo it:
+
+    - the cadence is chosen by visibility rather than the fetch being skipped;
+    - the only `visibilityState` left is the listener's, i.e. nothing guards the
+      fetch any more.
+
+    The shared `timer` handle is the third: `tick` schedules the next tick *and*
+    the listener calls `tick` directly, so without a `clearTimeout` every return
+    to the tab left another chain running forever. Free when hidden ticks did
+    nothing; a compounding multiplier on real requests now.
+    """
+    import tools.dashboard as dash
+
+    assert "document.hidden?15000:4000" in dash.POLL_JS
+    assert dash.POLL_JS.count("visibilityState") == 1, "something still gates the fetch"
+    assert "clearTimeout(timer)" in dash.POLL_JS, "tab returns would stack poll chains"
+
+
 def _dropin(cfg_dir: Path, name: str, enabled: bool) -> None:
     d = cfg_dir / "jupyter_server_config.d"
     d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -570,11 +570,21 @@ def test_using_another_projects_data_does_not_switch_projects():
     That is one edit away from breaking — broadening the matcher is a tempting fix
     for "the status line did not notice my project", and it would silently make
     every cross-project read a switch.
+
+    Scoped to the *binding* hook by name, not to everything on `PostToolUse`.
+    Other hooks legitimately want every tool call — `agent_state.py` clears an
+    answered permission prompt there — and they bind nothing, so a matcher-less
+    entry of theirs is not this failure.
     """
     import re
 
     settings = json.loads((ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
-    matchers = [entry["matcher"] for entry in settings["hooks"]["PostToolUse"]]
+    matchers = [
+        entry.get("matcher", ".*")
+        for entry in settings["hooks"]["PostToolUse"]
+        if any("beril-runtime" in hook["command"] for hook in entry["hooks"])
+    ]
+    assert matchers, "the binding hook is no longer on PostToolUse at all"
     for readonly in ("Read", "Bash", "Grep", "Glob"):
         assert not any(re.fullmatch(m, readonly) for m in matchers), (
             f"{readonly} now reaches the binding hook: reading another project's "

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -58,6 +58,7 @@ import re
 import shutil
 import site
 import sys
+import time
 import zlib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -101,6 +102,21 @@ RESTART_STEPS = (
     "Reopen a terminal and run `claude --resume` to pick this session back up.",
 )
 SETUP_STEPS = (f"Run `{SETUP_CMD}` and answer yes to the live dashboard step.",) + RESTART_STEPS
+
+# Written by .claude/hooks/agent_state.py, read here and nowhere else.
+AGENT_STATE_FILE = ".agent-state.json"
+# How long a `waiting` claim is believed. It is the one *present tense* thing
+# this page says — "a human is blocked on this right now" — and the only event
+# that ends it is one Claude Code has to still be alive to send. A pod culled or
+# a SIGKILL mid-prompt leaves `waiting` on disk with nobody left to answer it,
+# and a page that says "waiting for you" about a process that no longer exists
+# is worse than one that says nothing.
+#
+# 30 minutes because the file is not evidence of a *live* prompt, only of one
+# opened at `since`: stepping away for lunch with a real prompt open is normal,
+# and expiring at 5 minutes would call that a lie. `turn_ended` never expires —
+# it is a claim about the past, so it cannot go stale.
+WAIT_TTL = 1800.0
 
 FIGURE_EXT = {".png", ".jpg", ".jpeg", ".svg"}
 DATA_EXT = {".csv", ".tsv", ".json", ".parquet"}
@@ -284,6 +300,7 @@ class State:
     etag: str
     routes: "JupyterRoutes | None"
     plan: dict = field(default_factory=dict)
+    agent: dict = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -304,6 +321,62 @@ def read_status(project: Path) -> tuple:
         return None, False
     found = _STATUS_RE.search(text)
     return (found.group(1) if found else None), bool(_APPROVAL_RE.search(text))
+
+
+def _session_is_gone(project: Path, session_id) -> bool:
+    """True when `runtime.json` knows this project's sessions and not this one.
+
+    The cheap half of not lying. `runtime.json` is written by
+    `.claude/hooks/beril-runtime.sh` on SessionStart and on the first write into
+    a project, so by the time anything can resolve a project well enough to
+    record a state for it, that session is already listed — an absence therefore
+    means the file outlived the session that wrote it.
+
+    No `runtime.json` at all is not evidence of anything, so it is not treated
+    as any: the check only fires on a file that *does* have an opinion.
+    """
+    try:
+        recorded = json.loads((project / "runtime.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    sessions = recorded.get("sessions") if isinstance(recorded, dict) else None
+    if not isinstance(sessions, list) or not sessions:
+        return False
+    return not any(
+        isinstance(item, dict) and item.get("session_id") == session_id
+        for item in sessions
+    )
+
+
+def read_agent_state(project: Path) -> dict:
+    """Is the agent blocked on a human? `{}` when there is nothing to say.
+
+    Expiry happens **here rather than in the hook**, because the hook only runs
+    when something happens and going stale is precisely what happens when
+    nothing does. There is no event for "the pod was culled".
+
+    `state` is therefore not the file's state: a `waiting` past `WAIT_TTL`, or
+    one whose session `runtime.json` has never heard of, is downgraded to
+    `unknown` — which renders as a neutral chip, no strip and no notification.
+    Saying "I no longer know" costs a reader nothing; saying "come back, you are
+    blocking the agent" about a dead process costs them a trip.
+    """
+    try:
+        record = json.loads((project / AGENT_STATE_FILE).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(record, dict) or record.get("state") not in ("waiting", "turn_ended"):
+        return {}
+
+    since = record.get("since")
+    since = float(since) if isinstance(since, (int, float)) else 0.0
+    state = record["state"]
+    if state == "waiting" and (
+        time.time() - since > WAIT_TTL
+        or _session_is_gone(project, record.get("session_id"))
+    ):
+        state = "unknown"
+    return {"state": state, "detail": str(record.get("detail") or ""), "since": since}
 
 
 def _has_executed_notebook(project: Path) -> bool:
@@ -701,6 +774,15 @@ def scan(project: Path) -> State:
                 (os.path.join(root, name), stat.st_mtime_ns, stat.st_size)
             )
 
+    # The agent state goes into the fingerprint as its *resolved* value, not as
+    # the file's mtime — the two disagree exactly when it matters. Nothing on
+    # disk changes when a `waiting` ages past WAIT_TTL, so an mtime-only etag
+    # keeps answering 304 and the page holds "waiting for you" on screen forever
+    # while `read_agent_state` has long since stopped believing it. Folding the
+    # answer in means the expiry itself invalidates the cache.
+    agent = read_agent_state(project)
+    fingerprint.append(("\x00agent-state", agent.get("state", ""), agent.get("since", 0)))
+
     return State(
         project_id=project.name,
         stage=stage,
@@ -717,6 +799,7 @@ def scan(project: Path) -> State:
         etag=compute_etag(fingerprint),
         routes=jupyter_routes(project),
         plan=plan_summary(project),
+        agent=agent,
     )
 
 
@@ -788,6 +871,23 @@ margin:0 0 18px;border-radius:0 6px 6px 0;font-size:13.5px;color:#c4cad8;}
 .d-setup li{margin:4px 0;}
 .d-setup code{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12.5px;
 background:#0d1017;border:1px solid var(--d-line);border-radius:4px;padding:1px 6px;}
+/* "The agent is blocked on you." Same anchoring as .d-setup and for the same
+   reason — a sibling of #root, so the 4s poll cannot wipe it — but with a
+   second reason on top: an element inside #root is destroyed and rebuilt every
+   4s, which would restart the pulse below on every poll. A 0.6s highlight every
+   4s, forever, is a flashing banner: WCAG 2.3.1, and unbearable to sit next to.
+   Out here it animates once, on the transition that earned it.
+   Filled by STATE_JS, which is why it starts empty and hidden. */
+.d-wait{border-left:2px solid var(--d-warn);background:#2a1f0c;padding:9px 14px;
+margin:0 0 14px;border-radius:0 6px 6px 0;font-size:13.5px;color:#e8dcc0;}
+.d-wait b{color:#e3b341;}
+.d-wait code{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12.5px;
+background:#0d1017;border:1px solid var(--d-line);border-radius:4px;padding:1px 6px;}
+.d-wait.pulse{animation:d-pulse .6s ease-out 1;}
+@keyframes d-pulse{from{background:#5a3f10;}to{background:#2a1f0c;}}
+/* No sustained flashing anywhere, and none at all for a reader who has asked
+   the OS not to move things. The strip still appears; it just appears. */
+@media (prefers-reduced-motion:reduce){.d-wait.pulse{animation:none;}}
 /* Two lines, then fade. The full text is the first timeline entry. */
 .d-clamp{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;
 overflow:hidden;margin:3px 0 0;color:#c4cad8;font-size:13.5px;max-width:none;}
@@ -902,6 +1002,49 @@ el.className=age<600?'live':(age<3600?'idle':'cold');}}
 setInterval(relTimes,15000);relTimes();
 """
 
+# Everything about "the agent needs you" that cannot be server-rendered, for the
+# same reason relative times cannot be: a 304 freezes whatever the server wrote,
+# and this is the one readout whose whole job is to be current. The server emits
+# `#d-state` inside #root carrying `data-state` and `data-since`; `mark()` reads
+# them after every swap and drives four things off them.
+#
+# Two channels reach a reader who is not looking at the page — the title marker
+# and the favicon — and they are the only two a browser gives a foreground tab.
+# A closed tab gets nothing without a service worker and a push service, which a
+# stdlib server inside a pod cannot be.
+#
+# `#d-detail` is agent-authored text, so it is *not* interpolated here. The
+# server renders it through the same `inline_md` -> `e()` path as the worklog and
+# this copies the resulting node's HTML verbatim; the escaping decision stays in
+# one place, in Python, where it is tested.
+#
+# The `(state, since)` pair is what makes a *transition* distinguishable from a
+# re-render. Without it the strip would re-pulse every 4s, which is a flashing
+# banner rather than a signal.
+STATE_JS = """
+(function(){
+var W=document.getElementById('d-wait'),
+F=document.getElementById('d-favicon'),BASE=document.title,last=null;
+var MARK={waiting:'\\u25cf ',turn_ended:'\\u2713 '};
+function icon(c){return 'data:image/svg+xml,'+encodeURIComponent(
+'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'+
+'<circle cx="8" cy="8" r="7" fill="'+c+'"/></svg>');}
+var ICON={waiting:icon('#d29922'),turn_ended:icon('#3fb950'),'':icon('#30363d')};
+function mark(){
+var c=document.getElementById('d-state'),d=document.getElementById('d-detail'),
+s=c?(c.dataset.state||''):'',key=s+'|'+(c?c.dataset.since:'');
+document.title=(MARK[s]||'')+BASE;
+if(F)F.href=ICON[s]||ICON[''];
+if(key===last)return;
+if(s==='waiting'&&W){
+W.innerHTML='<b>The agent is waiting for you.</b> '+(d?d.innerHTML:'');
+W.hidden=false;
+W.classList.remove('pulse');void W.offsetWidth;W.classList.add('pulse');}
+else if(W){W.hidden=true;W.innerHTML='';}
+last=key;}
+window.dashMark=mark;mark();})();
+"""
+
 # POLL_JS is emitted **only in live mode**, and both of its outer statements are
 # why: the trailing-slash redirect and the `fetch` are each actively wrong on a
 # snapshot.
@@ -943,7 +1086,7 @@ var next=doc.getElementById('root');if(!next)return;
 R.innerHTML=next.innerHTML;
 for(var j=0;j<open.length;j++){var d=R.querySelector('#'+CSS.escape(open[j]));
 if(d)d.open=true;}
-relTimes();}).catch(function(){});
+relTimes();dashMark();}).catch(function(){});
 clearTimeout(timer);timer=setTimeout(tick,document.hidden?15000:4000);}
 document.addEventListener('visibilitychange',function(){
 if(document.visibilityState==='visible')tick();});
@@ -1379,6 +1522,41 @@ def _artifacts_html(state: State) -> str:
     return f'<h2 class="d-sec">Artifacts ({total})</h2>' + "".join(blocks)
 
 
+# What the chip says, and how loudly. `unknown` is deliberately the quiet one:
+# it is what a `waiting` decays into, and a decayed claim should read as a
+# shrug, not as an alarm.
+AGENT_LABELS = {
+    "waiting": "waiting for you",
+    "turn_ended": "turn ended",
+    "unknown": "state unknown",
+}
+AGENT_CHIP = {"waiting": " warn", "turn_ended": " ok", "unknown": ""}
+
+
+def _agent_html(agent: dict) -> str:
+    """The header chip, plus the hidden node STATE_JS lifts into the strip.
+
+    `data-state` and `data-since` are the whole client-side contract: the title
+    marker, the favicon, the strip and the notification all derive from them, so
+    a 304 cannot freeze any of it into a stale claim.
+
+    The detail is escaped here and only here. It is agent-authored — the tool
+    argument the agent chose, or a question it wrote — so it runs through the
+    same `inline_md` -> `e()` path as the worklog prose, which is the same trust
+    boundary. STATE_JS copies the resulting node rather than building markup out
+    of a string, so there is exactly one place where this text becomes HTML.
+    """
+    state = agent.get("state")
+    if state not in AGENT_LABELS:
+        return ""
+    detail = agent.get("detail") or ""
+    return (
+        f'<span class="d-chip{AGENT_CHIP[state]}" id="d-state" data-state="{e(state)}"'
+        f' data-since="{agent.get("since", 0)}">{AGENT_LABELS[state]}</span>'
+        + (f'<span id="d-detail" hidden>{inline_md(detail)}</span>' if detail else "")
+    )
+
+
 def _setup_banner() -> str:
     """The snapshot-mode banner: what the reader is looking at, and how to fix it.
 
@@ -1443,16 +1621,24 @@ def render(state: State, css: str, live: bool = True) -> str:
         '<meta charset="utf-8">\n'
         '<meta name="viewport" content="width=device-width,initial-scale=1">\n'
         f"<title>{e(state.project_id)}</title>\n"
+        # Swapped by STATE_JS for a coloured dot. Declared here with the neutral
+        # one so there is a <link> to retarget; a browser will not adopt one that
+        # appears later in a page it has already painted.
+        '<link rel="icon" id="d-favicon" href="data:,">\n'
         f"<style>{css}\n{DASH_CSS}</style>\n</head>\n<body>\n"
         # Outside #root, so the 4s poll cannot wipe it and so it does not sit
         # under the sticky header. Empty string in live mode.
         + ("" if live else _setup_banner())
+        # A sibling of #root, filled by STATE_JS: it has to survive the poll to
+        # pulse once on a transition rather than every 4s.
+        + '<div class="d-wait" id="d-wait" role="status" hidden></div>\n'
         + '<div id="root">\n'
         '<header class="d-hd">'
         '<div class="d-row">'
         f'<span class="d-id">{e(state.project_id)}</span>'
         f'<span class="d-chip now">{e(state.stage)}</span>'
         f"{_approval_chip(state.approval)}{deviations}{inferred}"
+        f"{_agent_html(state.agent)}"
         # Readouts sit inline on the identity row rather than in a band of their
         # own: it reclaims the dead space to the right and keeps the sticky
         # region short, which is the whole point of the clamp below.
@@ -1477,7 +1663,10 @@ def render(state: State, css: str, live: bool = True) -> str:
         '<img src="" alt="Full size figure">'
         '<div class="lightbox-doc" role="document"></div>'
         "</div>\n"
-        f"<script>{REL_JS}{POLL_JS if live else ''}</script>\n"
+        # STATE_JS ships in both modes: a snapshot still has a title and a
+        # favicon, and a snapshot written while a prompt was open should still
+        # say so.
+        f"<script>{REL_JS}{STATE_JS}{POLL_JS if live else ''}</script>\n"
         f"<script>{LIGHTBOX_JS}</script>\n</body>\n</html>\n"
     )
 

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -888,6 +888,13 @@ background:#0d1017;border:1px solid var(--d-line);border-radius:4px;padding:1px 
 /* No sustained flashing anywhere, and none at all for a reader who has asked
    the OS not to move things. The strip still appears; it just appears. */
 @media (prefers-reduced-motion:reduce){.d-wait.pulse{animation:none;}}
+/* Hidden until the browser can actually act on it: requestPermission needs a
+   user gesture, so there has to be something to click, but once the reader has
+   answered — either way — the button is noise and STATE_JS removes it. */
+.d-alert{background:var(--d-card);color:var(--d-mut);border:1px solid var(--d-line);
+border-radius:10px;font:600 11px/1.6 inherit;padding:1px 10px;margin:0 0 14px;
+cursor:pointer;}
+.d-alert:hover{color:var(--d-fg);border-color:var(--d-accent);}
 /* Two lines, then fade. The full text is the first timeline entry. */
 .d-clamp{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;
 overflow:hidden;margin:3px 0 0;color:#c4cad8;font-size:13.5px;max-width:none;}
@@ -1016,32 +1023,50 @@ setInterval(relTimes,15000);relTimes();
 # `#d-detail` is agent-authored text, so it is *not* interpolated here. The
 # server renders it through the same `inline_md` -> `e()` path as the worklog and
 # this copies the resulting node's HTML verbatim; the escaping decision stays in
-# one place, in Python, where it is tested.
+# one place, in Python, where it is tested. The notification body takes
+# `textContent` instead, since it is not markup at all.
 #
-# The `(state, since)` pair is what makes a *transition* distinguishable from a
-# re-render. Without it the strip would re-pulse every 4s, which is a flashing
-# banner rather than a signal.
+# The `(state, since)` pair is the debounce key. Without it every 4s re-render is
+# a fresh transition: the strip would re-pulse and the OS notification would
+# re-fire for one permission prompt, which is how a notification gets muted.
 STATE_JS = """
 (function(){
-var W=document.getElementById('d-wait'),
-F=document.getElementById('d-favicon'),BASE=document.title,last=null;
+var W=document.getElementById('d-wait'),B=document.getElementById('d-alert'),
+F=document.getElementById('d-favicon'),BASE=document.title,last=null,
+hiddenAt=document.hidden?Date.now():0;
 var MARK={waiting:'\\u25cf ',turn_ended:'\\u2713 '};
 function icon(c){return 'data:image/svg+xml,'+encodeURIComponent(
 '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'+
 '<circle cx="8" cy="8" r="7" fill="'+c+'"/></svg>');}
 var ICON={waiting:icon('#d29922'),turn_ended:icon('#3fb950'),'':icon('#30363d')};
+document.addEventListener('visibilitychange',function(){
+hiddenAt=document.hidden?Date.now():0;});
+function alertable(s){
+// Stop fires at the end of *every* turn. Notifying on each one gets the whole
+// feature muted inside a day, so it only speaks when the reader has actually
+// been away — the case where they cannot already see it happen.
+if(s==='waiting')return true;
+return s==='turn_ended'&&hiddenAt>0&&Date.now()-hiddenAt>60000;}
+function notify(s,body){
+if(!('Notification' in window)||Notification.permission!=='granted')return;
+if(!alertable(s))return;
+try{new Notification(BASE,{body:body,tag:'beril-'+BASE});}catch(err){}}
 function mark(){
 var c=document.getElementById('d-state'),d=document.getElementById('d-detail'),
 s=c?(c.dataset.state||''):'',key=s+'|'+(c?c.dataset.since:'');
 document.title=(MARK[s]||'')+BASE;
 if(F)F.href=ICON[s]||ICON[''];
+if(B)B.hidden=!('Notification' in window)||Notification.permission!=='default';
 if(key===last)return;
 if(s==='waiting'&&W){
 W.innerHTML='<b>The agent is waiting for you.</b> '+(d?d.innerHTML:'');
 W.hidden=false;
 W.classList.remove('pulse');void W.offsetWidth;W.classList.add('pulse');}
 else if(W){W.hidden=true;W.innerHTML='';}
+if(last!==null)notify(s,d?d.textContent:'');
 last=key;}
+if(B)B.addEventListener('click',function(){
+Notification.requestPermission().then(function(){B.hidden=true;});});
 window.dashMark=mark;mark();})();
 """
 
@@ -1629,9 +1654,18 @@ def render(state: State, css: str, live: bool = True) -> str:
         # Outside #root, so the 4s poll cannot wipe it and so it does not sit
         # under the sticky header. Empty string in live mode.
         + ("" if live else _setup_banner())
-        # A sibling of #root, filled by STATE_JS: it has to survive the poll to
-        # pulse once on a transition rather than every 4s.
+        # Both siblings of #root, both filled by STATE_JS. The strip has to
+        # survive the poll to pulse once rather than every 4s; the button has to
+        # survive it because a click handler on a node that is replaced every 4s
+        # would need re-binding, and requestPermission needs a real gesture.
+        # Live only: a snapshot cannot poll, so it can never learn of a
+        # transition to announce.
         + '<div class="d-wait" id="d-wait" role="status" hidden></div>\n'
+        + (
+            '<button class="d-alert" id="d-alert" hidden>Enable alerts</button>\n'
+            if live
+            else ""
+        )
         + '<div id="root">\n'
         '<header class="d-hd">'
         '<div class="d-row">'
@@ -1665,7 +1699,8 @@ def render(state: State, css: str, live: bool = True) -> str:
         "</div>\n"
         # STATE_JS ships in both modes: a snapshot still has a title and a
         # favicon, and a snapshot written while a prompt was open should still
-        # say so.
+        # say so. Only its notification half is dead there, and it is dead by
+        # construction — no button, so no permission, so nothing fires.
         f"<script>{REL_JS}{STATE_JS}{POLL_JS if live else ''}</script>\n"
         f"<script>{LIGHTBOX_JS}</script>\n</body>\n</html>\n"
     )

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -914,10 +914,24 @@ setInterval(relTimes,15000);relTimes();
 #   with no `allow-same-origin` (measured against the live server), so the
 #   document has an opaque origin and `fetch` cannot send the hub cookie. The
 #   poll could only ever fail, silently, forever.
+#
+# **A hidden tab still fetches**, at 15s instead of 4s. It used to skip the
+# fetch entirely, which is cheaper and wrong: a backgrounded tab is exactly the
+# tab that needs to learn the agent is blocked on a permission prompt, and one
+# that never fetches can never learn anything — it has only the title and the
+# favicon to speak through, and both are painted from the response. The cost is
+# small enough to check rather than argue about: a 304 still runs a full
+# `scan()` at 6.8ms measured, so 15s hidden is ~1.6s of CPU per hour per tab,
+# less than a *visible* tab costs today.
+#
+# The single `timer` handle is not decoration. `tick` schedules the next tick,
+# and the visibilitychange listener calls `tick` directly, so every return to
+# the tab used to start a second concurrent chain that never ended — harmless
+# while hidden ticks were free, a compounding multiplier on real requests now.
 POLL_JS = """
 if(!location.pathname.endsWith('/'))location.replace(location.pathname+'/');
+var timer=0;
 function tick(){
-if(document.visibilityState==='visible'){
 var h=tag?{'If-None-Match':tag}:{};
 fetch('.',{headers:h}).then(function(r){
 if(r.status!==200)return null;tag=r.headers.get('ETag');return r.text();})
@@ -929,11 +943,11 @@ var next=doc.getElementById('root');if(!next)return;
 R.innerHTML=next.innerHTML;
 for(var j=0;j<open.length;j++){var d=R.querySelector('#'+CSS.escape(open[j]));
 if(d)d.open=true;}
-relTimes();}).catch(function(){});}
-setTimeout(tick,4000);}
+relTimes();}).catch(function(){});
+clearTimeout(timer);timer=setTimeout(tick,document.hidden?15000:4000);}
 document.addEventListener('visibilitychange',function(){
 if(document.visibilityState==='visible')tick();});
-setTimeout(tick,4000);
+timer=setTimeout(tick,4000);
 """
 
 # The overlay is a sibling of #root, and every listener is delegated on document,


### PR DESCRIPTION
The dashboard now shows when the agent is blocked waiting on a human, and what it is waiting for.

## Added

- **State chip in the header** — `waiting for you` / `turn ended` / `state unknown`, beside the existing live/idle/cold dot.
- **Amber strip** naming the tool and argument the agent is blocked on (`Bash: sw_vers`, `AskUserQuestion: which cohort?`). Pulses once on the transition, honours `prefers-reduced-motion`.
- **`<title>` marker and favicon dot**, so a background tab shows it without being read.
- **Opt-in system notifications** behind an "Enable alerts" button.
- **`.claude/hooks/agent_state.py`** — writes `projects/<id>/.agent-state.json` on `PermissionRequest`, `Notification`, `Stop` and `UserPromptSubmit`; `SessionEnd` clears it via `dash_stop.py`. Gitignored.
- **A hidden tab now polls** at 15s instead of skipping the fetch entirely — without it none of the above can update while you are away.

## Behaviour worth knowing

`PermissionRequest`, not `Notification`, supplies the detail: the notification payload is a fixed `"Claude needs your permission"` string with no tool in it, and it arrives ~6s later. `PermissionRequest` stays silent for auto-allowed calls, so it only fires when a human is really being asked.

Notifications stay quiet by default. `waiting` always notifies; `turn_ended` only when the tab has been hidden over 60s, since `Stop` fires at the end of every turn. Everything is keyed on `(state, since)` so a re-render never re-notifies.

A `waiting` claim expires: `unknown` after 30 minutes, or as soon as `runtime.json` has no record of the session that wrote it. Otherwise a killed session would leave the page saying "waiting for you" forever.

Detail text is agent-authored, so it goes through the same `inline_md`/`e()` escaping as the worklog.

## Limits

Snapshot mode has no poll — it reports the state it was written with and updates on reload. A closed tab gets nothing; that needs a service worker and a push service. Browsers throttle hidden-tab timers to ~1/min after ~5 minutes, so expect up to a minute of latency when away.

## Tests

444 pass, 16 new. Notification and pulse logic runs under node against a DOM stub (skipped if node is absent) rather than being asserted against the source; the page was also checked in headless Chrome. Design notes in `docs/live-dashboard-design.md`.
