### PR TITLE
fix(ci): repair pyproject parse error and Codecov uploads

### DIFF
--- a/.github/workflows/run-cli-tests.yml
+++ b/.github/workflows/run-cli-tests.yml
@@ -27,9 +27,13 @@ jobs:
 
       - name: Run CLI tests
         run: |
-          uv run pytest tests/
+          uv run pytest tests/ --cov=beril_cli --cov=tools --cov-report=xml
 
       - name: Send to Codecov
         uses: codecov/codecov-action@v5
         with:
             token: ${{ secrets.CODECOV_TOKEN }}
+            files: ./coverage.xml
+            # Without this codecov filename-searches the repo and uploads any
+            # projects/**/ *coverage*.tsv it finds instead of a real report.
+            disable_search: true

--- a/.github/workflows/run-knowledge-tests.yml
+++ b/.github/workflows/run-knowledge-tests.yml
@@ -1,4 +1,4 @@
-name: Install and test BERIL CLI
+name: Install and test BERIL knowledge layer
 on:
   pull_request:
     types:
@@ -25,11 +25,13 @@ jobs:
         run: |
           uv sync --group test --group knowledge
 
-      - name: Run CLI tests
+      - name: Run knowledge layer tests
         run: |
-          uv run pytest knowledge/tests/
+          uv run pytest knowledge/tests/ --cov=knowledge --cov-report=xml
 
       - name: Send to Codecov
         uses: codecov/codecov-action@v5
         with:
             token: ${{ secrets.CODECOV_TOKEN }}
+            files: ./coverage.xml
+            disable_search: true

--- a/.github/workflows/run-webapp-tests.yml
+++ b/.github/workflows/run-webapp-tests.yml
@@ -29,9 +29,11 @@ jobs:
       - name: Run tests
         run: |
           cd ui
-          uv run pytest
+          uv run pytest --cov-report=xml
 
       - name: Send to Codecov
         uses: codecov/codecov-action@v5
         with:
             token: ${{ secrets.CODECOV_TOKEN }}
+            files: ./ui/coverage.xml
+            disable_search: true

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ venv/
 
 # Python test results
 .coverage
+coverage.xml
 htmlcov/
 .pytest_cache/
 .ruff_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ beril = "beril_cli.cli:main"
 
 [dependency-groups]
 test = [
-  "mistune">=3,
+  "mistune>=3",
   "pytest>=8.0.0",
   "pytest-cov>=5.0.0",
 ]


### PR DESCRIPTION
## Bugs fixed

**`pyproject.toml` is invalid TOML — all CI is red.** A merge conflict resolution in `02cfd17d` mangled the mistune test dependency into `"mistune">=3,`. Every `uv sync` fails to parse it, so all three test workflows die at the install step.

**Codecov uploads research data instead of coverage.** No workflow passed `--cov`, so no report was ever generated; `codecov-action`'s default filename search then picked up four unrelated files from `projects/**/`:

```
Found 4 coverage files to report
> projects/functional_dark_matter/data/non_fb_genus_og_coverage.tsv
> projects/enigma_contamination_functional_potential/data/mapped_coverage_deciles.tsv
> projects/paperblast_explorer/notebooks/02_coverage_skew.ipynb
> projects/genotype_to_phenotype_enigma/data/coverage_matrix.tsv
```

The step reported success throughout. Each workflow now emits `coverage.xml` and pins Codecov to it with `disable_search: true`. The webapp suite already had `--cov=app` but only emitted `term-missing` + `html`, never XML.

**Two PR checks with identical names.** `run-knowledge-tests.yml` was a copy-paste of the CLI workflow down to `name: Install and test BERIL CLI`, so both checks rendered indistinguishably and branch protection couldn't target either. Renamed to `Install and test BERIL knowledge layer`.

## Verified

Ran each workflow's exact pytest command and confirmed the artifact the Codecov step points at is produced:

| Workflow | Result | Artifact |
|---|---|---|
| cli | 440 passed | `coverage.xml` |
| knowledge | 110 passed | `coverage.xml` |
| webapp | 791 passed | `ui/coverage.xml` |

Reports are confirmed generated at the right paths; that Codecov *accepts* them only proves out on this PR's run. Files uploaded by earlier runs are already on Codecov's servers — `disable_search` stops future uploads but doesn't retract past ones.

## Not addressed

`data/structural_biology/tests/` (155 tests) runs in no workflow. Also unfixed: no `push:` trigger on `main` (how the bad merge landed untested), `types:` missing `reopened`, and `ui/` has no `uv.lock`.