### PR TITLE
feat(worklog): enforce worklog entries, add activity tier

### DIFF
--- a/.claude/hooks/worklog_gate.py
+++ b/.claude/hooks/worklog_gate.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Stop hook: refuse to end the turn while WORKLOG.md is behind the work.
+
+The worklog was purely advisory before this — six skills each carry a one-line
+"append a worklog entry", and an agent optimising for the analysis drops it. The
+result across this repo was zero WORKLOG.md files, so the dashboard's timeline
+had nothing to render.
+
+Two triggers, OR'd, no stage branching:
+
+* **an artifact is newer than the last entry** — a notebook ran, figures landed,
+  data exported. Bounded by construction: a project has as many of these as it
+  has notebooks.
+* **nothing has been written for IDLE_SECONDS** — the backstop, and the only
+  thing that covers exploration, which produces no artifact at all and so was
+  invisible to a file-mtime rule. The reply is an activity entry (`~`), which
+  the dashboard folds into a collapsed run.
+
+Both self-debounce: writing the entry updates the mtime, which *is* the rate
+limit. No counter, no state file, no transcript parsing.
+
+Idle is mostly handled by the mechanism rather than by code — a Stop hook only
+fires at the end of an agent turn, so waiting on a human, a permission prompt or
+an overnight gap fires nothing. What is left is the turn *after* a long gap, and
+for that the block explicitly accepts "nothing to record" as an answer: the
+point is a reset mtime, not a manufactured entry.
+
+The harness runs this with the *system* interpreter (3.9), so: stdlib only and
+no modern syntax. `beril_cli` is imported the way dash_stop.py does it — best
+effort, behind a bare except — because it is stdlib-only in practice but is not
+guaranteed to be importable from whatever interpreter the harness picked.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# 15 minutes. The effective cadence is looser than this number suggests: a Stop
+# hook fires at most once per turn, so a single turn running forty tool calls
+# over half an hour produces one entry, not two. Turn this up if it nags.
+IDLE_SECONDS = 900
+
+# Scanned for the artifact trigger. Deliberately not the project root: beril.yaml
+# and README.md are touched by tooling, and gating on those would fire the
+# narrative branch for a status bump nobody would write an entry about.
+ARTIFACT_DIRS = ("notebooks", "figures", "data")
+
+# A complete project is archived. Artifacts stop moving, so only the time floor
+# could fire, and it would then fire every fifteen minutes for as long as anyone
+# sat reading the thing.
+TERMINAL = ("complete",)
+
+# absolute(), not resolve(): resolve() follows a symlinked copy of this hook back
+# to wherever it really lives, which in a test tree is the wrong repo. Same
+# reasoning as dash_stop.py.
+ROOT = Path(__file__).absolute().parent.parent.parent
+
+
+def resolve(payload):
+    """Project id for this session, or None. Never raises."""
+    sys.path.insert(0, str(ROOT))
+    try:
+        from beril_cli.project_resolution import resolve_project
+
+        return resolve_project(payload, repo_root=ROOT)
+    except Exception:
+        return None
+
+
+def status_of(project):
+    """`status:` from beril.yaml, lowercased, or "" — a top-level key only.
+
+    A hand-rolled scan rather than PyYAML, which the hook cannot import. Same
+    constraint plan-gate.py works under.
+    """
+    try:
+        with open(str(project / "beril.yaml"), encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                if line[:1] in (" ", "\t", "#", "\n"):
+                    continue
+                key, sep, value = line.partition(":")
+                if sep and key.strip() == "status":
+                    return value.split("#", 1)[0].strip().strip("'\"").lower()
+    except OSError:
+        pass
+    return ""
+
+
+def newest_artifact(project):
+    """Newest mtime under the artifact directories, or 0.0 when there are none."""
+    newest = 0.0
+    for name in ARTIFACT_DIRS:
+        for root, _dirs, files in os.walk(str(project / name)):
+            for filename in files:
+                try:
+                    stamp = os.stat(os.path.join(root, filename)).st_mtime
+                except OSError:
+                    continue
+                if stamp > newest:
+                    newest = stamp
+    return newest
+
+
+NARRATIVE = (
+    "Work has landed since the last worklog entry — a notebook ran, figures or "
+    "data were written. Append one entry to projects/{pid}/WORKLOG.md per "
+    ".claude/skills/worklog-capture/SKILL.md covering everything since: the "
+    "decision, not the mechanics, and link the artifacts. One entry for the "
+    "whole stretch, not one per file. Prefix the title with `!` if it records a "
+    "correction. Then finish."
+)
+
+ACTIVITY = (
+    "No worklog entry for {mins} minutes. Append an activity entry to "
+    "projects/{pid}/WORKLOG.md — same format as .claude/skills/worklog-capture/"
+    "SKILL.md, but prefix the title with `~`: '## YYYY-MM-DD · ~ what you were "
+    "doing'. Two sentences on what this stretch ruled out, constrained or "
+    "established. If it genuinely produced nothing, say exactly that in one "
+    "line — an inconclusive stretch is a real constraint on the plan and a short "
+    "honest entry beats a padded one. Then finish."
+)
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return
+
+    # Set on the turn that this hook already blocked. Without it a block asking
+    # for an entry would fire again on the turn that writes the entry, forever.
+    if payload.get("stop_hook_active"):
+        return
+
+    pid = resolve(payload)
+    if not pid:
+        return
+    project = ROOT / "projects" / pid
+    if not project.is_dir() or status_of(project) in TERMINAL:
+        return
+
+    worklog = project / "WORKLOG.md"
+    try:
+        written = worklog.stat().st_mtime
+    except OSError:
+        written = 0.0  # no worklog yet: both triggers fire, either creates it
+
+    if newest_artifact(project) > written:
+        reason = NARRATIVE.format(pid=pid)
+    elif time.time() - written > IDLE_SECONDS:
+        reason = ACTIVITY.format(pid=pid, mins=int(IDLE_SECONDS / 60))
+    else:
+        return
+
+    json.dump({"decision": "block", "reason": reason}, sys.stdout)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass  # a Stop hook that raises is a Stop hook that strands the turn
+    sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -96,6 +96,16 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/worklog_gate.py\"; exit 0'"
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -82,6 +82,10 @@
           {
             "type": "command",
             "command": "python3 .claude/hooks/agent_state.py"
+          },
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/worklog_gate.py\"; exit 0'"
           }
         ]
       }
@@ -92,16 +96,6 @@
           {
             "type": "command",
             "command": "python3 .claude/hooks/agent_state.py"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/worklog_gate.py\"; exit 0'"
           }
         ]
       }

--- a/.claude/skills/worklog-capture/SKILL.md
+++ b/.claude/skills/worklog-capture/SKILL.md
@@ -21,6 +21,7 @@ Not in `memories/`. That directory is for cross-project knowledge destined for O
 ```markdown
 ## {YYYY-MM-DD} · {what happened}{ → new_status}
 ## {YYYY-MM-DD} · ! {a correction}
+## {YYYY-MM-DD} · ~ {a running activity summary}
 {One to three sentences: what was done and *why*. The decision, not the mechanics.}
 → [{label}]({project-relative-path})
 → [{label}]({project-relative-path}) ×{n}
@@ -29,6 +30,8 @@ Not in `memories/`. That directory is for cross-project knowledge destined for O
 The `→ new_status` suffix appears **only** on the six lifecycle transitions. Work-unit entries omit it.
 
 A **leading `!`** marks a correction — a bug found, a re-run, an approach abandoned. Use it whenever the entry records the project changing direction. These are the highest-value entries in the file, and the dashboard gives them an amber marker so a reader scanning the timeline finds the turning points without reading every entry. Without the `!` a correction is indistinguishable from "ran notebook 3". The marker is optional and unmarked worklogs parse exactly as before.
+
+A **leading `~`** marks an *activity* entry — see "Two tiers" below. The dashboard folds consecutive activity entries into one collapsed disclosure, so they never break up the narrative.
 
 Worked example:
 
@@ -50,6 +53,26 @@ and added a threshold sensitivity pass to check the result wasn't cutoff-driven.
 → [nb 02](notebooks/02_concordance_analysis.ipynb)
 → [fig](figures/threshold_sensitivity.png)
 ```
+
+## Two tiers
+
+The file holds two kinds of entry, in one chronological stream.
+
+**Narrative** (unmarked, or `!`) — what a human reads. Lifecycle transitions and completed units of work. Written when something *concluded*.
+
+**Activity** (`~`) — the running record. Written on a clock, not on a conclusion: roughly every 15 minutes of work, covering whatever happened since the last entry. These exist because the narrative tier is blind to the work that produces no artifact — exploration, in particular, where an agent can spend hours querying BERDL and reading papers and leave nothing on disk to write an entry *about*. That whole phase used to collapse into a single "plan written" entry composed in hindsight, after the dead ends had been tidied away.
+
+An activity entry records what the stretch **ruled out, constrained, or established** — not what was searched:
+
+- ✅ `~ pH framing dead` — "MicrobeAtlas has 40k samples but only ~900 carry pH. Not enough for a gradient analysis; falling back to a categorical split."
+- ✅ `~ TnSeq coverage checked` — "Three of the seven organisms have TnSeq. A two-organism comparison is the most the data supports."
+- ❌ "Queried the pangenome table and looked at some papers."
+
+**"Nothing to record" is a valid activity entry.** One line saying a stretch was inconclusive is worth having — an hour that produced no constraint is itself a fact about the question — and it is always better than padding. Never invent significance to fill an entry.
+
+Activity entries are collapsed by default on the dashboard, so they cost the reader nothing. That is not licence to write badly: the reason to open them is usually that a result looks wrong and someone is reconstructing how it was reached.
+
+If a stretch produced something that belongs in the narrative tier, write it as a narrative entry instead — one entry, not both.
 
 ## When to write an entry
 
@@ -73,6 +96,10 @@ Demotions are transitions too: a `/synthesize` re-open of a `complete` project, 
 - A data export lands in `data/`.
 - A correction: a bug found, a re-run, an approach abandoned. **These are the highest-value entries** — they are the only record of why the project isn't a straight line. Mark them with a leading `!` so they stand out on the dashboard.
 - The plan changes mid-flight (pair it with the `RESEARCH_PLAN.md` Revision History bump).
+
+### Activity — on the clock
+
+`.claude/hooks/worklog_gate.py` asks for one when ~15 minutes of work have gone by with nothing written, and asks for a *narrative* entry when an artifact is newer than the last entry. Both self-debounce: writing resets the clock. You do not need to watch the clock yourself — write entries as work concludes and the gate will rarely fire.
 
 ## Rules
 

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,12 @@ projects/*/.dash.log
 # only ever about the machine it was written on.
 projects/*/.agent-state.json
 projects/*/.agent-state.json.tmp
+# Passive per-session runtime history. Non-authoritative (see
+# docs/provenance-and-trust.md) and machine-local in content: shell user, ORCID,
+# session id, model. Never committed on any branch in this repo's history, so
+# ignoring it preserves the de-facto behaviour and stops a fresh clone showing an
+# untracked file after the SessionStart hook writes one.
+projects/*/runtime.json
 
 # UI application
 ui/data/cache.json

--- a/beril_cli/project_resolution.py
+++ b/beril_cli/project_resolution.py
@@ -13,6 +13,7 @@ _PROJECT_PATH = re.compile(
     r"(?:^|[\s/])projects/([A-Za-z0-9][A-Za-z0-9._-]*)(?=$|[\s/])"
 )
 _SIMPLE_PROJECT_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*$")
+_DEFAULT_BRANCHES = frozenset({"main", "master"})
 
 
 def _iter_strings(value: Any):
@@ -92,6 +93,16 @@ def _branch_project(repo_root: Path, branch: str | None) -> str | None:
     conventional = re.fullmatch(r"projects/([A-Za-z0-9][A-Za-z0-9._-]*)", branch)
     if conventional:
         return _existing_project(repo_root, conventional.group(1))
+    # The manifest scan below binds a session by an *exact* `branch:` match, which
+    # is meaningful for a working branch (`feat/p2-analysis`) and meaningless for
+    # the default branch: a lone manifest recording `branch: main` captures every
+    # repo-root session on `main`, including sessions doing unrelated work. One
+    # such value is indistinguishable from a correct one — the len(matches) == 1
+    # ambiguity guard only fires when a *second* project collides. Excluded here
+    # rather than validated at write time so an already-committed manifest cannot
+    # reintroduce it. The conventional `projects/<id>` form above is unaffected.
+    if branch in _DEFAULT_BRANCHES:
+        return None
     projects_root = repo_root / "projects"
     matches = (
         [

--- a/projects/lignin_community_enrichment/beril.yaml
+++ b/projects/lignin_community_enrichment/beril.yaml
@@ -2,7 +2,7 @@ project_id: lignin_community_enrichment
 status: complete
 created_at: "2026-05-07T00:00:00Z"
 last_session_at: "2026-06-10T18:49:59Z"
-branch: main
+branch: projects/lignin_community_enrichment
 engine:
   name: claude
 authors:

--- a/tests/test_cli_audit.py
+++ b/tests/test_cli_audit.py
@@ -110,6 +110,28 @@ def test_ambiguous_branch_mapping_returns_no_project(repo):
     assert resolve_project({"cwd": str(repo)}, repo_root=repo, branch="shared") is None
 
 
+def test_manifest_naming_default_branch_binds_nothing(repo):
+    """A lone `branch: main` must not capture every repo-root session on main.
+
+    The ambiguity guard cannot catch this: one such manifest looks exactly like a
+    correct unique match.
+    """
+    (repo / "projects" / "p2" / "beril.yaml").write_text(
+        "project_id: p2\nbranch: main\n"
+    )
+    assert resolve_project({"cwd": str(repo)}, repo_root=repo, branch="main") is None
+    assert resolve_project({"cwd": str(repo)}, repo_root=repo, branch="master") is None
+
+
+def test_default_branch_guard_spares_conventional_form(repo):
+    """`projects/<id>` still resolves even for a project literally named `main`."""
+    (repo / "projects" / "main").mkdir()
+    assert (
+        resolve_project({"cwd": str(repo)}, repo_root=repo, branch="projects/main")
+        == "main"
+    )
+
+
 def test_unknown_explicit_binding_does_not_fall_through(repo):
     payload = {"project_id": "ghost", "cwd": str(repo / "projects" / "p1")}
     assert resolve_project(payload, repo_root=repo, branch="projects/p1") is None

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -15,6 +15,7 @@ import json
 import shutil
 import subprocess
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -26,6 +27,7 @@ sys.path.insert(0, str(ROOT))
 from tools.dashboard import (  # noqa: E402
     jupyter_python,
     _approval_chip,
+    _timeline_html,
     count_deviations,
     main,
     notebook_stats,
@@ -441,6 +443,42 @@ def test_parse_worklog(tmp_path):
     assert (demote.correction, demote.title, demote.new_status) == (
         True, "plan revised", "proposed",
     )
+
+
+def test_activity_entries_fold_without_hiding_the_narrative(tmp_path):
+    """The `~` tier exists to carry the 15-minute running summary without
+    burying the entries a human actually reads. Three things have to hold at
+    once, and each of them was a way to get this wrong: activity entries parse
+    and are flagged, consecutive ones collapse into a disclosure whose id is
+    stable under appends (POLL_JS restores open state by id, so an id keyed on
+    rendered position would slam the panel shut every 4s), and the `now` card
+    keeps showing the newest *narrative* entry rather than whatever ran last."""
+    project = _project(tmp_path)
+    log = (
+        "## 2026-02-18 · plan written → proposed\nFramed it.\n\n"
+        "## 2026-02-18 · ~ checked coverage\nOnly 900 samples carry pH.\n\n"
+        "## 2026-02-18 · ~ read the Price 2019 methods\nInconclusive.\n\n"
+        "## 2026-02-19 · vectors built\nDropped 412 genes.\n"
+    )
+    entries = parse_worklog(log, project)
+    assert [e.activity for e in entries] == [False, True, True, False]
+    assert entries[1].title == "checked coverage"
+
+    html = _timeline_html(entries, None)
+    # One disclosure for the run of two, not one per entry.
+    assert html.count("<details") == 1
+    assert "2 activity entries" in html
+    # Id keyed on the run's position in the file: appending a third activity
+    # entry to that run must not renumber it.
+    assert 'id="act-1"' in html
+    grown = parse_worklog(
+        log + "\n## 2026-02-19 · ~ one more\nStill nothing.\n", project
+    )
+    assert 'id="act-1"' in _timeline_html(grown, None)
+
+    page = render(replace(scan(project), entries=entries), css="body{}")
+    assert "<b>vectors built</b>" in page.split('class="d-tl"')[0]
+    assert "Worklog (2)" in page and "+2 activity" in page
 
 
 def test_notebook_stats_and_partial_writes(tmp_path):

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -201,6 +201,7 @@ class Entry:
     prose: str = ""
     links: list = field(default_factory=list)
     correction: bool = False
+    activity: bool = False
 
 
 @dataclass
@@ -666,8 +667,23 @@ def parse_worklog(text: str, project: Path) -> list:
             correction = title.startswith("!")
             if correction:
                 title = title[1:].strip()
+            # A leading `~` marks an activity entry — the 15-minute running
+            # summary the Stop hook asks for. Same one-character mechanism as
+            # `!` above, for the same reason: the grammar is unchanged and a
+            # worklog written before this existed parses exactly as before.
+            # The renderer folds consecutive activity entries into one
+            # collapsed run so the narrative stays scannable.
+            activity = title.startswith("~")
+            if activity:
+                title = title[1:].strip()
             entries.append(
-                Entry(head.group(1), title, head.group(3), correction=correction)
+                Entry(
+                    head.group(1),
+                    title,
+                    head.group(3),
+                    correction=correction,
+                    activity=activity,
+                )
             )
             continue
         if not entries:
@@ -924,6 +940,21 @@ background:var(--d-accent);}
    timeline finds the moments the project changed direction. */
 .d-ev.fix:before{background:var(--d-warn);border-color:var(--d-warn);}
 .d-ev.fix{border-left:2px solid #d2992255;margin-left:-14px;padding-left:12px;}
+/* Activity runs: collapsed by default, so the narrative reads unbroken and the
+   15-minute summaries are one click away rather than in the way. Dimmed and
+   marked with a hollow tick inside the panel — once opened they are still the
+   lesser tier, and should not compete with the entries around them. */
+.d-act{margin:0 0 18px;}
+.d-act>summary{cursor:pointer;color:var(--d-mut);font-size:12px;list-style:none;
+padding:2px 0;}
+.d-act>summary::-webkit-details-marker{display:none;}
+.d-act>summary:before{content:'\\25B8  ';color:#4a5265;}
+.d-act[open]>summary:before{content:'\\25BE  ';}
+.d-act>summary:hover{color:var(--d-fg);}
+.d-act[open]>summary{margin-bottom:10px;}
+.d-ev.act{margin-bottom:12px;opacity:.72;}
+.d-ev.act:before{width:5px;height:5px;left:-20.5px;top:8px;border-color:#3a4152;}
+.d-ev.act p{font-size:13px;}
 .d-ev p{max-width:68ch;margin:4px 0;color:#c4cad8;}
 .d-links{display:flex;gap:7px;flex-wrap:wrap;align-items:center;margin-top:6px;}
 /* The gallery earns real size; the 104px inline thumbs in the timeline do not.
@@ -1362,8 +1393,46 @@ def _link_html(link: Link, routes: "JupyterRoutes | None") -> str:
     return f'<a class="d-chip" href="{href}" target="_blank">{label}{count}</a>'
 
 
+def _timeline_html(entries: list, routes: "JupyterRoutes | None") -> str:
+    """Newest first, with consecutive activity entries folded into one
+    ``<details>``.
+
+    Folded *in place* rather than swept into a section of their own: where in
+    the story the dense work happened is itself information, and a separate
+    container throws the chronology away.
+
+    The disclosure id keys on the run's index in the file (oldest-first), which
+    is why this walks the entries in file order and reverses afterwards. An
+    append extends the newest run without renumbering the earlier ones, so the
+    id survives, and with it the open/closed state that POLL_JS restores across
+    the 4s refresh — id keyed on the *rendered* position would collapse the
+    panel the reader just opened every time the agent wrote an entry.
+    """
+    runs: list = []
+    for index, entry in enumerate(entries):
+        if runs and runs[-1][0] == entry.activity:
+            runs[-1][2].append(entry)
+        else:
+            runs.append((entry.activity, index, [entry]))
+
+    parts = []
+    for is_activity, start, group in reversed(runs):
+        body = "".join(_entry_html(entry, routes) for entry in reversed(group))
+        if not is_activity:
+            parts.append(body)
+            continue
+        label = "%d activity %s" % (len(group), "entry" if len(group) == 1 else "entries")
+        parts.append(
+            f'<details class="d-act" id="act-{start}">'
+            f"<summary>{label}</summary>{body}</details>"
+        )
+    return '<div class="d-tl">' + "".join(parts) + "</div>"
+
+
 def _entry_html(entry: Entry, routes: "JupyterRoutes | None") -> str:
     big = " big" if entry.new_status else ""
+    if entry.activity:
+        big += " act"
     # Corrections are the only record of why a project was not a straight line,
     # and they used to render identically to "ran notebook 3". Labelled as well
     # as coloured — hue alone is not a signal everyone can read.
@@ -1621,7 +1690,16 @@ def render(state: State, css: str, live: bool = True) -> str:
     # summary, and the same entry sits in full at the top of the timeline a
     # scroll away. Unclamped, a long review write-up pushed the sticky header to
     # ~390px and buried the content it was supposed to sit above.
-    newest = state.entries[-1] if state.entries else None
+    # Newest *narrative* entry. Activity entries are the running summary and
+    # outnumber the narrative ones badly, so keying this on the literal last
+    # line would park "reviewed three tables, nothing conclusive" above the fold
+    # for the whole project. Falls back to the last entry only when there is
+    # nothing else, which is the honest answer for a project that has so far
+    # only been explored.
+    newest = next(
+        (entry for entry in reversed(state.entries) if not entry.activity),
+        state.entries[-1] if state.entries else None,
+    )
     now_card = (
         '<div class="d-now"><span class="d-eyebrow">now</span>'
         f"<b>{inline_md(newest.title)}</b>"
@@ -1631,10 +1709,20 @@ def render(state: State, css: str, live: bool = True) -> str:
         else ""
     )
 
+    # The heading counts the narrative entries only — that is the number a
+    # reader is being offered. Activity entries are announced beside it rather
+    # than summed in, so the count cannot imply a denser timeline than the one
+    # on screen.
+    activity_count = sum(1 for entry in state.entries if entry.activity)
+    narrative = len(state.entries) - activity_count
+    activity_chip = (
+        f'<span class="d-chip">+{activity_count} activity</span>'
+        if activity_count
+        else ""
+    )
+
     if state.entries:
-        timeline = '<div class="d-tl">' + "".join(
-            _entry_html(entry, state.routes) for entry in reversed(state.entries)
-        ) + "</div>"
+        timeline = _timeline_html(state.entries, state.routes)
     else:
         timeline = (
             '<p class="d-empty">No worklog entries yet — the agent writes one per '
@@ -1686,7 +1774,10 @@ def render(state: State, css: str, live: bool = True) -> str:
         f"{now_card}"
         "</header>\n"
         f"{_plan_html(state)}\n"
-        f'<h2 class="d-sec">Worklog ({len(state.entries)})</h2>{timeline}\n'
+        # The count is the narrative one — the number a reader is being offered.
+        # Activity entries are announced separately rather than summed in, so
+        # the heading cannot imply the timeline is denser than what it shows.
+        f'<h2 class="d-sec">Worklog ({narrative}){activity_chip}</h2>{timeline}\n'
         f"{_artifacts_html(state)}\n"
         "</div>\n"
         # Sibling of #root, so the 4s poll never wipes it. Reuses main.css's


### PR DESCRIPTION
Stacked on #354 — review that first; this diff is against its branch.

77 projects, zero `WORKLOG.md` files. Six skills each carry a one-line "append a worklog entry" and nothing enforced it.

## Added

- **`.claude/hooks/worklog_gate.py`** — Stop hook that holds the turn when the worklog is behind the work. Two triggers: an artifact newer than the last entry → narrative entry; 15 min with nothing written → activity entry. Both self-debounce on mtime, so no counter, state file or transcript parsing.
- **Activity tier** — `~`-marked entries, parsed like the existing `!` correction marker, folded by the dashboard into a collapsed `<details>` in chronological position. The time trigger is the only thing covering exploration, which leaves no artifact to gate on.
- **Narrative-only `now` card and heading count**, so neither implies a denser timeline than the one on screen.
- **`worklog-capture` skill** — the two-tier contract and what belongs in each.

## Fixed

- **Duplicate `"Stop"` keys in `settings.json`** from the rebase onto #354. Git merged cleanly — both sides appended a well-formed block — but JSON keeps the last, silently dropping #354's `agent_state.py` hook. Merged into one chain, `agent_state` first.

## Notes

- Skips `stop_hook_active`, unresolvable projects, and `status: complete`. A Stop hook fires only at turn end, so idle fires nothing; "nothing to record" is an accepted entry.
- Disclosure ids key on file position, so an append doesn't renumber earlier runs and collapse a panel the reader just opened.
- Not included: subtracting `waiting` time from the idle clock. `agent_state.py` writes `turn_ended` on Stop and runs first in the chain, so the duration is gone by the time the gate reads it.
- 451 tests pass.
