### PR TITLE
fix(runtime): prevent default-branch project binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,12 @@ projects/*/dashboard.html
 # Session pin marker — see PROJECT.md "Telling the tools which project"
 projects/*/.beril-pin
 projects/*/.dash.log
+# Passive per-session runtime history. Non-authoritative (see
+# docs/provenance-and-trust.md) and machine-local in content: shell user, ORCID,
+# session id, model. Never committed on any branch in this repo's history, so
+# ignoring it preserves the de-facto behaviour and stops a fresh clone showing an
+# untracked file after the SessionStart hook writes one.
+projects/*/runtime.json
 
 # UI application
 ui/data/cache.json

--- a/beril_cli/project_resolution.py
+++ b/beril_cli/project_resolution.py
@@ -13,6 +13,7 @@ _PROJECT_PATH = re.compile(
     r"(?:^|[\s/])projects/([A-Za-z0-9][A-Za-z0-9._-]*)(?=$|[\s/])"
 )
 _SIMPLE_PROJECT_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*$")
+_DEFAULT_BRANCHES = frozenset({"main", "master"})
 
 
 def _iter_strings(value: Any):
@@ -92,6 +93,16 @@ def _branch_project(repo_root: Path, branch: str | None) -> str | None:
     conventional = re.fullmatch(r"projects/([A-Za-z0-9][A-Za-z0-9._-]*)", branch)
     if conventional:
         return _existing_project(repo_root, conventional.group(1))
+    # The manifest scan below binds a session by an *exact* `branch:` match, which
+    # is meaningful for a working branch (`feat/p2-analysis`) and meaningless for
+    # the default branch: a lone manifest recording `branch: main` captures every
+    # repo-root session on `main`, including sessions doing unrelated work. One
+    # such value is indistinguishable from a correct one — the len(matches) == 1
+    # ambiguity guard only fires when a *second* project collides. Excluded here
+    # rather than validated at write time so an already-committed manifest cannot
+    # reintroduce it. The conventional `projects/<id>` form above is unaffected.
+    if branch in _DEFAULT_BRANCHES:
+        return None
     projects_root = repo_root / "projects"
     matches = (
         [

--- a/projects/lignin_community_enrichment/beril.yaml
+++ b/projects/lignin_community_enrichment/beril.yaml
@@ -2,7 +2,7 @@ project_id: lignin_community_enrichment
 status: complete
 created_at: "2026-05-07T00:00:00Z"
 last_session_at: "2026-06-10T18:49:59Z"
-branch: main
+branch: projects/lignin_community_enrichment
 engine:
   name: claude
 authors:

--- a/tests/test_cli_audit.py
+++ b/tests/test_cli_audit.py
@@ -110,6 +110,28 @@ def test_ambiguous_branch_mapping_returns_no_project(repo):
     assert resolve_project({"cwd": str(repo)}, repo_root=repo, branch="shared") is None
 
 
+def test_manifest_naming_default_branch_binds_nothing(repo):
+    """A lone `branch: main` must not capture every repo-root session on main.
+
+    The ambiguity guard cannot catch this: one such manifest looks exactly like a
+    correct unique match.
+    """
+    (repo / "projects" / "p2" / "beril.yaml").write_text(
+        "project_id: p2\nbranch: main\n"
+    )
+    assert resolve_project({"cwd": str(repo)}, repo_root=repo, branch="main") is None
+    assert resolve_project({"cwd": str(repo)}, repo_root=repo, branch="master") is None
+
+
+def test_default_branch_guard_spares_conventional_form(repo):
+    """`projects/<id>` still resolves even for a project literally named `main`."""
+    (repo / "projects" / "main").mkdir()
+    assert (
+        resolve_project({"cwd": str(repo)}, repo_root=repo, branch="projects/main")
+        == "main"
+    )
+
+
 def test_unknown_explicit_binding_does_not_fall_through(repo):
     payload = {"project_id": "ghost", "cwd": str(repo / "projects" / "p1")}
     assert resolve_project(payload, repo_root=repo, branch="projects/p1") is None


### PR DESCRIPTION
- Prevent repo-root sessions on `main` or `master` from binding through project manifest branch matches.
- Correct the lignin enrichment project’s branch mapping.
- Ignore machine-local per-project `runtime.json` files.