### PR TITLE
Extract dashboard client assets and fix polling/thumbnail bugs

### DIFF
--- a/.claude/hooks/agent_state.py
+++ b/.claude/hooks/agent_state.py
@@ -83,26 +83,26 @@ GENERIC = {"Claude needs your permission", "Claude is waiting for your input"}
 ROOT = Path(__file__).absolute().parent.parent.parent
 
 
-def find_detail(value, keys=DETAIL_KEYS) -> "str | None":
-    """The first non-empty string under any of `keys`, at any depth.
+def find_detail(value) -> "str | None":
+    """The first non-empty string under any of `DETAIL_KEYS`, at any depth.
 
     Keys are tried in priority order at each level before descending, so a
     `command` two levels down still loses to a `question` at the top.
     """
     if isinstance(value, dict):
-        for key in keys:
+        for key in DETAIL_KEYS:
             found = value.get(key)
             if isinstance(found, str) and found.strip():
                 return found.strip()
-        for child in value.values():
-            found = find_detail(child, keys)
-            if found:
-                return found
+        children = value.values()
     elif isinstance(value, list):
-        for child in value:
-            found = find_detail(child, keys)
-            if found:
-                return found
+        children = value
+    else:
+        return None
+    for child in children:
+        found = find_detail(child)
+        if found:
+            return found
     return None
 
 

--- a/.claude/hooks/beril-runtime.sh
+++ b/.claude/hooks/beril-runtime.sh
@@ -16,8 +16,13 @@
 # so the snapshot would then receive nothing.
 payload="$(cat)"
 
-# Cost guard. Unguarded this costs ~103ms on *every* Write/Edit (measured);
-# guarded, a write outside any project costs a few ms.
+# Cost guard. Unguarded this costs ~65ms on *every* Write/Edit; guarded, a write
+# outside any project costs ~8ms (medians of 21 runs on this checkout).
+#
+# Pinned by tests/test_statusline.py::test_the_guard_does_not_start_the_interpreter_
+# for_a_write_outside_a_project, which asserts the *boolean* — whether the
+# interpreter starts — not the milliseconds, so it cannot go stale the way the
+# earlier ~103ms/~16ms figures here did.
 #
 # It applies to tool events ONLY. A SessionStart payload for a session on branch
 # `projects/<id>` sitting at the repo root contains no `projects/` string at all

--- a/.claude/hooks/dash_stop.py
+++ b/.claude/hooks/dash_stop.py
@@ -35,20 +35,19 @@ STAYING = {"bypass_permissions_disabled"}
 ROOT = Path(__file__).absolute().parent.parent.parent
 
 
-def projects_for(payload: dict) -> "list[str]":
+def projects_for(payload: dict, session_id: "str | None") -> "list[str]":
     """Every project whose dashboard this session may have started.
 
     Not one project. The status line starts a dashboard for whichever project the
     session is on, so a session that switched has one running per project it
     touched, each on its own port. Stopping only the current one left the rest
-    alive after Claude Code exited — the leak this hook exists to prevent.""" 
+    alive after Claude Code exited — the leak this hook exists to prevent."""
     sys.path.insert(0, str(ROOT))
     try:
         from beril_cli.project_resolution import projects_for_session, resolve_project
     except Exception:
         return []
 
-    session_id = payload.get("session_id") or os.environ.get("CLAUDE_CODE_SESSION_ID")
     found = list(projects_for_session(session_id, ROOT))
     try:
         # cwd/branch/`/add-dir` can name a project the runtime record never saw.
@@ -68,7 +67,11 @@ def main() -> None:
     if payload.get("reason") in STAYING:
         return
 
-    projects = projects_for(payload)
+    # One expression, two uses: which dashboards to stop and whose
+    # `.agent-state.json` to delete are the same question.
+    session_id = payload.get("session_id") or os.environ.get("CLAUDE_CODE_SESSION_ID")
+
+    projects = projects_for(payload, session_id)
     if not projects:
         return
 
@@ -82,7 +85,6 @@ def main() -> None:
     # Only this session's own record, though. Two sessions can share a project,
     # and one exiting used to delete the other's live "waiting for you" — the
     # departing session silencing the one that still needs a human.
-    session_id = payload.get("session_id") or os.environ.get("CLAUDE_CODE_SESSION_ID")
     for name in projects:
         state = ROOT / "projects" / name / ".agent-state.json"
         try:

--- a/docs/live-dashboard-design.md
+++ b/docs/live-dashboard-design.md
@@ -9,9 +9,20 @@ observatory (`ui/`), which is Postgres-backed, auth'd, and renders *finished* pr
 imported from GitHub. This renders the working directory as it is right now.
 
 **This document records decisions and the evidence behind them — mostly why things were
-*not* built.** How the code works is documented in `tools/dashboard.py` itself, next to
-the code, where it cannot drift. Nothing here should restate a docstring; if it does,
-delete it here.
+*not* built.** How the code works is documented in `tools/dashboard.py` and
+`tools/dashboard_assets/` themselves, next to the code, where it cannot drift. Nothing here
+should restate a docstring; if it does, delete it here.
+
+The client scripts live in `tools/dashboard_assets/` — `rel.js`, `state.js`, `poll.js`,
+`lightbox.js` — one file per constant, read at import and inlined by `render()`. Their
+rationale moved with them; `poll.js`'s header is where the cross-file coupling is written
+down. Two consequences worth knowing before rediscovering them. The comments now ride the
+wire — 5.2 KB became 13.9 KB on every uncached response — so if page weight ever becomes a
+budget, strip them in `_asset()`. It is not the one-liner it looks like: `state.js` has a
+`//` inside a string literal. And if the directory fails to ship, the loudest symptom is
+the quietest — `.claude/statusline.sh` and `beril setup` both catch the import error and
+drop the stage chip, the URL and the dashboard auto-start without a word. Run
+`python3 tools/dashboard.py --static <project>` to see the real one.
 
 ## Why a server, and why this one
 
@@ -399,6 +410,7 @@ runs in, and people reasonably assume it kills the session too. It does not.
 | a service worker, so a *closed* tab can be notified | never — it also needs a push service, and a stdlib server in an ephemeral pod cannot be one |
 | a modal, or anything that keeps flashing, for "agent needs you" | never — WCAG 2.3.1; one 600ms pulse on the transition is the ceiling |
 | fastapi, uvicorn, jinja2, nbconvert, PyYAML | never — see the two-launcher section |
+| a bundler, minifier, eslint or any build step for `tools/dashboard_assets/` | never — the pod has no egress, so a bundle would have to be committed, and a stale committed artifact is a failure no test can see |
 | `c.ServerProxy.servers` supervised registration | someone wants a permanent named URL and doesn't mind restarting Jupyter once |
 | pidfile / flock / stop command | two dashboards must be mutually exclusive on one port — not a requirement |
 | TOC, tabs, search, sortable tables, light mode | past ~6 sections, or >10 notebooks in a project |

--- a/docs/live-dashboard-design.md
+++ b/docs/live-dashboard-design.md
@@ -201,8 +201,11 @@ file exists *only* while a prompt is pending, which is exactly when it must run.
 `if(document.visibilityState==='visible')` around the `fetch` — made every channel
 above impossible: the backgrounded tab is precisely the one that needs to learn the
 agent is blocked, and the title and the favicon are painted from a response. A 304
-still runs a full `scan()` at 6.8ms, so 15s hidden is ~1.6s of CPU per hour per tab,
-less than a visible tab costs today.
+used to run a full `scan()` at 6.8ms, so 15s hidden was ~1.6s of CPU per hour per
+tab — already less than a visible tab costs. It now runs only `fingerprint()`, the
+directory walk plus the resolved agent state, measured at 0.25-0.84ms across the
+three largest projects on disk, so the interval has an order of magnitude of slack
+it did not have when it was chosen.
 
 **Three things are anchored outside `#root`, and each for a different failure.**
 The strip, because inside `#root` it is destroyed and rebuilt every 4s and its

--- a/docs/live-dashboard-design.md
+++ b/docs/live-dashboard-design.md
@@ -357,8 +357,13 @@ Two things about that hook are easy to break and are pinned by tests:
   read by shelling out to git — so a blanket "skip unless the payload mentions `projects/`"
   would silently break the path that already worked.
 
-Unguarded the hook costs ~103 ms on every `Write`/`Edit`; guarded, a write outside any
-project costs ~16 ms (measured).
+Unguarded the hook costs ~65 ms on every `Write`/`Edit`; guarded, a write outside any
+project costs ~8 ms (medians of 21 runs, this checkout). Both figures were ~103 ms and
+~16 ms when first written; they are re-measured here because the guard is now pinned by
+`test_the_guard_does_not_start_the_interpreter_for_a_write_outside_a_project`, and a test
+that exists to defend a number should not sit next to a stale one. What the test asserts
+is the *boolean* — whether the interpreter starts at all — precisely so it cannot rot the
+way these figures did.
 
 Everything stays keyed to `session_id` on purpose. Several sessions can run in one clone on
 different projects, so any repo-wide signal — an env var, "whichever `beril.yaml` was

--- a/docs/live-dashboard-design.md
+++ b/docs/live-dashboard-design.md
@@ -13,13 +13,15 @@ imported from GitHub. This renders the working directory as it is right now.
 `tools/dashboard_assets/` themselves, next to the code, where it cannot drift. Nothing here
 should restate a docstring; if it does, delete it here.
 
-The client scripts live in `tools/dashboard_assets/` — `rel.js`, `state.js`, `poll.js`,
-`lightbox.js` — one file per constant, read at import and inlined by `render()`. Their
-rationale moved with them; `poll.js`'s header is where the cross-file coupling is written
-down. Two consequences worth knowing before rediscovering them. The comments now ride the
-wire — 5.2 KB became 13.9 KB on every uncached response — so if page weight ever becomes a
-budget, strip them in `_asset()`. It is not the one-liner it looks like: `state.js` has a
-`//` inside a string literal. And if the directory fails to ship, the loudest symptom is
+The client assets live in `tools/dashboard_assets/` — `dash.css` plus `rel.js`,
+`state.js`, `poll.js`, `lightbox.js` — one file per constant, read at import and inlined
+by `render()`. Their rationale moved with them; `poll.js`'s header is where the cross-file
+coupling is written down, and `dash.css`'s is where its ordering against `main.css` is.
+Two consequences worth knowing before rediscovering them. The comments now
+ride the wire — 5.2 KB of JS became 13.9 KB, plus 0.4 KB of header on `dash.css`, on every
+uncached response — so if page weight ever becomes a budget, strip them in `_asset()`. It
+is not the one-liner it looks like: `state.js` has a `//` inside a string literal, and CSS
+has no line comments at all. And if the directory fails to ship, the loudest symptom is
 the quietest — `.claude/statusline.sh` and `beril setup` both catch the import error and
 drop the stage chip, the URL and the dashboard auto-start without a word. Run
 `python3 tools/dashboard.py --static <project>` to see the real one.
@@ -410,7 +412,7 @@ runs in, and people reasonably assume it kills the session too. It does not.
 | a service worker, so a *closed* tab can be notified | never — it also needs a push service, and a stdlib server in an ephemeral pod cannot be one |
 | a modal, or anything that keeps flashing, for "agent needs you" | never — WCAG 2.3.1; one 600ms pulse on the transition is the ceiling |
 | fastapi, uvicorn, jinja2, nbconvert, PyYAML | never — see the two-launcher section |
-| a bundler, minifier, eslint or any build step for `tools/dashboard_assets/` | never — the pod has no egress, so a bundle would have to be committed, and a stale committed artifact is a failure no test can see |
+| a bundler, minifier, eslint, stylelint or any build step for `tools/dashboard_assets/` | never — the pod has no egress, so a bundle would have to be committed, and a stale committed artifact is a failure no test can see |
 | `c.ServerProxy.servers` supervised registration | someone wants a permanent named URL and doesn't mind restarting Jupyter once |
 | pidfile / flock / stop command | two dashboards must be mutually exclusive on one port — not a requirement |
 | TOC, tabs, search, sortable tables, light mode | past ~6 sections, or >10 notebooks in a project |

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -827,8 +828,8 @@ def test_the_title_marker_and_favicon_are_client_side(tmp_path):
     page = dash.render(dash.scan(_waiting(_project(tmp_path))), "")
 
     assert "<title>demo</title>" in page, "the marker was baked into the response"
-    assert "document.title=(MARK[s]||'')+BASE" in page
-    assert 'id="d-favicon"' in page and "F.href=ICON[s]" in page
+    assert "document.title = (MARK[s] || '') + BASE;" in page
+    assert 'id="d-favicon"' in page and "F.href = ICON[s] || ICON[''];" in page
 
 
 def test_a_snapshot_gets_the_state_but_never_the_alert_button(tmp_path):
@@ -956,9 +957,155 @@ def test_a_hidden_tab_still_polls_only_slower():
     """
     import tools.dashboard as dash
 
-    assert "document.hidden?15000:4000" in dash.POLL_JS
+    assert "document.hidden ? 15000 : 4000" in dash.POLL_JS
     assert dash.POLL_JS.count("visibilityState") == 1, "something still gates the fetch"
     assert "clearTimeout(timer)" in dash.POLL_JS, "tab returns would stack poll chains"
+
+
+ASSET_DIR = ROOT / "tools" / "dashboard_assets"
+JS_FILES = ("rel.js", "state.js", "poll.js", "lightbox.js")
+
+
+SCOPE_HARNESS = """
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const DIR = process.argv[2];
+const src = {};
+const out = {parsed: {}, exported: {}, calls: [], threw: null, rescheduled: []};
+
+// `new vm.Script` is the parser a classic inline <script> uses. `node --check`
+// is not: on a .js file it falls back to the module goal, so `import`,
+// `export`, top-level `await` and top-level `return` all pass there and are
+// hard SyntaxErrors in the page render() actually emits.
+for (const f of ['rel.js', 'state.js', 'poll.js', 'lightbox.js']) {
+  src[f] = fs.readFileSync(path.join(DIR, f), 'utf8');
+  try {
+    new vm.Script(src[f]);
+    out.parsed[f] = true;
+  } catch (e) {
+    out.parsed[f] = String(e);
+  }
+}
+if (Object.values(out.parsed).some((v) => v !== true)) {
+  console.log(JSON.stringify(out));
+  process.exit(0);
+}
+
+const el = () => ({
+  innerHTML: '', hidden: true, offsetWidth: 1, href: '', dataset: {},
+  classList: {add() {}, remove() {}},
+  querySelector: () => null, querySelectorAll: () => [], addEventListener() {},
+});
+const ctx = {
+  console,
+  document: {
+    title: 'demo', hidden: false, getElementById: el,
+    querySelectorAll: () => [], addEventListener() {},
+  },
+  location: {pathname: '/proxy/9000/', replace() {}},
+  setInterval: () => 0,
+  setTimeout: (f, ms) => { out.rescheduled.push(ms); return 1; },
+  clearTimeout() {},
+  CSS: {escape: (s) => s},
+  DOMParser: class {
+    parseFromString() { return {getElementById: () => ({innerHTML: 'swapped'})}; }
+  },
+  fetch: () => Promise.resolve({
+    status: 200, headers: {get: () => 'W/"etag"'},
+    text: () => Promise.resolve('<html></html>'),
+  }),
+};
+ctx.window = ctx;
+vm.createContext(ctx);
+
+// Exactly what render() emits in live mode: three files, one <script>.
+new vm.Script(src['rel.js'] + src['state.js'] + src['poll.js']).runInContext(ctx);
+
+// Both are global bindings a *sibling file* created, so read them before
+// spying — a spy would paper over the binding having gone missing.
+out.exported = {relTimes: typeof ctx.relTimes, dashMark: typeof ctx.dashMark};
+ctx.relTimes = () => out.calls.push('relTimes');
+ctx.dashMark = () => out.calls.push('dashMark');
+out.rescheduled.length = 0;
+try { ctx.tick(); } catch (e) { out.threw = String(e); }
+await new Promise((r) => setTimeout(r, 20));
+console.log(JSON.stringify(out));
+"""
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="needs node to run the scripts")
+def test_the_live_scripts_parse_and_share_one_scope(tmp_path):
+    """The extracted scripts have no bundler, no eslint and no build step behind
+    them, deliberately, so this is the whole lint story — and reading each file
+    is not enough of one.
+
+    `rel.js`, `state.js` and `poll.js` are concatenated into a single
+    `<script>`, which is the only reason `poll.js` can see `R`, `tag`,
+    `relTimes` and `dashMark`. Nothing in the language records that. Splitting
+    one blob into four separately editable files is exactly what makes it easy
+    to sever — wrap `rel.js` in an IIFE and every file still parses, so a
+    per-file check stays green while the page renders once and then stops
+    updating. So the three are compiled together and driven through one `tick()`
+    against a stub browser.
+
+    Parsing is `vm.Script`, not `node --check`: `--check` on a `.js` file falls
+    back to the module goal and accepts `import`, `export` and top-level
+    `await`, all of which kill a classic inline `<script>` stone dead.
+    """
+    (tmp_path / "harness.mjs").write_text(SCOPE_HARNESS, encoding="utf-8")
+    done = subprocess.run(
+        ["node", str(tmp_path / "harness.mjs"), str(ASSET_DIR)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert done.returncode == 0, done.stderr
+    result = json.loads(done.stdout)
+
+    assert result["parsed"] == dict.fromkeys(JS_FILES, True)
+    assert result["exported"] == {"relTimes": "function", "dashMark": "function"}
+    assert result["threw"] is None, "poll.js lost a sibling's global"
+    assert result["calls"] == ["relTimes", "dashMark"], "the swap repainted nothing"
+    assert result["rescheduled"] == [4000], "the poll did not schedule its next tick"
+
+
+def test_the_page_inlines_its_scripts_instead_of_linking_them(tmp_path):
+    """The page is one file, in both transports, and that is what makes a
+    `<script src=>` wrong rather than merely different.
+
+    A snapshot is opened through Jupyter's `files/` route or double-clicked off
+    disk, so a relative src resolves next to the *project*, not next to
+    `tools/`. Live is no better: the server hands every unrecognised path to
+    `SimpleHTTPRequestHandler(directory=project)`. Both 404, and a 404 script
+    fails silently.
+
+    `test_render_has_no_absolute_urls` does not cover this — a *relative* src
+    passes it cleanly.
+
+    Inlining is also what makes the moved prose dangerous in a way it was not
+    inside a Python string: a `</script` or a `<!--` in a comment ends the tag
+    early and silently truncates the page, so the file bodies are checked for
+    both.
+    """
+    import tools.dashboard as dash
+
+    state = dash.scan(_project(tmp_path, {"WORKLOG.md": WORKLOG}))
+    live = dash.render(state, "", live=True)
+    snap = dash.render(state, "", live=False)
+
+    for page in (live, snap):
+        # A literal `"<script src="` misses `<script defer src=`; a bare
+        # `" src="` would hit the lightbox's real <img>.
+        assert not re.search(r"<script[^>]*\ssrc=", page)
+    for name in JS_FILES:
+        body = (ASSET_DIR / name).read_text(encoding="utf-8")
+        assert "</script" not in body and "<!--" not in body, f"{name} would truncate the page"
+        assert body.endswith("\n"), f"{name} would glue onto the next file"
+        assert body in live, f"{name} is not inlined verbatim"
+        if name != "poll.js":  # live only, by design
+            assert body in snap, f"{name} is not inlined verbatim in a snapshot"
 
 
 def _dropin(cfg_dir: Path, name: str, enabled: bool) -> None:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -793,6 +793,10 @@ def test_the_expiry_reaches_a_polling_page(tmp_path, monkeypatch):
 
     assert after.agent["state"] == "unknown"
     assert after.etag != before.etag, "a polling browser would be served a 304 forever"
+    # The 304 gate reads `fingerprint`, the 200 body carries `scan().etag`. They
+    # are one expression today only because `scan` calls `fingerprint`; if they
+    # ever drift the browser is handed a 304 for a page it does not have.
+    assert dash.fingerprint(project)[0] == after.etag, "the gate and the body disagree"
     assert fingerprint == [(project / ".agent-state.json").stat().st_mtime_ns], (
         "the file changed, so this proved nothing about the clock"
     )
@@ -822,14 +826,23 @@ def test_the_title_marker_and_favicon_are_client_side(tmp_path):
     """The same rule as relative times, for the same reason: a 304 freezes
     anything the server wrote, and these two are the only channels that reach a
     reader whose tab is in the background. A `<title>` baked with a marker would
-    keep claiming the agent needs you long after it stopped."""
+    keep claiming the agent needs you long after it stopped.
+
+    This is the server's half: an unmarked title, and a `<link>` for the client
+    to retarget (a browser will not adopt one that appears after it has painted).
+    The client half — that STATE_JS actually writes both — is asserted from the
+    node harness in `test_when_a_system_notification_actually_fires`, because the
+    source-string greps this used to carry broke on a variable rename and passed
+    on a behaviour-preserving one, which is backwards. That harness is
+    node-gated, so on a box without node this assertion is the only half of the
+    contract left standing — a green run there is not the whole story.
+    """
     import tools.dashboard as dash
 
     page = dash.render(dash.scan(_waiting(_project(tmp_path))), "")
 
     assert "<title>demo</title>" in page, "the marker was baked into the response"
-    assert "document.title = (MARK[s] || '') + BASE;" in page
-    assert 'id="d-favicon"' in page and "F.href = ICON[s] || ICON[''];" in page
+    assert '<link rel="icon" id="d-favicon"' in page, "nothing for STATE_JS to retarget"
 
 
 def test_a_snapshot_gets_the_state_but_never_the_alert_button(tmp_path):
@@ -891,6 +904,12 @@ go('waiting_hidden', () => set('waiting', 5, 'AskUserQuestion: which?'));
 set('waiting', 9, 'x');
 out.pulsed = nodes['d-wait'].classList.has('pulse');
 out.strip_shown = !nodes['d-wait'].hidden;
+// Read while the state is still `waiting`: the two channels a background tab has.
+out.title_marked = document.title;
+out.favicon_href = nodes['d-favicon'].href;
+// `unknown` has no ICON entry and is reached by every expired `waiting`.
+set('unknown', 7, '');
+out.favicon_unknown = nodes['d-favicon'].href;
 set('', 0, '');
 out.strip_cleared = nodes['d-wait'].hidden;
 out.title_restored = document.title;
@@ -910,6 +929,20 @@ def test_when_a_system_notification_actually_fires(tmp_path):
     And nothing fires twice for one event: a re-render is not a transition, so
     the `(state, since)` pair gates it. Without that gate the 4s poll would
     notify fifteen times a minute about a single permission prompt.
+
+    The title marker and the favicon dot are asserted here too, from the same
+    run: they are the only two channels that reach a reader whose tab is in the
+    background, and they used to be pinned by grepping the source for
+    `document.title = (MARK[s] || '') + BASE;`. That grep failed on a rename that
+    changed nothing and passed on a hoist that could have broken it. Reading the
+    values back out of the harness is the check that was actually meant.
+
+    `favicon_unknown` is the `|| ICON['']` fallback, and it is not hypothetical:
+    `ICON` maps `waiting` and `turn_ended` only, while `AGENT_LABELS` also emits
+    `unknown` — the resolved state of every `waiting` that aged past `WAIT_TTL`
+    and of every orphaned record. Without the fallback the href becomes the
+    literal string `undefined` and the browser 404s for a file of that name,
+    with nothing in the console to say so.
 
     Node stands in for a browser because the two inputs that matter — the clock
     and the visibility flag — are exactly what a real headless page will not let
@@ -934,6 +967,13 @@ def test_when_a_system_notification_actually_fires(tmp_path):
 
     assert result["pulsed"] and result["strip_shown"]
     assert result["strip_cleared"] and result["title_restored"] == "demo"
+
+    assert result["title_marked"] == "● demo", "no marker on a backgrounded tab"
+    assert result["favicon_href"].startswith("data:image/svg+xml,")
+    assert "d29922" in result["favicon_href"], "the favicon dot never turned amber"
+    assert result["favicon_unknown"].startswith("data:image/svg+xml,"), (
+        "an unmapped state left the favicon href as the string 'undefined'"
+    )
 
 
 def test_a_hidden_tab_still_polls_only_slower():
@@ -1042,7 +1082,7 @@ def test_the_live_scripts_parse_and_share_one_scope(tmp_path):
     is not enough of one.
 
     `rel.js`, `state.js` and `poll.js` are concatenated into a single
-    `<script>`, which is the only reason `poll.js` can see `R`, `tag`,
+    `<script>`, which is the only reason `poll.js` can see `rootEl`, `tag`,
     `relTimes` and `dashMark`. Nothing in the language records that. Splitting
     one blob into four separately editable files is exactly what makes it easy
     to sever — wrap `rel.js` in an IIFE and every file still parses, so a
@@ -1113,6 +1153,30 @@ def test_the_page_inlines_its_scripts_instead_of_linking_them(tmp_path):
         assert body in live, f"{name} is not inlined verbatim"
         if name != "poll.js":  # live only, by design
             assert body in snap, f"{name} is not inlined verbatim in a snapshot"
+
+
+def test_the_gallery_wins_the_thumbnail_width_tie():
+    """REGRESSION. The figure gallery is `class="d-links d-figs"`, so both
+    `.d-links img` and `.d-figs img` match its tiles at specificity (0,1,1) and
+    source order alone decides the width. `.d-figs img` was written *above*
+    `.d-links img`, so every gallery tile rendered at the timeline's 104px inside
+    a 230px-minimum grid — from the file's first commit (3b7e36ec) until this
+    one, silently, because nothing errors and the page still looks deliberate.
+
+    A comment in dash.css says the order is load-bearing; a comment does not
+    survive the next tidy-up of a stylesheet that has no other ordering
+    constraint. This is the only thing that fails if the two rules swap back.
+
+    Matched as `^selector{` rather than by substring: that same comment quotes
+    `.d-links img`, so a plain `.index()` compares the comment's position and
+    passes however the rules are ordered.
+    """
+    import tools.dashboard as dash
+
+    links = re.search(r"^\.d-links img\{", dash.DASH_CSS, re.M)
+    figs = re.search(r"^\.d-figs img\{", dash.DASH_CSS, re.M)
+    assert links and figs, "one of the two thumbnail width rules is gone"
+    assert links.start() < figs.start(), "gallery tiles are back to 104px"
 
 
 def _dropin(cfg_dir: Path, name: str, enabled: bool) -> None:
@@ -1259,14 +1323,18 @@ def test_every_markdown_link_opens_the_overlay_not_a_new_tab(tmp_path):
     page opened raw markdown source in a new tab, which is worse than what it
     replaced. The chips were verified and the cards were assumed.
 
-    So: assert over *every* anchor pointing at a `.md`, not one call site."""
+    So: assert over *every* anchor pointing at a `.md`, not one call site.
+
+    The plan needs a Research Question or `_plan_html` returns "" and the plan
+    card — the third emitter of a markdown anchor — never renders, which is how
+    this swept only the chips and the cards for its first year."""
     import re
 
     html = _render(
         tmp_path,
         {
             "WORKLOG.md": WORKLOG,
-            "RESEARCH_PLAN.md": PLAN,
+            "RESEARCH_PLAN.md": "# Plan\n\n## Research Question\nQ?\n\n" + PLAN,
             "REPORT.md": "# R\n",
             "figures/a.png": "x",
         },
@@ -1376,27 +1444,3 @@ def test_setup_refuses_rather_than_installing_against_the_wrong_python(tmp_path,
     assert setup_cmd._install_server_proxy(ROOT, assume_yes=True) == 1
     assert not ran, "ran an install with no idea which interpreter to target"
     assert "jupyter" in capsys.readouterr().err.lower()
-
-
-def test_the_gallery_wins_the_thumbnail_width_tie():
-    """REGRESSION. The figure gallery is `class="d-links d-figs"`, so both
-    `.d-links img` and `.d-figs img` match its tiles at specificity (0,1,1) and
-    source order alone decides the width. `.d-figs img` was written *above*
-    `.d-links img`, so every gallery tile rendered at the timeline's 104px inside
-    a 230px-minimum grid — from the file's first commit (3b7e36ec) until this
-    one, silently, because nothing errors and the page still looks deliberate.
-
-    A comment in dash.css says the order is load-bearing; a comment does not
-    survive the next tidy-up of a stylesheet that has no other ordering
-    constraint. This is the only thing that fails if the two rules swap back.
-
-    Matched as `^selector{` rather than by substring: that same comment quotes
-    `.d-links img`, so a plain `.index()` compares the comment's position and
-    passes however the rules are ordered.
-    """
-    import tools.dashboard as dash
-
-    links = re.search(r"^\.d-links img\{", dash.DASH_CSS, re.M)
-    figs = re.search(r"^\.d-figs img\{", dash.DASH_CSS, re.M)
-    assert links and figs, "one of the two thumbnail width rules is gone"
-    assert links.start() < figs.start(), "gallery tiles are back to 104px"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1376,3 +1376,27 @@ def test_setup_refuses_rather_than_installing_against_the_wrong_python(tmp_path,
     assert setup_cmd._install_server_proxy(ROOT, assume_yes=True) == 1
     assert not ran, "ran an install with no idea which interpreter to target"
     assert "jupyter" in capsys.readouterr().err.lower()
+
+
+def test_the_gallery_wins_the_thumbnail_width_tie():
+    """REGRESSION. The figure gallery is `class="d-links d-figs"`, so both
+    `.d-links img` and `.d-figs img` match its tiles at specificity (0,1,1) and
+    source order alone decides the width. `.d-figs img` was written *above*
+    `.d-links img`, so every gallery tile rendered at the timeline's 104px inside
+    a 230px-minimum grid — from the file's first commit (3b7e36ec) until this
+    one, silently, because nothing errors and the page still looks deliberate.
+
+    A comment in dash.css says the order is load-bearing; a comment does not
+    survive the next tidy-up of a stylesheet that has no other ordering
+    constraint. This is the only thing that fails if the two rules swap back.
+
+    Matched as `^selector{` rather than by substring: that same comment quotes
+    `.d-links img`, so a plain `.index()` compares the comment's position and
+    passes however the rules are ordered.
+    """
+    import tools.dashboard as dash
+
+    links = re.search(r"^\.d-links img\{", dash.DASH_CSS, re.M)
+    figs = re.search(r"^\.d-figs img\{", dash.DASH_CSS, re.M)
+    assert links and figs, "one of the two thumbnail width rules is gone"
+    assert links.start() < figs.start(), "gallery tiles are back to 104px"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1084,6 +1084,8 @@ def test_the_page_inlines_its_scripts_instead_of_linking_them(tmp_path):
     `test_render_has_no_absolute_urls` does not cover this — a *relative* src
     passes it cleanly.
 
+    `dash.css` is the same bargain in the other tag, so it is checked here too.
+
     Inlining is also what makes the moved prose dangerous in a way it was not
     inside a Python string: a `</script` or a `<!--` in a comment ends the tag
     early and silently truncates the page, so the file bodies are checked for
@@ -1095,10 +1097,15 @@ def test_the_page_inlines_its_scripts_instead_of_linking_them(tmp_path):
     live = dash.render(state, "", live=True)
     snap = dash.render(state, "", live=False)
 
+    css = (ASSET_DIR / "dash.css").read_text(encoding="utf-8")
+    assert "</style" not in css, "dash.css would truncate the page"
     for page in (live, snap):
         # A literal `"<script src="` misses `<script defer src=`; a bare
         # `" src="` would hit the lightbox's real <img>.
         assert not re.search(r"<script[^>]*\ssrc=", page)
+        # The favicon <link> is real and stays; a stylesheet one never is.
+        assert not re.search(r"<link[^>]*stylesheet", page)
+        assert css in page, "dash.css is not inlined verbatim"
     for name in JS_FILES:
         body = (ASSET_DIR / name).read_text(encoding="utf-8")
         assert "</script" not in body and "<!--" not in body, f"{name} would truncate the page"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -309,22 +309,6 @@ def test_plan_approval_states(tmp_path, monkeypatch):
     assert "relayed" in _approval_chip(plan_approval(project, "active"))
 
 
-def test_review_freshness_and_deviation_count(tmp_path):
-    """A review whose footer no longer matches REPORT.md must read `stale` — the
-    single most misleading thing a lifecycle page could get wrong."""
-    project = _project(tmp_path, {"REPORT.md": "# Report\n\nFindings.\n"})
-    digest = hashlib.sha256((project / "REPORT.md").read_bytes()).hexdigest()
-    (project / "REVIEW_1.md").write_text(f"<!-- report_hash: sha256:{digest} -->\n")
-    (project / "REVIEW_2.md").write_text("<!-- report_hash: sha256:dead -->\n")
-
-    chips = {doc.name: doc.chip for doc in review_docs(project)}
-    assert chips == {"REVIEW_1.md": "current", "REVIEW_2.md": "stale"}
-
-    assert count_deviations(project) == 0
-    (project / "plan_deviations.jsonl").write_text('{"path":"a"}\n{"path":"b"}\n\n')
-    assert count_deviations(project) == 2
-
-
 def test_plan_reviews_are_listed_and_chipped_against_the_plan(tmp_path):
     """`glob("REVIEW*.md")` is anchored, so it never matched `PLAN_REVIEW_1.md` —
     the file `/berdl_start`'s plan-review checkpoint option (b) tells the operator
@@ -358,6 +342,13 @@ def test_plan_reviews_are_listed_and_chipped_against_the_plan(tmp_path):
     after = {doc.name: doc.chip for doc in review_docs(project)}
     assert after["PLAN_REVIEW_1.md"] == "current"
     assert after["REVIEW_1.md"] == "stale"
+
+    # The deviation count rides along here: it is the other number § Documents
+    # prints, and no other test in this file is sensitive to it. A blank
+    # trailing line is not a deviation.
+    assert count_deviations(project) == 0
+    (project / "plan_deviations.jsonl").write_text('{"path":"a"}\n{"path":"b"}\n\n')
+    assert count_deviations(project) == 2
 
 
 def test_plan_review_chip_matches_review_sh_not_plan_digest(tmp_path):
@@ -976,32 +967,6 @@ def test_when_a_system_notification_actually_fires(tmp_path):
     )
 
 
-def test_a_hidden_tab_still_polls_only_slower():
-    """The poll used to wrap its `fetch` in `visibilityState==='visible'`, so a
-    backgrounded tab fetched nothing at all — and a backgrounded tab is exactly
-    the one that needs to find out the agent is blocked. Nothing that reaches an
-    unattended reader (the title marker, the favicon dot, a notification) can
-    work on top of a transport that stops when nobody is looking.
-
-    The two assertions are the two halves of that fix, and each fails on the
-    obvious way to undo it:
-
-    - the cadence is chosen by visibility rather than the fetch being skipped;
-    - the only `visibilityState` left is the listener's, i.e. nothing guards the
-      fetch any more.
-
-    The shared `timer` handle is the third: `tick` schedules the next tick *and*
-    the listener calls `tick` directly, so without a `clearTimeout` every return
-    to the tab left another chain running forever. Free when hidden ticks did
-    nothing; a compounding multiplier on real requests now.
-    """
-    import tools.dashboard as dash
-
-    assert "document.hidden ? 15000 : 4000" in dash.POLL_JS
-    assert dash.POLL_JS.count("visibilityState") == 1, "something still gates the fetch"
-    assert "clearTimeout(timer)" in dash.POLL_JS, "tab returns would stack poll chains"
-
-
 ASSET_DIR = ROOT / "tools" / "dashboard_assets"
 JS_FILES = ("rel.js", "state.js", "poll.js", "lightbox.js")
 
@@ -1013,7 +978,8 @@ import vm from 'node:vm';
 
 const DIR = process.argv[2];
 const src = {};
-const out = {parsed: {}, exported: {}, calls: [], threw: null, rescheduled: []};
+const out = {parsed: {}, exported: {}, calls: [], hidden_calls: [], threw: null,
+             rescheduled: [], cleared: 0};
 
 // `new vm.Script` is the parser a classic inline <script> uses. `node --check`
 // is not: on a .js file it falls back to the module goal, so `import`,
@@ -1041,13 +1007,15 @@ const el = () => ({
 const ctx = {
   console,
   document: {
+    // Derived, not a second flag: a guard that reads either one is then caught.
+    get visibilityState() { return this.hidden ? 'hidden' : 'visible'; },
     title: 'demo', hidden: false, getElementById: el,
     querySelectorAll: () => [], addEventListener() {},
   },
   location: {pathname: '/proxy/9000/', replace() {}},
   setInterval: () => 0,
   setTimeout: (f, ms) => { out.rescheduled.push(ms); return 1; },
-  clearTimeout() {},
+  clearTimeout() { out.cleared += 1; },
   CSS: {escape: (s) => s},
   DOMParser: class {
     parseFromString() { return {getElementById: () => ({innerHTML: 'swapped'})}; }
@@ -1066,11 +1034,21 @@ new vm.Script(src['rel.js'] + src['state.js'] + src['poll.js']).runInContext(ctx
 // Both are global bindings a *sibling file* created, so read them before
 // spying — a spy would paper over the binding having gone missing.
 out.exported = {relTimes: typeof ctx.relTimes, dashMark: typeof ctx.dashMark};
-ctx.relTimes = () => out.calls.push('relTimes');
-ctx.dashMark = () => out.calls.push('dashMark');
+let calls = [];
+ctx.relTimes = () => calls.push('relTimes');
+ctx.dashMark = () => calls.push('dashMark');
 out.rescheduled.length = 0;
 try { ctx.tick(); } catch (e) { out.threw = String(e); }
 await new Promise((r) => setTimeout(r, 20));
+out.calls = calls;
+
+// ...then the same tick with the tab backgrounded. It must still fetch and
+// repaint, only on the slower cadence.
+calls = [];
+ctx.document.hidden = true;
+try { ctx.tick(); } catch (e) { out.threw = String(e); }
+await new Promise((r) => setTimeout(r, 20));
+out.hidden_calls = calls;
 console.log(JSON.stringify(out));
 """
 
@@ -1093,6 +1071,19 @@ def test_the_live_scripts_parse_and_share_one_scope(tmp_path):
     Parsing is `vm.Script`, not `node --check`: `--check` on a `.js` file falls
     back to the module goal and accepts `import`, `export` and top-level
     `await`, all of which kill a classic inline `<script>` stone dead.
+
+    The tick is then driven a second time with the tab backgrounded, which pins
+    the poll's other three properties. `poll.js` used to wrap its `fetch` in
+    `visibilityState === 'visible'`, so a backgrounded tab fetched nothing at
+    all — and that is exactly the tab that needs to learn the agent is blocked:
+    the title marker, the favicon dot and any notification are all painted from
+    a response, so none of them can sit on a transport that stops when nobody
+    is looking. So a hidden tick must still repaint (`hidden_calls`), must
+    reschedule at 15s rather than 4s, and must `clearTimeout` first — `tick`
+    schedules the next tick *and* the visibilitychange listener calls `tick`
+    directly, so without that clear every return to the tab left another chain
+    running forever. Free when hidden ticks did nothing; a compounding
+    multiplier on real requests now.
     """
     (tmp_path / "harness.mjs").write_text(SCOPE_HARNESS, encoding="utf-8")
     done = subprocess.run(
@@ -1108,7 +1099,13 @@ def test_the_live_scripts_parse_and_share_one_scope(tmp_path):
     assert result["exported"] == {"relTimes": "function", "dashMark": "function"}
     assert result["threw"] is None, "poll.js lost a sibling's global"
     assert result["calls"] == ["relTimes", "dashMark"], "the swap repainted nothing"
-    assert result["rescheduled"] == [4000], "the poll did not schedule its next tick"
+    assert result["hidden_calls"] == ["relTimes", "dashMark"], (
+        "a backgrounded tab stopped fetching — the one tab that cannot see the page"
+    )
+    assert result["rescheduled"] == [4000, 15000], (
+        "the poll did not schedule its next tick at the visible, then hidden, cadence"
+    )
+    assert result["cleared"] == 2, "tab returns would stack poll chains"
 
 
 def test_the_page_inlines_its_scripts_instead_of_linking_them(tmp_path):

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -263,21 +263,6 @@ def test_the_guard_does_not_skip_a_non_tool_payload(tmp_path):
     )
 
 
-def test_a_write_outside_any_project_records_nothing(tmp_path):
-    """The guard's whole purpose: most writes are not into a project, and paying
-    ~70ms for each would be the cost that made the hook not worth registering."""
-    repo = _repo(tmp_path, {"untouched": None})
-    done = _hook(repo, {
-        "session_id": "sess-elsewhere",
-        "hook_event_name": "PostToolUse",
-        "cwd": str(repo),
-        "tool_name": "Edit",
-        "tool_input": {"file_path": str(repo / "tools" / "dashboard.py")},
-    }, "sess-elsewhere")
-    assert done.returncode == 0, done.stderr
-    assert not (repo / "projects" / "untouched" / "runtime.json").exists()
-
-
 def test_the_statusline_starts_a_dashboard_that_is_not_running(tmp_path):
     """The launcher moved here because skill prose never fired during
     exploration: the earliest copy sat in `/berdl_start` Phase C, after the plan
@@ -421,23 +406,6 @@ def _spawn_dashboard(repo: Path, pid: str):
         [s.executable, str(ROOT / "tools" / "dashboard.py"), str(repo / "projects" / pid)],
         stdout=sp.DEVNULL, stderr=sp.DEVNULL, start_new_session=True,
     )
-
-
-def test_session_end_stops_the_dashboard_for_its_project(tmp_path):
-    """The counterpart to the status line starting it. Without this the server is
-    detached, so it outlives Claude Code and nothing ever stops it."""
-    repo = _repo(tmp_path, {"stopme": ["sess-stop"]})
-    proc = _spawn_dashboard(repo, "stopme")
-    try:
-        assert _wait_until_listening(_port("stopme")), "dashboard did not start"
-
-        done = _stop(repo, {"session_id": "sess-stop", "hook_event_name": "SessionEnd",
-                            "cwd": str(repo), "reason": "other"}, "sess-stop")
-        assert done.returncode == 0, done.stderr      # must never block the exit
-        assert proc.wait(timeout=15) is not None
-    finally:
-        if proc.poll() is None:
-            proc.kill()
 
 
 def test_a_mode_toggle_does_not_stop_the_dashboard(tmp_path):

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -373,14 +373,29 @@ def test_without_the_proxy_it_snapshots_instead_of_respawning_forever(tmp_path, 
 
 def test_it_does_not_spawn_when_no_project_resolves(tmp_path):
     """A display component with a side effect has to stay bounded: no project,
-    no process."""
+    no process.
+
+    Two details, both found by mutating the launcher to spawn unconditionally and
+    watching this test pass anyway:
+
+    - `pgrep -fc <pat>` with no match exits 2 on Darwin 25.5.0 with empty stdout
+      and a usage message on stderr, so the earlier `.stdout.strip() or "0"`
+      compared `"0"` to `"0"` whatever happened. Count `pgrep -f` lines instead.
+    - The pattern has to name *this* tmp repo. A repo-wide one is masked in a
+      full-suite run: `port_for("unbound")` is the same port every time, so a
+      stray from an earlier test holds it, the spawn dies on EADDRINUSE, and the
+      count matches again. Same pattern the rest of this file pkills with.
+    """
     repo = _repo(tmp_path, {"unbound": None})
-    before = subprocess.run(["pgrep", "-fc", "tools/dashboard.py"],
-                            capture_output=True, text=True).stdout.strip() or "0"
+
+    def running() -> int:
+        found = subprocess.run(["pgrep", "-f", f"dashboard.py {repo}/projects"],
+                               capture_output=True, text=True)
+        return len(found.stdout.split())
+
+    before = running()
     assert "unbound" not in _render(repo, session_id="no-such-session")
-    after = subprocess.run(["pgrep", "-fc", "tools/dashboard.py"],
-                           capture_output=True, text=True).stdout.strip() or "0"
-    assert before == after, "spawned a dashboard with no project resolved"
+    assert running() == before, "spawned a dashboard with no project resolved"
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -20,10 +20,40 @@ import subprocess
 import time
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parent.parent
 STATUSLINE = ROOT / ".claude" / "statusline.sh"
 
 ANSI = re.compile(r"\033\[[0-9;]*m")
+
+
+@pytest.fixture(autouse=True)
+def _reap_dashboards(tmp_path):
+    """Kill any dashboard *this* test started, whether it passed or failed.
+
+    `_render` runs the real status line, which starts a dashboard as a side
+    effect for whichever project resolves, and `port_for` derives the port from
+    the *project id* — so a leaked process squats a deterministic port that a
+    later test, or the next run of this file, expects to be free. The launcher
+    then correctly reports "already running" and writes no snapshot, and the
+    failure surfaces somewhere else entirely: `port 8766 already in use`, or
+    `the dashboard was killed on a non-exit reason` accusing dash_stop.py of a
+    bug it did not commit. A stray can also turn a test green for the wrong
+    reason — `_wait_until_listening` is satisfied by the squatter.
+
+    Teardown, not a `finally` in each test, because the case that actually
+    leaks is the one after a *failed* assertion, and three tests had no cleanup
+    at all.
+
+    Scoped to this test's tmp_path and never `dashboard.py` alone: the
+    maintainer runs a real dashboard on this very checkout, whose argv lives
+    under the real repo path and so cannot match. Both spawn paths put tmp_path
+    immediately after `dashboard.py` in argv — the status line's, and
+    `_spawn_dashboard`, which runs the *real* script against a tmp project dir.
+    """
+    yield
+    subprocess.run(["pkill", "-f", f"dashboard.py {tmp_path}"], capture_output=True)
 
 
 def _wait_until_listening(port: int, timeout: float = 10.0) -> bool:
@@ -263,6 +293,54 @@ def test_the_guard_does_not_skip_a_non_tool_payload(tmp_path):
     )
 
 
+def test_the_guard_does_not_start_the_interpreter_for_a_write_outside_a_project(tmp_path):
+    """The other half of the guard — and the only half with an observable effect.
+
+    Its predecessor asserted "a write outside any project records nothing" and
+    could not fail: deleting the guard outright left it green. The guard changes
+    nothing but *cost*. A write outside any project resolves to no project, so
+    nothing is recorded whether or not the interpreter ever started, and the
+    assertion was about the outcome the two paths share.
+
+    So make the interpreter itself observable. The hook prefers
+    `$root/.venv/bin/python` over PATH, and the throwaway tree has no `.venv`,
+    so a shim written there *is* the interpreter the hook will pick; the
+    sentinel it touches is the fact "the interpreter started". No wall clock, so
+    nothing to be flaky about on a loaded machine.
+
+    Direction three — a SessionStart payload carrying no `projects/` string at
+    all — is already pinned by test_the_guard_does_not_skip_a_non_tool_payload
+    above, and is not repeated here.
+    """
+    repo = _repo(tmp_path, {"newproj": None})
+    sentinel = tmp_path / "interpreter-started"
+    shim = repo / ".venv" / "bin" / "python"
+    shim.parent.mkdir(parents=True)
+    # Drains stdin so the hook's `printf | py` never takes SIGPIPE.
+    shim.write_text(f"#!/bin/sh\ncat >/dev/null\ntouch '{sentinel}'\n")
+    shim.chmod(0o755)
+
+    def interpreter_started(file_path: Path) -> bool:
+        sentinel.unlink(missing_ok=True)
+        done = _hook(repo, {
+            "session_id": "s", "hook_event_name": "PostToolUse", "cwd": str(repo),
+            "tool_name": "Write", "tool_input": {"file_path": str(file_path)},
+        }, "s")
+        assert done.returncode == 0, done.stderr
+        return sentinel.exists()
+
+    assert not interpreter_started(repo / "NOTES.md"), (
+        "an ordinary edit outside every project paid for a Python start-up; the "
+        "cost guard is gone and every Write/Edit in the repo now pays it"
+    )
+    assert interpreter_started(repo / "projects" / "newproj" / "beril.yaml"), (
+        "no interpreter for a write *into* a project: either the guard swallowed "
+        "it — the same silent break as skipping a SessionStart payload, nothing "
+        "would ever be bound — or the hook stopped preferring $root/.venv/bin/"
+        "python and never reached the shim"
+    )
+
+
 def test_the_statusline_starts_a_dashboard_that_is_not_running(tmp_path):
     """The launcher moved here because skill prose never fired during
     exploration: the earliest copy sat in `/berdl_start` Phase C, after the plan
@@ -283,17 +361,13 @@ def test_the_statusline_starts_a_dashboard_that_is_not_running(tmp_path):
     first = _render(repo, session_id="sess-spawn")
     assert "dashboard starting" in first             # nothing to advertise yet
 
-    try:
-        assert _wait_until_listening(port), "the statusline did not start a dashboard"
-        # Through `public_url`, not a hardcoded `:<port>/`. That literal is the
-        # off-cluster form only, so this assertion passed in CI and failed on the
-        # hub — the one environment the dashboard exists for.
-        from tools.dashboard import public_url
+    assert _wait_until_listening(port), "the statusline did not start a dashboard"
+    # Through `public_url`, not a hardcoded `:<port>/`. That literal is the
+    # off-cluster form only, so this assertion passed in CI and failed on the
+    # hub — the one environment the dashboard exists for.
+    from tools.dashboard import public_url
 
-        assert public_url(port) in _render(repo, session_id="sess-spawn")
-    finally:
-        subprocess.run(["pkill", "-f", f"dashboard.py {repo}/projects/spawnme"],
-                       capture_output=True)
+    assert public_url(port) in _render(repo, session_id="sess-spawn")
 
 
 def _no_proxy(tmp_path: Path, repo: Path, monkeypatch) -> None:
@@ -369,7 +443,8 @@ def test_it_does_not_spawn_when_no_project_resolves(tmp_path):
     - The pattern has to name *this* tmp repo. A repo-wide one is masked in a
       full-suite run: `port_for("unbound")` is the same port every time, so a
       stray from an earlier test holds it, the spawn dies on EADDRINUSE, and the
-      count matches again. Same pattern the rest of this file pkills with.
+      count matches again. The _reap_dashboards fixture pkills the same way,
+      one path segment broader.
     """
     repo = _repo(tmp_path, {"unbound": None})
 
@@ -455,13 +530,7 @@ def test_switching_projects_resolves_to_the_one_worked_on_most_recently(tmp_path
         _bind(repo, older, "moved", "2026-07-31T10:00:00Z")
         _bind(repo, newer, "moved", "2026-07-31T11:00:00Z")
 
-        try:
-            out = _render(repo, session_id="moved")
-        finally:
-            # _render is the real status line, so resolving a project starts its
-            # dashboard. Left running it holds the port the next test asserts free.
-            subprocess.run(["pkill", "-f", f"dashboard.py {repo}/projects"],
-                           capture_output=True)
+        out = _render(repo, session_id="moved")
         assert newer in out, f"resolved to the stale project, not {newer}"
         assert older not in out
 
@@ -521,19 +590,15 @@ def test_writing_the_pin_marker_switches_the_session_to_that_project(tmp_path):
         root.mkdir()
         repo = _repo(root, {first: None, second: None})
 
-        try:
-            assert not project_line(_render(repo, session_id="sid"))  # nothing bound yet
-            for project in (first, second):                        # pinned back to back
-                done = _hook(repo, {
-                    "session_id": "sid", "hook_event_name": "PostToolUse",
-                    "cwd": str(repo), "tool_name": "Write",
-                    "tool_input": {"file_path": str(repo / "projects" / project / ".beril-pin")},
-                }, "sid")
-                assert done.returncode == 0, done.stderr
-            out = _render(repo, session_id="sid")
-        finally:
-            subprocess.run(["pkill", "-f", f"dashboard.py {repo}/projects"],
-                           capture_output=True)
+        assert not project_line(_render(repo, session_id="sid"))  # nothing bound yet
+        for project in (first, second):                        # pinned back to back
+            done = _hook(repo, {
+                "session_id": "sid", "hook_event_name": "PostToolUse",
+                "cwd": str(repo), "tool_name": "Write",
+                "tool_input": {"file_path": str(repo / "projects" / project / ".beril-pin")},
+            }, "sid")
+            assert done.returncode == 0, done.stderr
+        out = _render(repo, session_id="sid")
 
         line = project_line(out)
         assert second in line, f"pinning {second} did not switch away from {first}"
@@ -561,11 +626,7 @@ def test_two_sessions_pin_different_projects_in_one_clone(tmp_path):
         assert done.returncode == 0, done.stderr
 
     def project_of(session_id: str) -> str:
-        try:
-            out = _render(repo, session_id=session_id)
-        finally:
-            subprocess.run(["pkill", "-f", f"dashboard.py {repo}/projects"],
-                           capture_output=True)
+        out = _render(repo, session_id=session_id)
         return next((l for l in out.splitlines() if l.startswith("  ")), "")
 
     pin("session-A", "metal_cofit")
@@ -629,11 +690,8 @@ def test_a_write_that_merely_cites_another_project_does_not_rebind(tmp_path):
                      "file_path": str(repo / "projects" / "my_work" / "REPORT.md"),
                      "content": "Counts reused from projects/other_proj/data/counts.csv\n",
                  }}, "s")
-    try:
-        line = next((l for l in _render(repo, session_id="s").splitlines()
-                     if l.startswith("  ")), "")
-    finally:
-        subprocess.run(["pkill", "-f", f"dashboard.py {repo}/projects"], capture_output=True)
+    line = next((l for l in _render(repo, session_id="s").splitlines()
+                 if l.startswith("  ")), "")
 
     assert "my_work" in line
     assert "other_proj" not in line, "citing another project switched the session to it"

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -148,7 +148,8 @@ PRUNE_DIRS = {".ipynb_checkpoints", "__pycache__", ".git"}
 MARKDOWN_EXT = {".md", ".markdown"}
 # Where the overlay fetches rendered markdown from. Kept off the project's own
 # namespace by the leading underscore, since every other path this server answers
-# is a real file. LIGHTBOX_JS hardcodes the same prefix without the leading slash.
+# is a real file. tools/dashboard_assets/lightbox.js hardcodes the same prefix
+# without the leading slash.
 DOC_ROUTE = "/_doc/"
 # Types with a real Lab viewer: Notebook, the DataGrid CSV/TSV viewers, and the
 # collapsible JSON tree. `.parquet` is deliberately absent — see open_url.
@@ -981,184 +982,34 @@ border-left:3px solid var(--d-line);}
 .lightbox-doc .doc-error{color:var(--d-bad);}
 """
 
-# The page ships in two halves because it has two transports and only one of
-# them can poll.
-#
-# REL_JS always runs. Every timestamp renders client-side from `data-epoch`
-# (see the design doc), so without it the readouts are empty elements — which
-# is why the snapshot gets this half rather than no script at all. It is also
-# what keeps a *stale* snapshot honest: `relTimes` measures age against the
-# reader's clock, not the render time, so an abandoned snapshot visibly ages
-# green -> amber -> grey instead of freezing on a green dot.
-REL_JS = """
-var R=document.getElementById('root'),tag=null;
-function rel(s){var d=Math.max(0,Date.now()/1000-s);
-if(d<60)return Math.floor(d)+'s ago';if(d<3600)return Math.floor(d/60)+'m ago';
-if(d<86400)return Math.floor(d/3600)+'h ago';return Math.floor(d/86400)+'d ago';}
-function since(s){var d=Math.max(0,Date.now()/1000-s);
-if(d<3600)return Math.floor(d/60)+'m';if(d<86400)return Math.floor(d/3600)+'h '+
-Math.floor((d%3600)/60)+'m';return Math.floor(d/86400)+'d';}
-function relTimes(){
-var n=document.querySelectorAll('[data-epoch]');
-for(var i=0;i<n.length;i++){var el=n[i],s=parseFloat(el.dataset.epoch);
-if(!s){el.textContent='--';continue;}
-var age=Date.now()/1000-s;
-el.textContent=(el.dataset.mode==='since')?since(s):rel(s);
-if(el.dataset.mode!=='since')
-el.className=age<600?'live':(age<3600?'idle':'cold');}}
-setInterval(relTimes,15000);relTimes();
-"""
+_ASSET_DIR = Path(__file__).resolve().parent / "dashboard_assets"
 
-# Everything about "the agent needs you" that cannot be server-rendered, for the
-# same reason relative times cannot be: a 304 freezes whatever the server wrote,
-# and this is the one readout whose whole job is to be current. The server emits
-# `#d-state` inside #root carrying `data-state` and `data-since`; `mark()` reads
-# them after every swap and drives four things off them.
-#
-# Two channels reach a reader who is not looking at the page — the title marker
-# and the favicon — and they are the only two a browser gives a foreground tab.
-# A closed tab gets nothing without a service worker and a push service, which a
-# stdlib server inside a pod cannot be.
-#
-# `#d-detail` is agent-authored text, so it is *not* interpolated here. The
-# server renders it through the same `inline_md` -> `e()` path as the worklog and
-# this copies the resulting node's HTML verbatim; the escaping decision stays in
-# one place, in Python, where it is tested. The notification body takes
-# `textContent` instead, since it is not markup at all.
-#
-# The `(state, since)` pair is the debounce key. Without it every 4s re-render is
-# a fresh transition: the strip would re-pulse and the OS notification would
-# re-fire for one permission prompt, which is how a notification gets muted.
-STATE_JS = """
-(function(){
-var W=document.getElementById('d-wait'),B=document.getElementById('d-alert'),
-F=document.getElementById('d-favicon'),BASE=document.title,last=null,
-hiddenAt=document.hidden?Date.now():0;
-var MARK={waiting:'\\u25cf ',turn_ended:'\\u2713 '};
-function icon(c){return 'data:image/svg+xml,'+encodeURIComponent(
-'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'+
-'<circle cx="8" cy="8" r="7" fill="'+c+'"/></svg>');}
-var ICON={waiting:icon('#d29922'),turn_ended:icon('#3fb950'),'':icon('#30363d')};
-document.addEventListener('visibilitychange',function(){
-hiddenAt=document.hidden?Date.now():0;});
-function alertable(s){
-// Stop fires at the end of *every* turn. Notifying on each one gets the whole
-// feature muted inside a day, so it only speaks when the reader has actually
-// been away — the case where they cannot already see it happen.
-if(s==='waiting')return true;
-return s==='turn_ended'&&hiddenAt>0&&Date.now()-hiddenAt>60000;}
-function notify(s,body){
-if(!('Notification' in window)||Notification.permission!=='granted')return;
-if(!alertable(s))return;
-try{new Notification(BASE,{body:body,tag:'beril-'+BASE});}catch(err){}}
-function mark(){
-var c=document.getElementById('d-state'),d=document.getElementById('d-detail'),
-s=c?(c.dataset.state||''):'',key=s+'|'+(c?c.dataset.since:'');
-document.title=(MARK[s]||'')+BASE;
-if(F)F.href=ICON[s]||ICON[''];
-if(B)B.hidden=!('Notification' in window)||Notification.permission!=='default';
-if(key===last)return;
-if(s==='waiting'&&W){
-W.innerHTML='<b>The agent is waiting for you.</b> '+(d?d.innerHTML:'');
-W.hidden=false;
-W.classList.remove('pulse');void W.offsetWidth;W.classList.add('pulse');}
-else if(W){W.hidden=true;W.innerHTML='';}
-if(last!==null)notify(s,d?d.textContent:'');
-last=key;}
-if(B)B.addEventListener('click',function(){
-Notification.requestPermission().then(function(){B.hidden=true;});});
-window.dashMark=mark;mark();})();
-"""
 
-# POLL_JS is emitted **only in live mode**, and both of its outer statements are
-# why: the trailing-slash redirect and the `fetch` are each actively wrong on a
-# snapshot.
-#
-# - The redirect exists so relative asset URLs resolve under `/proxy/<port>`.
-#   A snapshot is served at `<prefix>files/<rel>/dashboard.html`, which does not
-#   end in `/`, so this line would navigate the page to `dashboard.html/` — a
-#   Jupyter 404. The page would destroy itself on load.
-# - `files/` responses carry `Content-Security-Policy: sandbox allow-scripts`
-#   with no `allow-same-origin` (measured against the live server), so the
-#   document has an opaque origin and `fetch` cannot send the hub cookie. The
-#   poll could only ever fail, silently, forever.
-#
-# **A hidden tab still fetches**, at 15s instead of 4s. It used to skip the
-# fetch entirely, which is cheaper and wrong: a backgrounded tab is exactly the
-# tab that needs to learn the agent is blocked on a permission prompt, and one
-# that never fetches can never learn anything — it has only the title and the
-# favicon to speak through, and both are painted from the response. The cost is
-# small enough to check rather than argue about: a 304 still runs a full
-# `scan()` at 6.8ms measured, so 15s hidden is ~1.6s of CPU per hour per tab,
-# less than a *visible* tab costs today.
-#
-# The single `timer` handle is not decoration. `tick` schedules the next tick,
-# and the visibilitychange listener calls `tick` directly, so every return to
-# the tab used to start a second concurrent chain that never ended — harmless
-# while hidden ticks were free, a compounding multiplier on real requests now.
-POLL_JS = """
-if(!location.pathname.endsWith('/'))location.replace(location.pathname+'/');
-var timer=0;
-function tick(){
-var h=tag?{'If-None-Match':tag}:{};
-fetch('.',{headers:h}).then(function(r){
-if(r.status!==200)return null;tag=r.headers.get('ETag');return r.text();})
-.then(function(t){if(!t)return;
-var open=[],ds=R.querySelectorAll('details[open]');
-for(var i=0;i<ds.length;i++)if(ds[i].id)open.push(ds[i].id);
-var doc=new DOMParser().parseFromString(t,'text/html');
-var next=doc.getElementById('root');if(!next)return;
-R.innerHTML=next.innerHTML;
-for(var j=0;j<open.length;j++){var d=R.querySelector('#'+CSS.escape(open[j]));
-if(d)d.open=true;}
-relTimes();dashMark();}).catch(function(){});
-clearTimeout(timer);timer=setTimeout(tick,document.hidden?15000:4000);}
-document.addEventListener('visibilitychange',function(){
-if(document.visibilityState==='visible')tick();});
-timer=setTimeout(tick,4000);
-"""
+def _asset(name: str) -> str:
+    """Read one of the sibling scripts in ``tools/dashboard_assets/``.
 
-# The overlay is a sibling of #root, and every listener is delegated on document,
-# so a trigger stays clickable after the 4s poll swaps #root's innerHTML — the
-# trigger elements are replaced, but the handler and the overlay are not.
-#
-# Two modes share one overlay: an <img> for figures, and a scrollable panel for
-# markdown fetched from `/_doc/`. Sharing it means Esc, the backdrop and the ×
-# have exactly one implementation. An <iframe> was the obvious alternative for the
-# document mode and was rejected: keystrokes inside an iframe never reach the
-# parent document, so Esc would silently stop closing the popup.
-LIGHTBOX_JS = """
-(function(){var L=document.getElementById('lightbox');if(!L)return;
-var I=L.querySelector('img'),D=L.querySelector('.lightbox-doc'),seq=0;
-function close(){L.classList.remove('active','mode-doc');}
-function near(t,sel){return t&&t.closest?t.closest(sel):null;}
-function note(cls,msg){D.innerHTML='<p class="'+cls+'"></p>';
-D.firstChild.textContent=msg;}
-document.addEventListener('click',function(e){
-var fig=near(e.target,'.lightbox-trigger');
-if(fig){I.src=fig.getAttribute('src');I.alt=fig.getAttribute('alt')||'';
-L.classList.remove('mode-doc');L.classList.add('active');return;}
-var doc=near(e.target,'.doc-trigger');
-if(doc&&e.button===0&&!e.metaKey&&!e.ctrlKey&&!e.shiftKey&&!e.altKey){
-e.preventDefault();
-var path=doc.getAttribute('data-doc'),n=++seq;
-note('d-empty','loading\\u2026');
-L.classList.add('active','mode-doc');D.scrollTop=0;
-fetch('_doc/'+path.split('/').map(encodeURIComponent).join('/'))
-.then(function(r){return r.ok?r.text():r.status;})
-.then(function(v){if(n!==seq)return;
-if(typeof v==='number'){note('doc-error','could not render '+path+' ('+v+')');return;}
-D.innerHTML=v;D.scrollTop=0;})
-.catch(function(){if(n!==seq)return;
-// fetch rejected outright: nothing is serving this page, which is what a
-// written-out dashboard.html opened from disk looks like. Follow the real
-// href instead of leaving an empty overlay open.
-close();location.href=doc.getAttribute('href');});
-return;}
-if(e.target===L||near(e.target,'.lightbox-close'))close();});
-document.addEventListener('keydown',function(e){
-if(e.key==='Escape'||e.key==='Esc')close();});})();
-"""
+    Same trick as ``load_css``: the page is one self-contained HTML file, so
+    every asset is inlined rather than linked. A ``<script src=>`` would
+    resolve against the *project* directory in live mode and against whatever
+    directory the snapshot was written into otherwise — a 404 in both.
+
+    Unlike ``load_css`` this does **not** swallow the error. A missing
+    stylesheet is an unstyled but readable page; a missing script is a dead
+    one — rel.js alone leaves every ``[data-epoch]`` blank and lets a stale
+    page keep looking fresh. And unlike ``ui/app/static/``, which this module
+    is only a guest in, this directory is part of the module, so a missing
+    file means a broken checkout and should say so at import.
+    """
+    return (_ASSET_DIR / name).read_text(encoding="utf-8")
+
+
+# Rationale for each of these lives in the file itself, next to the code it
+# explains. All four are inlined verbatim by ``render``; rel.js, state.js and
+# poll.js share one ``<script>`` and therefore one scope — see poll.js's header.
+REL_JS = _asset("rel.js")  # always emitted; defines R, tag, rel, since, relTimes
+STATE_JS = _asset("state.js")  # always emitted; exports window.dashMark
+POLL_JS = _asset("poll.js")  # live mode only; reads rel.js's and state.js's globals
+LIGHTBOX_JS = _asset("lightbox.js")  # always emitted; self-contained IIFE
 
 
 _MD_CODE_RE = re.compile(r"`([^`\n]+)`")
@@ -1701,8 +1552,13 @@ def render(state: State, css: str, live: bool = True) -> str:
         # favicon, and a snapshot written while a prompt was open should still
         # say so. Only its notification half is dead there, and it is dead by
         # construction — no button, so no permission, so nothing fires.
-        f"<script>{REL_JS}{STATE_JS}{POLL_JS if live else ''}</script>\n"
-        f"<script>{LIGHTBOX_JS}</script>\n</body>\n</html>\n"
+        # The newline after each `<script>` is cosmetic — it keeps the emitted
+        # source readable now that every file opens with a `//` comment. The
+        # trailing newline on each *file* is not: the three in the first tag are
+        # concatenated raw, so a file ending in a comment would swallow the next
+        # file's first line. Pinned by test_the_page_inlines_its_scripts_*.
+        f"<script>\n{REL_JS}{STATE_JS}{POLL_JS if live else ''}</script>\n"
+        f"<script>\n{LIGHTBOX_JS}</script>\n</body>\n</html>\n"
     )
 
 

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -808,200 +808,31 @@ def scan(project: Path) -> State:
 # Render
 # ---------------------------------------------------------------------------
 
-DASH_CSS = """
-:root{--d-bg:#12141a;--d-panel:#171a21;--d-card:#1b1f28;--d-line:#262a35;
---d-fg:#e6e8ee;--d-mut:#8b93a7;--d-dim:#5c6478;--d-accent:#58a6ff;--d-ok:#3fb950;
---d-warn:#d29922;--d-bad:#ff7b72;}
-body{background:var(--d-bg);color:var(--d-fg);margin:0;
-font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
-#root{max-width:1100px;margin:0 auto;padding:0 20px 60px;}
-/* Sticky, so it must stay short — everything inside is either one line or
-   clamped. A shadow rather than a hairline: content genuinely passes beneath
-   it, and the border alone read as a seam cutting through the text. */
-.d-hd{position:sticky;top:0;z-index:9;background:var(--d-panel);
-border-bottom:1px solid var(--d-line);margin:0 -20px 24px;padding:12px 20px 14px;
-box-shadow:0 8px 20px -12px #000c;}
-/* Anchors and scrolled-to elements must clear the sticky region. */
-#root [id]{scroll-margin-top:180px;}
-.d-id{font-family:ui-monospace,SFMono-Regular,monospace;font-weight:650;}
-.d-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap;}
-.d-chip{display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;
-font-weight:600;border:1px solid var(--d-line);background:var(--d-card);color:var(--d-mut);}
-.d-chip.ok{color:#7ee787;border-color:#238636aa;background:#23863626;}
-.d-chip.bad{color:var(--d-bad);border-color:#ff7b7255;background:#ff7b7218;}
-.d-chip.warn{color:#e3b341;border-color:#d2992255;background:#d2992218;}
-.d-chip.now{color:#79b8ff;border-color:#1f6feb66;background:#1f6feb26;}
-.live{color:var(--d-ok);}.idle{color:var(--d-warn);}.cold{color:var(--d-dim);}
-.d-rail{display:flex;list-style:none;margin:12px 0 4px;padding:0;}
-.d-rail li{flex:1;text-align:center;font-size:11px;position:relative;color:var(--d-dim);}
-.d-rail li i{display:block;width:10px;height:10px;border-radius:50%;
-margin:0 auto 6px;background:#2b3040;}
-.d-rail li[data-state=done]{color:#7ee787;}.d-rail li[data-state=done] i{background:var(--d-ok);}
-.d-rail li[data-state=current]{color:#79b8ff;font-weight:700;}
-.d-rail li[data-state=current] i{background:var(--d-accent);box-shadow:0 0 0 4px #58a6ff2e;}
-.d-rail li[data-state=future]{opacity:.32;}
-.d-rail li:not(:last-child):after{content:'';position:absolute;top:4px;
-left:calc(50% + 11px);right:calc(-50% + 11px);height:1px;background:#2b3040;}
-/* Inline readouts. Tabular figures matter here: the page repaints every 4s and
-   proportional digits make the elapsed clock jitter sideways as they change. */
-.d-read{display:flex;flex-direction:column;align-items:flex-end;line-height:1.15;}
-.d-read.push{margin-left:auto;}
-/* No `color` here on purpose: relTimes() sets .live/.idle/.cold on this element
-   and a `.d-read b` rule would outrank them, silencing the liveness signal. */
-.d-read b{font:600 13px/1.15 ui-monospace,SFMono-Regular,monospace;
-font-variant-numeric:tabular-nums;}
-.d-read i{font-style:normal;font-size:9px;text-transform:uppercase;
-letter-spacing:.08em;color:var(--d-dim);}
-/* The dot inherits currentColor, so it turns amber then grey with the number —
-   one glance answers "is the agent alive". Only on the activity readout. */
-.d-read.push b::before{content:'';display:inline-block;width:6px;height:6px;
-border-radius:50%;background:currentColor;margin-right:6px;vertical-align:.1em;}
-.d-eyebrow{display:block;font-size:9px;text-transform:uppercase;
-letter-spacing:.1em;color:var(--d-dim);margin-bottom:3px;}
-.d-now{border-left:2px solid var(--d-accent);background:#161b24;padding:8px 14px;
-margin-top:12px;border-radius:0 6px 6px 0;}
-.d-now b{font-size:14px;}
-/* Snapshot mode only, and loud on purpose: it is the one thing on this page the
-   reader has to act on, and the instructions it replaces were five lines in a
-   gitignored log file nobody had a reason to open. Above #root's header rather
-   than inside it — the header is sticky and must stay short. */
-.d-setup{border-left:2px solid var(--d-warn);background:#221c10;padding:10px 14px;
-margin:0 0 18px;border-radius:0 6px 6px 0;font-size:13.5px;color:#c4cad8;}
-.d-setup b{color:#e3b341;}
-.d-setup ol{margin:8px 0 0;padding-left:20px;}
-.d-setup li{margin:4px 0;}
-.d-setup code{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12.5px;
-background:#0d1017;border:1px solid var(--d-line);border-radius:4px;padding:1px 6px;}
-/* "The agent is blocked on you." Same anchoring as .d-setup and for the same
-   reason — a sibling of #root, so the 4s poll cannot wipe it — but with a
-   second reason on top: an element inside #root is destroyed and rebuilt every
-   4s, which would restart the pulse below on every poll. A 0.6s highlight every
-   4s, forever, is a flashing banner: WCAG 2.3.1, and unbearable to sit next to.
-   Out here it animates once, on the transition that earned it.
-   Filled by STATE_JS, which is why it starts empty and hidden. */
-.d-wait{border-left:2px solid var(--d-warn);background:#2a1f0c;padding:9px 14px;
-margin:0 0 14px;border-radius:0 6px 6px 0;font-size:13.5px;color:#e8dcc0;}
-.d-wait b{color:#e3b341;}
-.d-wait code{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12.5px;
-background:#0d1017;border:1px solid var(--d-line);border-radius:4px;padding:1px 6px;}
-.d-wait.pulse{animation:d-pulse .6s ease-out 1;}
-@keyframes d-pulse{from{background:#5a3f10;}to{background:#2a1f0c;}}
-/* No sustained flashing anywhere, and none at all for a reader who has asked
-   the OS not to move things. The strip still appears; it just appears. */
-@media (prefers-reduced-motion:reduce){.d-wait.pulse{animation:none;}}
-/* Hidden until the browser can actually act on it: requestPermission needs a
-   user gesture, so there has to be something to click, but once the reader has
-   answered — either way — the button is noise and STATE_JS removes it. */
-.d-alert{background:var(--d-card);color:var(--d-mut);border:1px solid var(--d-line);
-border-radius:10px;font:600 11px/1.6 inherit;padding:1px 10px;margin:0 0 14px;
-cursor:pointer;}
-.d-alert:hover{color:var(--d-fg);border-color:var(--d-accent);}
-/* Two lines, then fade. The full text is the first timeline entry. */
-.d-clamp{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;
-overflow:hidden;margin:3px 0 0;color:#c4cad8;font-size:13.5px;max-width:none;}
-/* The contract the worklog below is measured against, so it gets the accent
-   rather than the neutral card outline every other block uses — it is not just
-   another card. */
-.d-plan{border-left:2px solid var(--d-accent);background:linear-gradient(
-90deg,#58a6ff0d,transparent 60%);padding:10px 0 12px 16px;margin:26px 0 4px;
-border-radius:0 6px 6px 0;}
-.d-plan .d-eyebrow{margin-top:12px;color:var(--d-mut);}
-.d-plan .d-eyebrow:first-child{margin-top:0;}
-.d-clamp2{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;
-overflow:hidden;margin:2px 0 0;max-width:78ch;color:#c9cfdd;}
-.d-clamp3{display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;
-overflow:hidden;margin:2px 0 0;max-width:78ch;color:#c9cfdd;}
-.d-sec{font-size:11px;text-transform:uppercase;letter-spacing:.09em;color:var(--d-mut);
-margin:30px 0 12px;padding-bottom:6px;border-bottom:1px solid var(--d-line);}
-.d-tl{position:relative;padding-left:22px;}
-.d-tl:before{content:'';position:absolute;left:4px;top:6px;bottom:4px;width:1px;
-background:#2b3040;}
-.d-ev{position:relative;margin-bottom:18px;}
-.d-ev:before{content:'';position:absolute;left:-22px;top:6px;width:8px;height:8px;
-border-radius:50%;border:1.5px solid #4a5265;background:var(--d-bg);}
-.d-ev.big:before{left:-24px;top:4px;width:12px;height:12px;border:none;
-background:var(--d-accent);}
-/* Corrections: amber ring and an amber rule down the entry, so a scan of the
-   timeline finds the moments the project changed direction. */
-.d-ev.fix:before{background:var(--d-warn);border-color:var(--d-warn);}
-.d-ev.fix{border-left:2px solid #d2992255;margin-left:-14px;padding-left:12px;}
-.d-ev p{max-width:68ch;margin:4px 0;color:#c4cad8;}
-.d-links{display:flex;gap:7px;flex-wrap:wrap;align-items:center;margin-top:6px;}
-/* The gallery earns real size; the 104px inline thumbs in the timeline do not.
-   Same white plate, since matplotlib output is white and should read as
-   intentional rather than as a hole punched in a dark page. */
-.d-figs{display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));
-gap:12px;margin-top:0;}
-.d-figs img{width:100%;padding:6px;box-sizing:border-box;
-transition:border-color .15s ease,transform .15s ease;}
-.d-figs img:hover{border-color:var(--d-accent);transform:translateY(-2px);}
-.d-links img{width:104px;height:auto;background:#ffffffeb;border-radius:4px;
-border:1px solid var(--d-line);display:block;}
-.d-grid{display:grid;gap:10px;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));}
-.d-card{background:var(--d-card);border:1px solid var(--d-line);border-radius:6px;
-padding:9px 12px;font-size:13px;}
-.d-empty{color:var(--d-dim);font-style:italic;}
-a{color:#79b8ff;}
-table{border-collapse:collapse;font-size:13px;width:100%;}
-td,th{border-bottom:1px solid var(--d-line);padding:5px 8px;text-align:left;}
-.doc-trigger{cursor:pointer;}
-/* Document mode for the shared overlay. main.css centres a bare <img>; a report
-   instead needs a bounded, scrollable panel, so the two modes are switched by a
-   class on the overlay rather than given separate overlays — one close path. */
-.lightbox-doc{display:none;}
-/* Child combinator, not descendant. The overlay's own figure <img> is a direct
-   child of #lightbox; every image inside a rendered document is nested in
-   .lightbox-doc. A descendant selector here hid the figures embedded in
-   REPORT.md — which are the whole point of inlining them next to each finding. */
-.lightbox-overlay.mode-doc>img{display:none;}
-.lightbox-overlay.mode-doc .lightbox-doc{display:block;text-align:left;
-background:var(--d-panel);border:1px solid var(--d-line);border-radius:8px;
-width:min(880px,calc(100vw - 56px));max-height:calc(100vh - 96px);
-overflow-y:auto;overscroll-behavior:contain;padding:24px 32px;}
-.lightbox-doc>:first-child{margin-top:0;}
-.lightbox-doc h1{font-size:1.5rem;}.lightbox-doc h2{font-size:1.22rem;}
-.lightbox-doc h3{font-size:1.05rem;}.lightbox-doc h4{font-size:.95rem;}
-.lightbox-doc h1,.lightbox-doc h2{border-bottom:1px solid var(--d-line);
-padding-bottom:6px;}
-.lightbox-doc h1,.lightbox-doc h2,.lightbox-doc h3,.lightbox-doc h4{
-margin:26px 0 10px;line-height:1.3;}
-.lightbox-doc p,.lightbox-doc li{color:#c9cfdd;}
-.lightbox-doc li{margin:3px 0;}
-.lightbox-doc code{background:#0f1117;border:1px solid var(--d-line);
-border-radius:4px;padding:1px 5px;font-size:.88em;
-font-family:ui-monospace,SFMono-Regular,monospace;}
-.lightbox-doc pre{background:#0f1117;border:1px solid var(--d-line);
-border-radius:6px;padding:12px 14px;overflow-x:auto;}
-.lightbox-doc pre code{background:none;border:none;padding:0;}
-.lightbox-doc blockquote{margin:12px 0;padding:2px 14px;color:var(--d-mut);
-border-left:3px solid var(--d-line);}
-.lightbox-doc table{display:block;overflow-x:auto;white-space:nowrap;}
-.lightbox-doc th{color:var(--d-fg);font-weight:650;}
-.lightbox-doc img{max-width:100%;height:auto;}
-.lightbox-doc hr{border:none;border-top:1px solid var(--d-line);margin:20px 0;}
-.lightbox-doc .doc-error{color:var(--d-bad);}
-"""
-
 _ASSET_DIR = Path(__file__).resolve().parent / "dashboard_assets"
 
 
 def _asset(name: str) -> str:
-    """Read one of the sibling scripts in ``tools/dashboard_assets/``.
+    """Read one of the sibling assets in ``tools/dashboard_assets/``.
 
     Same trick as ``load_css``: the page is one self-contained HTML file, so
     every asset is inlined rather than linked. A ``<script src=>`` would
     resolve against the *project* directory in live mode and against whatever
     directory the snapshot was written into otherwise — a 404 in both.
 
-    Unlike ``load_css`` this does **not** swallow the error. A missing
-    stylesheet is an unstyled but readable page; a missing script is a dead
-    one — rel.js alone leaves every ``[data-epoch]`` blank and lets a stale
-    page keep looking fresh. And unlike ``ui/app/static/``, which this module
-    is only a guest in, this directory is part of the module, so a missing
-    file means a broken checkout and should say so at import.
+    Unlike ``load_css`` this does **not** swallow the error — including for
+    dash.css, whose absence really would leave the page unstyled but readable.
+    The realistic failure is the whole directory not shipping, and that is not
+    survivable: a missing rel.js leaves every ``[data-epoch]`` blank and lets a
+    stale page keep looking fresh, with no error anyone will see. And unlike
+    ``ui/app/static/``, which this module is only a guest in, this directory is
+    part of the module — a missing file means a broken checkout, so say so.
     """
     return (_ASSET_DIR / name).read_text(encoding="utf-8")
 
+
+# Emitted after ``load_css``'s main.css inside the one <style>; dash.css's own
+# header says why that order matters.
+DASH_CSS = _asset("dash.css")
 
 # Rationale for each of these lives in the file itself, next to the code it
 # explains. All four are inlined verbatim by ``render``; rel.js, state.js and

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -49,13 +49,12 @@ pidfile to go stale and no stop command to misfire on a recycled PID.
 
 from __future__ import annotations
 
-import argparse
+import errno
 import hashlib
 import html as _html
 import json
 import os
 import re
-import shutil
 import site
 import sys
 import time
@@ -65,6 +64,11 @@ from pathlib import Path
 from urllib.parse import quote
 
 HUB = "https://hub.berdl.kbase.us"
+
+# Resolved once. Three places used to re-derive one of these with a fresh
+# `Path(__file__).resolve()`, one of them on the per-request path.
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent
 
 STAGES = ["exploration", "proposed", "active", "analysis", "reviewed", "complete"]
 
@@ -183,7 +187,7 @@ _LINK_RE = re.compile(r"^→ \[([^\]]*)\]\(([^)]*)\)(?:\s*[×x](\d+))?\s*$")
 class Doc:
     name: str
     path: str
-    chip: "str | None" = None
+    chip: str | None = None
 
 
 @dataclass
@@ -198,7 +202,7 @@ class Link:
 class Entry:
     date: str
     title: str
-    new_status: "str | None"
+    new_status: str | None
     prose: str = ""
     links: list = field(default_factory=list)
     correction: bool = False
@@ -250,7 +254,7 @@ class JupyterRoutes:
         joined = f"{self.rel}/{path.lstrip('/')}" if self.rel else path.lstrip("/")
         return "/".join(quote(seg, safe="") for seg in joined.split("/"))
 
-    def open_url(self, path: str) -> "str | None":
+    def open_url(self, path: str) -> str | None:
         """The URL that opens ``path`` in a viewer that actually renders it, or
         ``None`` when Jupyter has no such viewer and the caller should keep the
         plain relative link.
@@ -299,7 +303,7 @@ class State:
     last_activity: float
     first_activity: float
     etag: str
-    routes: "JupyterRoutes | None"
+    routes: JupyterRoutes | None
     plan: dict = field(default_factory=dict)
     agent: dict = field(default_factory=dict)
 
@@ -309,7 +313,7 @@ class State:
 # ---------------------------------------------------------------------------
 
 
-def read_status(project: Path) -> tuple:
+def read_status(project: Path) -> tuple[str | None, bool]:
     """Return ``(status, has_approval_block)`` from ``beril.yaml``.
 
     One key is not a parsing problem, and PyYAML is not worth a runtime
@@ -408,7 +412,7 @@ def _infer_stage(project: Path) -> str:
     return "exploration"
 
 
-def resolve_stage(project: Path) -> tuple:
+def resolve_stage(project: Path) -> tuple[str, bool]:
     """Return ``(stage, inferred)``. ``inferred`` drives the honesty label."""
     status, has_approval = read_status(project)
     if has_approval:
@@ -510,8 +514,7 @@ def _planning_workflow_installed() -> bool:
     Without ``plan-gate.py`` there is no such thing as an unapproved plan, so
     accusing a project of missing an approval would be a false alarm.
     """
-    root = Path(__file__).resolve().parent.parent
-    return (root / ".claude" / "hooks" / "plan-gate.py").is_file()
+    return (_REPO_ROOT / ".claude" / "hooks" / "plan-gate.py").is_file()
 
 
 def _accusable(project: Path, stage: str) -> bool:
@@ -591,7 +594,7 @@ def count_deviations(project: Path) -> int:
     return sum(1 for line in text.splitlines() if line.strip())
 
 
-def review_docs(project: Path) -> list:
+def review_docs(project: Path) -> list[Doc]:
     """Every review file with a freshness chip against the thing it reviewed.
 
     Without this the page shows "reviewed" for a review that no longer applies —
@@ -650,7 +653,7 @@ def review_docs(project: Path) -> list:
 # ---------------------------------------------------------------------------
 
 
-def parse_worklog(text: str, project: Path) -> list:
+def parse_worklog(text: str, project: Path) -> list[Entry]:
     """Parse ``WORKLOG.md`` in file order (oldest first; the renderer reverses).
 
     Anything that is neither a heading nor a link line is prose.
@@ -694,7 +697,7 @@ def parse_worklog(text: str, project: Path) -> list:
 # ---------------------------------------------------------------------------
 
 
-def notebook_stats(path: Path) -> "Notebook | None":
+def notebook_stats(path: Path) -> Notebook | None:
     """Cell counts from raw JSON — no nbformat, no nbconvert.
 
     Returns ``None`` when unreadable. A partial read while the agent is writing
@@ -718,7 +721,7 @@ def notebook_stats(path: Path) -> "Notebook | None":
     )
 
 
-def _files(directory: Path, extensions: set, prefix: str) -> list:
+def _files(directory: Path, extensions: set[str], prefix: str) -> list[FileRef]:
     refs = []
     if not directory.is_dir():
         return refs
@@ -731,11 +734,45 @@ def _files(directory: Path, extensions: set, prefix: str) -> list:
     return refs
 
 
-def compute_etag(fingerprint: list) -> str:
+def compute_etag(items: list) -> str:
     digest = hashlib.sha1()
-    for item in sorted(fingerprint):
+    for item in sorted(items):
         digest.update(repr(item).encode("utf-8"))
     return digest.hexdigest()[:16]
+
+
+def fingerprint(project: Path) -> tuple[str, list[float], dict]:
+    """``(etag, mtimes, agent state)`` — everything the etag is derived from, and
+    nothing else.
+
+    Split out of ``scan`` because it is the *only* input to the etag, and the
+    etag is the only thing a 304 needs: the poll makes 304 the overwhelmingly
+    common response, and answering one used to cost a whole ``scan`` — every
+    notebook JSON parsed, the plan regexed, the review files hashed — all of it
+    discarded. Measured on the three largest projects on disk: 0.25-0.84ms here
+    against ``scan``'s 3.6-16.3ms.
+    """
+    stamps: list[float] = []
+    items: list = []
+    for root, dirs, names in os.walk(project):
+        dirs[:] = [d for d in dirs if d not in PRUNE_DIRS]
+        for name in names:
+            try:
+                stat = os.stat(os.path.join(root, name))
+            except OSError:
+                continue
+            stamps.append(stat.st_mtime)
+            items.append((os.path.join(root, name), stat.st_mtime_ns, stat.st_size))
+
+    # The agent state goes into the etag as its *resolved* value, as well as the
+    # file's own mtime — the two disagree exactly when it matters. Nothing on
+    # disk changes when a `waiting` ages past WAIT_TTL, so an mtime-only etag
+    # keeps answering 304 and the page holds "waiting for you" on screen forever
+    # while `read_agent_state` has long since stopped believing it. Folding the
+    # answer in means the expiry itself invalidates the cache.
+    agent = read_agent_state(project)
+    items.append(("\x00agent-state", agent.get("state", ""), agent.get("since", 0)))
+    return compute_etag(items), stamps, agent
 
 
 def scan(project: Path) -> State:
@@ -761,28 +798,7 @@ def scan(project: Path) -> State:
     except OSError:
         worklog = ""
 
-    stamps: list = []
-    fingerprint: list = []
-    for root, dirs, names in os.walk(project):
-        dirs[:] = [d for d in dirs if d not in PRUNE_DIRS]
-        for name in names:
-            try:
-                stat = os.stat(os.path.join(root, name))
-            except OSError:
-                continue
-            stamps.append(stat.st_mtime)
-            fingerprint.append(
-                (os.path.join(root, name), stat.st_mtime_ns, stat.st_size)
-            )
-
-    # The agent state goes into the fingerprint as its *resolved* value, not as
-    # the file's mtime — the two disagree exactly when it matters. Nothing on
-    # disk changes when a `waiting` ages past WAIT_TTL, so an mtime-only etag
-    # keeps answering 304 and the page holds "waiting for you" on screen forever
-    # while `read_agent_state` has long since stopped believing it. Folding the
-    # answer in means the expiry itself invalidates the cache.
-    agent = read_agent_state(project)
-    fingerprint.append(("\x00agent-state", agent.get("state", ""), agent.get("since", 0)))
+    etag, stamps, agent = fingerprint(project)
 
     return State(
         project_id=project.name,
@@ -797,7 +813,7 @@ def scan(project: Path) -> State:
         data=_files(project / "data", DATA_EXT, "data"),
         last_activity=max(stamps) if stamps else 0.0,
         first_activity=min(stamps) if stamps else 0.0,
-        etag=compute_etag(fingerprint),
+        etag=etag,
         routes=jupyter_routes(project),
         plan=plan_summary(project),
         agent=agent,
@@ -808,7 +824,7 @@ def scan(project: Path) -> State:
 # Render
 # ---------------------------------------------------------------------------
 
-_ASSET_DIR = Path(__file__).resolve().parent / "dashboard_assets"
+_ASSET_DIR = _HERE / "dashboard_assets"
 
 
 def _asset(name: str) -> str:
@@ -837,7 +853,7 @@ DASH_CSS = _asset("dash.css")
 # Rationale for each of these lives in the file itself, next to the code it
 # explains. All four are inlined verbatim by ``render``; rel.js, state.js and
 # poll.js share one ``<script>`` and therefore one scope — see poll.js's header.
-REL_JS = _asset("rel.js")  # always emitted; defines R, tag, rel, since, relTimes
+REL_JS = _asset("rel.js")  # always emitted; defines rootEl, tag, rel, since, relTimes
 STATE_JS = _asset("state.js")  # always emitted; exports window.dashMark
 POLL_JS = _asset("poll.js")  # live mode only; reads rel.js's and state.js's globals
 LIGHTBOX_JS = _asset("lightbox.js")  # always emitted; self-contained IIFE
@@ -871,7 +887,7 @@ def inline_md(value) -> str:
     text = e(value)
     codes: list = []
 
-    def stash(match: "re.Match") -> str:
+    def stash(match: re.Match) -> str:
         codes.append(match.group(1))
         return f"\x00{len(codes) - 1}\x00"
 
@@ -923,12 +939,12 @@ def render_markdown(text: str) -> str:
     return f"<pre>{e(text)}</pre>"
 
 
-def load_css(repo_root: Path) -> str:
+def load_css() -> str:
     """Inline the observatory stylesheet so the in-progress dashboard matches the
     site a project graduates into. It has zero ``url()`` references, so it is
     self-contained. Missing is survivable: unstyled but fully readable."""
     try:
-        return (repo_root / "ui" / "app" / "static" / "css" / "main.css").read_text(
+        return (_REPO_ROOT / "ui" / "app" / "static" / "css" / "main.css").read_text(
             encoding="utf-8"
         )
     except OSError:
@@ -936,11 +952,11 @@ def load_css(repo_root: Path) -> str:
 
 
 def _human(size: int) -> str:
-    for unit in ("B", "KB", "MB", "GB"):
-        if size < 1024 or unit == "GB":
-            return "%d %s" % (size, unit) if unit == "B" else "%.1f %s" % (size, unit)
+    for unit in ("B", "KB", "MB"):
+        if size < 1024:
+            return f"{size} {unit}" if unit == "B" else f"{size:.1f} {unit}"
         size /= 1024.0
-    return str(size)
+    return f"{size:.1f} GB"
 
 
 def _approval_chip(approval: dict) -> str:
@@ -991,7 +1007,7 @@ def _rail(stage: str) -> str:
     return '<ol class="d-rail" aria-live="polite">' + "".join(items) + "</ol>"
 
 
-def _open_href(routes: "JupyterRoutes | None", path: str) -> str:
+def _open_href(routes: JupyterRoutes | None, path: str) -> str:
     """Where a document link points: a Jupyter viewer that renders it when one
     exists and we can reach it, otherwise the relative file the dashboard serves
     itself — today's behaviour, and the only thing that works off-cluster."""
@@ -1025,7 +1041,7 @@ def _doc_trigger(path: str, label: str, css_class: str = "") -> str:
     return f'<a class="{cls}" href="{e(path)}" data-doc="{e(path)}">{label}</a>'
 
 
-def _link_html(link: Link, routes: "JupyterRoutes | None") -> str:
+def _link_html(link: Link, routes: JupyterRoutes | None) -> str:
     label = e(link.label)
     count = f" &#215;{link.count}" if link.count > 1 else ""
     if not link.exists:
@@ -1044,7 +1060,7 @@ def _link_html(link: Link, routes: "JupyterRoutes | None") -> str:
     return f'<a class="d-chip" href="{href}" target="_blank">{label}{count}</a>'
 
 
-def _entry_html(entry: Entry, routes: "JupyterRoutes | None") -> str:
+def _entry_html(entry: Entry, routes: JupyterRoutes | None) -> str:
     big = " big" if entry.new_status else ""
     # Corrections are the only record of why a project was not a straight line,
     # and they used to render identically to "ran notebook 3". Labelled as well
@@ -1070,7 +1086,7 @@ def _entry_html(entry: Entry, routes: "JupyterRoutes | None") -> str:
     )
 
 
-def _notebook_html(notebook: Notebook, routes: "JupyterRoutes | None") -> str:
+def _notebook_html(notebook: Notebook, routes: JupyterRoutes | None) -> str:
     if notebook.mtime == 0.0:
         detail = '<span class="d-empty">unreadable — being written?</span>'
     else:
@@ -1117,12 +1133,7 @@ def _plan_html(state: State) -> str:
         return ""
 
     doc = next((d for d in state.docs if d.name == "RESEARCH_PLAN.md"), None)
-    link = (
-        f'<a class="doc-trigger d-chip" data-doc="{e(doc.path)}" '
-        f'href="{e(doc.path)}">RESEARCH_PLAN.md</a>'
-        if doc
-        else ""
-    )
+    link = _doc_trigger(doc.path, e(doc.name), "d-chip") if doc else ""
 
     # Counts, never a mapping: plan section numbers do not correspond to
     # filenames on disk (measured — see plan_summary), so a per-notebook
@@ -1489,7 +1500,7 @@ def public_url(port: int) -> str:
     return f"{HUB}{prefix}proxy/{port}/" if prefix else f"http://127.0.0.1:{port}/"
 
 
-def jupyter_routes(project: Path) -> "JupyterRoutes | None":
+def jupyter_routes(project: Path) -> JupyterRoutes | None:
     """URL builder for opening this project's files in Jupyter, or ``None``.
 
     ``<rel>`` is the project directory relative to the running server's
@@ -1530,14 +1541,14 @@ def snapshot_url(project: Path) -> str:
 
     Reuses ``jupyter_routes`` rather than recomputing the relative path: it
     already handles the root-relative case and the outside-root case, and a
-    second implementation is a second thing to get wrong.
+    second implementation is a second thing to get wrong. That includes the
+    join and the escaping — ``_path`` is the same encoder every other Jupyter
+    URL on this page goes through.
     """
-    snapshot = project / "dashboard.html"
     routes = jupyter_routes(project)
     if routes is None:  # off-cluster, or outside root_dir — no URL can reach it
-        return str(snapshot)
-    rel = f"{routes.rel}/dashboard.html" if routes.rel else "dashboard.html"
-    return f"{routes.base}files/{quote(rel)}"
+        return str(project / "dashboard.html")
+    return f"{routes.base}files/{routes._path('dashboard.html')}"
 
 
 def in_jupyterhub() -> bool:
@@ -1570,7 +1581,7 @@ def _handler_factory(project: Path, css: str):
         def _is_index(self) -> bool:
             return self.path.split("?")[0] in ("/", "/index.html")
 
-        def _doc_target(self) -> "Path | None":
+        def _doc_target(self) -> Path | None:
             """The markdown file a ``/_doc/`` request names, or ``None``.
 
             ``translate_path`` is ``SimpleHTTPRequestHandler``'s own sanitiser —
@@ -1598,6 +1609,20 @@ def _handler_factory(project: Path, css: str):
                 return None
             return resolved
 
+        def _send_html(self, payload: bytes, body: bool, etag: str = ""):
+            """The one place this server states its caching contract. Both HTML
+            routes go through here so a future third one cannot quietly ship
+            without ``no-cache`` and let a browser serve a stale REPORT.md."""
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            if etag:
+                self.send_header("ETag", etag)
+            self.send_header("Cache-Control", "no-cache")
+            self.end_headers()
+            if body:
+                self.wfile.write(payload)
+
         def _doc(self, body: bool):
             target = self._doc_target()
             if target is None:
@@ -1606,14 +1631,7 @@ def _handler_factory(project: Path, css: str):
                 text = target.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError):
                 return self.send_error(404, "document could not be read")
-            payload = render_markdown(text).encode("utf-8")
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html; charset=utf-8")
-            self.send_header("Content-Length", str(len(payload)))
-            self.send_header("Cache-Control", "no-cache")
-            self.end_headers()
-            if body:
-                self.wfile.write(payload)
+            self._send_html(render_markdown(text).encode("utf-8"), body)
 
         def do_GET(self):  # noqa: N802
             if self._is_index():
@@ -1630,26 +1648,21 @@ def _handler_factory(project: Path, css: str):
             return super().do_HEAD()
 
         def _page(self, body: bool):
-            state = scan(project)
-            if self.headers.get("If-None-Match") == state.etag:
+            # `fingerprint` before `scan`: a 304 needs the etag and nothing else,
+            # and the poll makes 304 the common answer. The miss path pays one
+            # extra directory walk, which is the cheap half of a scan.
+            if self.headers.get("If-None-Match") == fingerprint(project)[0]:
                 self.send_response(304)
                 self.end_headers()
                 return
-            payload = render(state, css).encode("utf-8")
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html; charset=utf-8")
-            self.send_header("Content-Length", str(len(payload)))
-            self.send_header("ETag", state.etag)
-            self.send_header("Cache-Control", "no-cache")
-            self.end_headers()
-            if body:
-                self.wfile.write(payload)
+            state = scan(project)
+            self._send_html(render(state, css).encode("utf-8"), body, state.etag)
 
-    def _reject(self):
-        self.send_error(405, "read-only dashboard")
+        def _reject(self):
+            self.send_error(405, "read-only dashboard")
 
-    for verb in ("POST", "PUT", "DELETE", "PATCH", "OPTIONS"):
-        setattr(Handler, "do_" + verb, _reject)
+        do_POST = do_PUT = do_DELETE = do_PATCH = do_OPTIONS = _reject
+
     return Handler
 
 
@@ -1661,7 +1674,7 @@ def serve(project: Path, port: int, css: str) -> None:
     server.serve_forever()
 
 
-def _write_snapshot(project: Path, css: str, live: bool = False) -> Path:
+def _write_snapshot(project: Path, css: str) -> Path:
     snapshot = project / "dashboard.html"
     # Rendered to a sibling and renamed, because the banner tells the reader to
     # reload and the status line rewrites this file every turn — so a reload
@@ -1670,12 +1683,12 @@ def _write_snapshot(project: Path, css: str, live: bool = False) -> Path:
     # POSIX, so a reader sees either the old snapshot or the new one. Two sessions
     # on one project resolve the same way: last writer wins, whole file.
     staging = snapshot.with_name("dashboard.html.tmp")
-    staging.write_text(render(scan(project), css, live=live), encoding="utf-8")
+    staging.write_text(render(scan(project), css, live=False), encoding="utf-8")
     os.replace(staging, snapshot)
     return snapshot
 
 
-def jupyter_python() -> "str | None":
+def jupyter_python() -> str | None:
     """The interpreter the Jupyter server runs on, or ``None`` if it can't be found.
 
     **Not `sys.executable`.** The extension has to be importable by the process
@@ -1693,6 +1706,10 @@ def jupyter_python() -> "str | None":
     `sys.base_prefix` is wrong under uv, whose base is a managed CPython rather
     than the conda prefix.
     """
+    # Deferred like http.server (see _handler_factory) and for the same reason:
+    # 3.4ms measured, paid by every statusline render if it sits at module scope.
+    import shutil
+
     launcher = shutil.which("jupyter")
     if launcher is None:
         return None
@@ -1722,23 +1739,22 @@ def _print_snapshot_fallback(project: Path) -> None:
 
 
 def main(argv=None) -> int:
+    import argparse  # deferred like shutil above: 1.2ms, and only a CLI run needs it
+
     parser = argparse.ArgumentParser(description="Live dashboard for one BERIL project.")
-    parser.add_argument("project", nargs="?", help="Path to projects/<id>")
+    parser.add_argument("project", help="Path to projects/<id>")
     parser.add_argument("--port", type=int, help="Override the derived port")
     parser.add_argument(
         "--static", action="store_true", help="Write dashboard.html and exit"
     )
     args = parser.parse_args(argv)
 
-    if not args.project:
-        parser.error("the following arguments are required: project")
-
     project = Path(args.project).resolve()
     if not project.is_dir():
         print(f"no such project directory: {project}", file=sys.stderr)
         return 1
 
-    css = load_css(Path(__file__).resolve().parent.parent)
+    css = load_css()
     port = args.port or port_for(project.name)
 
     # Two callers, one branch. `--static` is someone asking for a snapshot;
@@ -1752,7 +1768,7 @@ def main(argv=None) -> int:
     try:
         serve(project, port, css)
     except OSError as exc:
-        if exc.errno in (48, 98):  # EADDRINUSE on macOS / Linux
+        if exc.errno == errno.EADDRINUSE:
             print(f"Dashboard already running: {public_url(port)}")
             return 0
         raise

--- a/tools/dashboard_assets/dash.css
+++ b/tools/dashboard_assets/dash.css
@@ -1,9 +1,13 @@
 /* Inlined by tools/dashboard.py as DASH_CSS and emitted into the page's single
    style element, immediately after ui/app/static/css/main.css. That order is
-   load-bearing: `a`, `body` and `.lightbox-doc img` tie main.css on specificity
-   and win only by coming second. The .lightbox-* rules here extend main.css's
-   overlay rather than replace it -- they assume its backdrop, .active toggle
-   and .lightbox-close are already present. */
+   load-bearing: `a` and `.lightbox-doc img` tie main.css on specificity and win
+   only by coming second. The .lightbox-* rules here extend main.css's overlay
+   rather than replace it -- they assume its backdrop, .active toggle and
+   .lightbox-close are already present.
+
+   `body` is NOT one of them: main.css:108 carries `!important`, which beats
+   source order, so the page is #0d1117 and --d-bg is only the no-main.css
+   fallback. */
 
 :root{--d-bg:#12141a;--d-panel:#171a21;--d-card:#1b1f28;--d-line:#262a35;
 --d-fg:#e6e8ee;--d-mut:#8b93a7;--d-dim:#5c6478;--d-accent:#58a6ff;--d-ok:#3fb950;
@@ -63,11 +67,8 @@ margin-top:12px;border-radius:0 6px 6px 0;}
    than inside it — the header is sticky and must stay short. */
 .d-setup{border-left:2px solid var(--d-warn);background:#221c10;padding:10px 14px;
 margin:0 0 18px;border-radius:0 6px 6px 0;font-size:13.5px;color:#c4cad8;}
-.d-setup b{color:#e3b341;}
 .d-setup ol{margin:8px 0 0;padding-left:20px;}
 .d-setup li{margin:4px 0;}
-.d-setup code{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12.5px;
-background:#0d1017;border:1px solid var(--d-line);border-radius:4px;padding:1px 6px;}
 /* "The agent is blocked on you." Same anchoring as .d-setup and for the same
    reason — a sibling of #root, so the 4s poll cannot wipe it — but with a
    second reason on top: an element inside #root is destroyed and rebuilt every
@@ -77,9 +78,11 @@ background:#0d1017;border:1px solid var(--d-line);border-radius:4px;padding:1px 
    Filled by STATE_JS, which is why it starts empty and hidden. */
 .d-wait{border-left:2px solid var(--d-warn);background:#2a1f0c;padding:9px 14px;
 margin:0 0 14px;border-radius:0 6px 6px 0;font-size:13.5px;color:#e8dcc0;}
-.d-wait b{color:#e3b341;}
-.d-wait code{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12.5px;
-background:#0d1017;border:1px solid var(--d-line);border-radius:4px;padding:1px 6px;}
+/* Shared: the containers stay apart, they differ in more than they share. */
+.d-setup b,.d-wait b{color:#e3b341;}
+.d-setup code,.d-wait code{font-family:ui-monospace,SFMono-Regular,monospace;
+font-size:12.5px;background:#0d1017;border:1px solid var(--d-line);
+border-radius:4px;padding:1px 6px;}
 .d-wait.pulse{animation:d-pulse .6s ease-out 1;}
 @keyframes d-pulse{from{background:#5a3f10;}to{background:#2a1f0c;}}
 /* No sustained flashing anywhere, and none at all for a reader who has asked
@@ -103,10 +106,10 @@ overflow:hidden;margin:3px 0 0;color:#c4cad8;font-size:13.5px;max-width:none;}
 border-radius:0 6px 6px 0;}
 .d-plan .d-eyebrow{margin-top:12px;color:var(--d-mut);}
 .d-plan .d-eyebrow:first-child{margin-top:0;}
-.d-clamp2{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;
+.d-clamp2,.d-clamp3{display:-webkit-box;-webkit-box-orient:vertical;
 overflow:hidden;margin:2px 0 0;max-width:78ch;color:#c9cfdd;}
-.d-clamp3{display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;
-overflow:hidden;margin:2px 0 0;max-width:78ch;color:#c9cfdd;}
+.d-clamp2{-webkit-line-clamp:2;}
+.d-clamp3{-webkit-line-clamp:3;}
 .d-sec{font-size:11px;text-transform:uppercase;letter-spacing:.09em;color:var(--d-mut);
 margin:30px 0 12px;padding-bottom:6px;border-bottom:1px solid var(--d-line);}
 .d-tl{position:relative;padding-left:22px;}
@@ -178,4 +181,7 @@ border-left:3px solid var(--d-line);}
 .lightbox-doc th{color:var(--d-fg);font-weight:650;}
 .lightbox-doc img{max-width:100%;height:auto;}
 .lightbox-doc hr{border:none;border-top:1px solid var(--d-line);margin:20px 0;}
+/* Both of lightbox.js's note() states, scoped: `.lightbox-doc p` above is
+   (0,1,1) and beats a bare class whatever the order. */
 .lightbox-doc .doc-error{color:var(--d-bad);}
+.lightbox-doc .d-empty{color:var(--d-dim);}

--- a/tools/dashboard_assets/dash.css
+++ b/tools/dashboard_assets/dash.css
@@ -1,0 +1,178 @@
+/* Inlined by tools/dashboard.py as DASH_CSS and emitted into the page's single
+   style element, immediately after ui/app/static/css/main.css. That order is
+   load-bearing: `a`, `body` and `.lightbox-doc img` tie main.css on specificity
+   and win only by coming second. The .lightbox-* rules here extend main.css's
+   overlay rather than replace it -- they assume its backdrop, .active toggle
+   and .lightbox-close are already present. */
+
+:root{--d-bg:#12141a;--d-panel:#171a21;--d-card:#1b1f28;--d-line:#262a35;
+--d-fg:#e6e8ee;--d-mut:#8b93a7;--d-dim:#5c6478;--d-accent:#58a6ff;--d-ok:#3fb950;
+--d-warn:#d29922;--d-bad:#ff7b72;}
+body{background:var(--d-bg);color:var(--d-fg);margin:0;
+font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
+#root{max-width:1100px;margin:0 auto;padding:0 20px 60px;}
+/* Sticky, so it must stay short — everything inside is either one line or
+   clamped. A shadow rather than a hairline: content genuinely passes beneath
+   it, and the border alone read as a seam cutting through the text. */
+.d-hd{position:sticky;top:0;z-index:9;background:var(--d-panel);
+border-bottom:1px solid var(--d-line);margin:0 -20px 24px;padding:12px 20px 14px;
+box-shadow:0 8px 20px -12px #000c;}
+/* Anchors and scrolled-to elements must clear the sticky region. */
+#root [id]{scroll-margin-top:180px;}
+.d-id{font-family:ui-monospace,SFMono-Regular,monospace;font-weight:650;}
+.d-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap;}
+.d-chip{display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;
+font-weight:600;border:1px solid var(--d-line);background:var(--d-card);color:var(--d-mut);}
+.d-chip.ok{color:#7ee787;border-color:#238636aa;background:#23863626;}
+.d-chip.bad{color:var(--d-bad);border-color:#ff7b7255;background:#ff7b7218;}
+.d-chip.warn{color:#e3b341;border-color:#d2992255;background:#d2992218;}
+.d-chip.now{color:#79b8ff;border-color:#1f6feb66;background:#1f6feb26;}
+.live{color:var(--d-ok);}.idle{color:var(--d-warn);}.cold{color:var(--d-dim);}
+.d-rail{display:flex;list-style:none;margin:12px 0 4px;padding:0;}
+.d-rail li{flex:1;text-align:center;font-size:11px;position:relative;color:var(--d-dim);}
+.d-rail li i{display:block;width:10px;height:10px;border-radius:50%;
+margin:0 auto 6px;background:#2b3040;}
+.d-rail li[data-state=done]{color:#7ee787;}.d-rail li[data-state=done] i{background:var(--d-ok);}
+.d-rail li[data-state=current]{color:#79b8ff;font-weight:700;}
+.d-rail li[data-state=current] i{background:var(--d-accent);box-shadow:0 0 0 4px #58a6ff2e;}
+.d-rail li[data-state=future]{opacity:.32;}
+.d-rail li:not(:last-child):after{content:'';position:absolute;top:4px;
+left:calc(50% + 11px);right:calc(-50% + 11px);height:1px;background:#2b3040;}
+/* Inline readouts. Tabular figures matter here: the page repaints every 4s and
+   proportional digits make the elapsed clock jitter sideways as they change. */
+.d-read{display:flex;flex-direction:column;align-items:flex-end;line-height:1.15;}
+.d-read.push{margin-left:auto;}
+/* No `color` here on purpose: relTimes() sets .live/.idle/.cold on this element
+   and a `.d-read b` rule would outrank them, silencing the liveness signal. */
+.d-read b{font:600 13px/1.15 ui-monospace,SFMono-Regular,monospace;
+font-variant-numeric:tabular-nums;}
+.d-read i{font-style:normal;font-size:9px;text-transform:uppercase;
+letter-spacing:.08em;color:var(--d-dim);}
+/* The dot inherits currentColor, so it turns amber then grey with the number —
+   one glance answers "is the agent alive". Only on the activity readout. */
+.d-read.push b::before{content:'';display:inline-block;width:6px;height:6px;
+border-radius:50%;background:currentColor;margin-right:6px;vertical-align:.1em;}
+.d-eyebrow{display:block;font-size:9px;text-transform:uppercase;
+letter-spacing:.1em;color:var(--d-dim);margin-bottom:3px;}
+.d-now{border-left:2px solid var(--d-accent);background:#161b24;padding:8px 14px;
+margin-top:12px;border-radius:0 6px 6px 0;}
+.d-now b{font-size:14px;}
+/* Snapshot mode only, and loud on purpose: it is the one thing on this page the
+   reader has to act on, and the instructions it replaces were five lines in a
+   gitignored log file nobody had a reason to open. Above #root's header rather
+   than inside it — the header is sticky and must stay short. */
+.d-setup{border-left:2px solid var(--d-warn);background:#221c10;padding:10px 14px;
+margin:0 0 18px;border-radius:0 6px 6px 0;font-size:13.5px;color:#c4cad8;}
+.d-setup b{color:#e3b341;}
+.d-setup ol{margin:8px 0 0;padding-left:20px;}
+.d-setup li{margin:4px 0;}
+.d-setup code{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12.5px;
+background:#0d1017;border:1px solid var(--d-line);border-radius:4px;padding:1px 6px;}
+/* "The agent is blocked on you." Same anchoring as .d-setup and for the same
+   reason — a sibling of #root, so the 4s poll cannot wipe it — but with a
+   second reason on top: an element inside #root is destroyed and rebuilt every
+   4s, which would restart the pulse below on every poll. A 0.6s highlight every
+   4s, forever, is a flashing banner: WCAG 2.3.1, and unbearable to sit next to.
+   Out here it animates once, on the transition that earned it.
+   Filled by STATE_JS, which is why it starts empty and hidden. */
+.d-wait{border-left:2px solid var(--d-warn);background:#2a1f0c;padding:9px 14px;
+margin:0 0 14px;border-radius:0 6px 6px 0;font-size:13.5px;color:#e8dcc0;}
+.d-wait b{color:#e3b341;}
+.d-wait code{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12.5px;
+background:#0d1017;border:1px solid var(--d-line);border-radius:4px;padding:1px 6px;}
+.d-wait.pulse{animation:d-pulse .6s ease-out 1;}
+@keyframes d-pulse{from{background:#5a3f10;}to{background:#2a1f0c;}}
+/* No sustained flashing anywhere, and none at all for a reader who has asked
+   the OS not to move things. The strip still appears; it just appears. */
+@media (prefers-reduced-motion:reduce){.d-wait.pulse{animation:none;}}
+/* Hidden until the browser can actually act on it: requestPermission needs a
+   user gesture, so there has to be something to click, but once the reader has
+   answered — either way — the button is noise and STATE_JS removes it. */
+.d-alert{background:var(--d-card);color:var(--d-mut);border:1px solid var(--d-line);
+border-radius:10px;font:600 11px/1.6 inherit;padding:1px 10px;margin:0 0 14px;
+cursor:pointer;}
+.d-alert:hover{color:var(--d-fg);border-color:var(--d-accent);}
+/* Two lines, then fade. The full text is the first timeline entry. */
+.d-clamp{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;
+overflow:hidden;margin:3px 0 0;color:#c4cad8;font-size:13.5px;max-width:none;}
+/* The contract the worklog below is measured against, so it gets the accent
+   rather than the neutral card outline every other block uses — it is not just
+   another card. */
+.d-plan{border-left:2px solid var(--d-accent);background:linear-gradient(
+90deg,#58a6ff0d,transparent 60%);padding:10px 0 12px 16px;margin:26px 0 4px;
+border-radius:0 6px 6px 0;}
+.d-plan .d-eyebrow{margin-top:12px;color:var(--d-mut);}
+.d-plan .d-eyebrow:first-child{margin-top:0;}
+.d-clamp2{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;
+overflow:hidden;margin:2px 0 0;max-width:78ch;color:#c9cfdd;}
+.d-clamp3{display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;
+overflow:hidden;margin:2px 0 0;max-width:78ch;color:#c9cfdd;}
+.d-sec{font-size:11px;text-transform:uppercase;letter-spacing:.09em;color:var(--d-mut);
+margin:30px 0 12px;padding-bottom:6px;border-bottom:1px solid var(--d-line);}
+.d-tl{position:relative;padding-left:22px;}
+.d-tl:before{content:'';position:absolute;left:4px;top:6px;bottom:4px;width:1px;
+background:#2b3040;}
+.d-ev{position:relative;margin-bottom:18px;}
+.d-ev:before{content:'';position:absolute;left:-22px;top:6px;width:8px;height:8px;
+border-radius:50%;border:1.5px solid #4a5265;background:var(--d-bg);}
+.d-ev.big:before{left:-24px;top:4px;width:12px;height:12px;border:none;
+background:var(--d-accent);}
+/* Corrections: amber ring and an amber rule down the entry, so a scan of the
+   timeline finds the moments the project changed direction. */
+.d-ev.fix:before{background:var(--d-warn);border-color:var(--d-warn);}
+.d-ev.fix{border-left:2px solid #d2992255;margin-left:-14px;padding-left:12px;}
+.d-ev p{max-width:68ch;margin:4px 0;color:#c4cad8;}
+.d-links{display:flex;gap:7px;flex-wrap:wrap;align-items:center;margin-top:6px;}
+/* The gallery earns real size; the 104px inline thumbs in the timeline do not.
+   Same white plate, since matplotlib output is white and should read as
+   intentional rather than as a hole punched in a dark page. */
+.d-figs{display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));
+gap:12px;margin-top:0;}
+.d-figs img{width:100%;padding:6px;box-sizing:border-box;
+transition:border-color .15s ease,transform .15s ease;}
+.d-figs img:hover{border-color:var(--d-accent);transform:translateY(-2px);}
+.d-links img{width:104px;height:auto;background:#ffffffeb;border-radius:4px;
+border:1px solid var(--d-line);display:block;}
+.d-grid{display:grid;gap:10px;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));}
+.d-card{background:var(--d-card);border:1px solid var(--d-line);border-radius:6px;
+padding:9px 12px;font-size:13px;}
+.d-empty{color:var(--d-dim);font-style:italic;}
+a{color:#79b8ff;}
+table{border-collapse:collapse;font-size:13px;width:100%;}
+td,th{border-bottom:1px solid var(--d-line);padding:5px 8px;text-align:left;}
+.doc-trigger{cursor:pointer;}
+/* Document mode for the shared overlay. main.css centres a bare <img>; a report
+   instead needs a bounded, scrollable panel, so the two modes are switched by a
+   class on the overlay rather than given separate overlays — one close path. */
+.lightbox-doc{display:none;}
+/* Child combinator, not descendant. The overlay's own figure <img> is a direct
+   child of #lightbox; every image inside a rendered document is nested in
+   .lightbox-doc. A descendant selector here hid the figures embedded in
+   REPORT.md — which are the whole point of inlining them next to each finding. */
+.lightbox-overlay.mode-doc>img{display:none;}
+.lightbox-overlay.mode-doc .lightbox-doc{display:block;text-align:left;
+background:var(--d-panel);border:1px solid var(--d-line);border-radius:8px;
+width:min(880px,calc(100vw - 56px));max-height:calc(100vh - 96px);
+overflow-y:auto;overscroll-behavior:contain;padding:24px 32px;}
+.lightbox-doc>:first-child{margin-top:0;}
+.lightbox-doc h1{font-size:1.5rem;}.lightbox-doc h2{font-size:1.22rem;}
+.lightbox-doc h3{font-size:1.05rem;}.lightbox-doc h4{font-size:.95rem;}
+.lightbox-doc h1,.lightbox-doc h2{border-bottom:1px solid var(--d-line);
+padding-bottom:6px;}
+.lightbox-doc h1,.lightbox-doc h2,.lightbox-doc h3,.lightbox-doc h4{
+margin:26px 0 10px;line-height:1.3;}
+.lightbox-doc p,.lightbox-doc li{color:#c9cfdd;}
+.lightbox-doc li{margin:3px 0;}
+.lightbox-doc code{background:#0f1117;border:1px solid var(--d-line);
+border-radius:4px;padding:1px 5px;font-size:.88em;
+font-family:ui-monospace,SFMono-Regular,monospace;}
+.lightbox-doc pre{background:#0f1117;border:1px solid var(--d-line);
+border-radius:6px;padding:12px 14px;overflow-x:auto;}
+.lightbox-doc pre code{background:none;border:none;padding:0;}
+.lightbox-doc blockquote{margin:12px 0;padding:2px 14px;color:var(--d-mut);
+border-left:3px solid var(--d-line);}
+.lightbox-doc table{display:block;overflow-x:auto;white-space:nowrap;}
+.lightbox-doc th{color:var(--d-fg);font-weight:650;}
+.lightbox-doc img{max-width:100%;height:auto;}
+.lightbox-doc hr{border:none;border-top:1px solid var(--d-line);margin:20px 0;}
+.lightbox-doc .doc-error{color:var(--d-bad);}

--- a/tools/dashboard_assets/dash.css
+++ b/tools/dashboard_assets/dash.css
@@ -123,16 +123,19 @@ background:var(--d-accent);}
 .d-ev.fix{border-left:2px solid #d2992255;margin-left:-14px;padding-left:12px;}
 .d-ev p{max-width:68ch;margin:4px 0;color:#c4cad8;}
 .d-links{display:flex;gap:7px;flex-wrap:wrap;align-items:center;margin-top:6px;}
+.d-links img{width:104px;height:auto;background:#ffffffeb;border-radius:4px;
+border:1px solid var(--d-line);display:block;}
 /* The gallery earns real size; the 104px inline thumbs in the timeline do not.
    Same white plate, since matplotlib output is white and should read as
-   intentional rather than as a hole punched in a dark page. */
+   intentional rather than as a hole punched in a dark page.
+   MUST stay below `.d-links img`: the gallery is class="d-links d-figs", so
+   both match it at (0,1,1) and only order decides -- the other way round every
+   gallery tile rendered 104px wide inside a 230px-minimum grid. */
 .d-figs{display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));
 gap:12px;margin-top:0;}
 .d-figs img{width:100%;padding:6px;box-sizing:border-box;
 transition:border-color .15s ease,transform .15s ease;}
 .d-figs img:hover{border-color:var(--d-accent);transform:translateY(-2px);}
-.d-links img{width:104px;height:auto;background:#ffffffeb;border-radius:4px;
-border:1px solid var(--d-line);display:block;}
 .d-grid{display:grid;gap:10px;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));}
 .d-card{background:var(--d-card);border:1px solid var(--d-line);border-radius:6px;
 padding:9px 12px;font-size:13px;}

--- a/tools/dashboard_assets/lightbox.js
+++ b/tools/dashboard_assets/lightbox.js
@@ -15,42 +15,40 @@
 // the parent document, so Esc would silently stop closing the popup.
 
 (function () {
-  const L = document.getElementById('lightbox');
-  if (!L) return;
-  const I = L.querySelector('img');
-  const D = L.querySelector('.lightbox-doc');
+  const overlay = document.getElementById('lightbox');
+  if (!overlay) return;
+  const img = overlay.querySelector('img');
+  const panel = overlay.querySelector('.lightbox-doc');
   let seq = 0;
 
   function close() {
-    L.classList.remove('active', 'mode-doc');
-  }
-
-  function near(t, sel) {
-    return t && t.closest ? t.closest(sel) : null;
+    overlay.classList.remove('active', 'mode-doc');
   }
 
   function note(cls, msg) {
-    D.innerHTML = '<p class="' + cls + '"></p>';
-    D.firstChild.textContent = msg;
+    panel.innerHTML = '<p class="' + cls + '"></p>';
+    panel.firstChild.textContent = msg;
   }
 
   document.addEventListener('click', function (e) {
-    const fig = near(e.target, '.lightbox-trigger');
+    const t = e.target;
+    if (!t || !t.closest) return;
+    const fig = t.closest('.lightbox-trigger');
     if (fig) {
-      I.src = fig.getAttribute('src');
-      I.alt = fig.getAttribute('alt') || '';
-      L.classList.remove('mode-doc');
-      L.classList.add('active');
+      img.src = fig.getAttribute('src');
+      img.alt = fig.getAttribute('alt') || '';
+      overlay.classList.remove('mode-doc');
+      overlay.classList.add('active');
       return;
     }
-    const doc = near(e.target, '.doc-trigger');
+    const doc = t.closest('.doc-trigger');
     if (doc && e.button === 0 && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
       e.preventDefault();
       const path = doc.getAttribute('data-doc');
       const n = ++seq;
       note('d-empty', 'loading\u2026');
-      L.classList.add('active', 'mode-doc');
-      D.scrollTop = 0;
+      overlay.classList.add('active', 'mode-doc');
+      panel.scrollTop = 0;
       fetch('_doc/' + path.split('/').map(encodeURIComponent).join('/'))
         .then(function (r) {
           return r.ok ? r.text() : r.status;
@@ -61,8 +59,8 @@
             note('doc-error', 'could not render ' + path + ' (' + v + ')');
             return;
           }
-          D.innerHTML = v;
-          D.scrollTop = 0;
+          panel.innerHTML = v;
+          panel.scrollTop = 0;
         })
         .catch(function () {
           if (n !== seq) return;
@@ -74,7 +72,7 @@
         });
       return;
     }
-    if (e.target === L || near(e.target, '.lightbox-close')) close();
+    if (t === overlay || t.closest('.lightbox-close')) close();
   });
 
   document.addEventListener('keydown', function (e) {

--- a/tools/dashboard_assets/lightbox.js
+++ b/tools/dashboard_assets/lightbox.js
@@ -1,0 +1,83 @@
+// The figure/document overlay. Inlined into the page by tools/dashboard.py as
+// LIGHTBOX_JS, in its own <script>, and self-contained: it reads nothing from
+// rel.js, state.js or poll.js.
+//
+// The overlay is a sibling of #root, and every listener is delegated on
+// document, so a trigger stays clickable after the 4s poll swaps #root's
+// innerHTML — the trigger elements are replaced, but the handler and the
+// overlay are not.
+//
+// Two modes share one overlay: an <img> for figures, and a scrollable panel
+// for markdown fetched from `_doc/` (DOC_ROUTE in dashboard.py, same prefix
+// without the leading slash). Sharing it means Esc, the backdrop and the ×
+// have exactly one implementation. An <iframe> was the obvious alternative for
+// the document mode and was rejected: keystrokes inside an iframe never reach
+// the parent document, so Esc would silently stop closing the popup.
+
+(function () {
+  const L = document.getElementById('lightbox');
+  if (!L) return;
+  const I = L.querySelector('img');
+  const D = L.querySelector('.lightbox-doc');
+  let seq = 0;
+
+  function close() {
+    L.classList.remove('active', 'mode-doc');
+  }
+
+  function near(t, sel) {
+    return t && t.closest ? t.closest(sel) : null;
+  }
+
+  function note(cls, msg) {
+    D.innerHTML = '<p class="' + cls + '"></p>';
+    D.firstChild.textContent = msg;
+  }
+
+  document.addEventListener('click', function (e) {
+    const fig = near(e.target, '.lightbox-trigger');
+    if (fig) {
+      I.src = fig.getAttribute('src');
+      I.alt = fig.getAttribute('alt') || '';
+      L.classList.remove('mode-doc');
+      L.classList.add('active');
+      return;
+    }
+    const doc = near(e.target, '.doc-trigger');
+    if (doc && e.button === 0 && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+      e.preventDefault();
+      const path = doc.getAttribute('data-doc');
+      const n = ++seq;
+      note('d-empty', 'loading\u2026');
+      L.classList.add('active', 'mode-doc');
+      D.scrollTop = 0;
+      fetch('_doc/' + path.split('/').map(encodeURIComponent).join('/'))
+        .then(function (r) {
+          return r.ok ? r.text() : r.status;
+        })
+        .then(function (v) {
+          if (n !== seq) return;
+          if (typeof v === 'number') {
+            note('doc-error', 'could not render ' + path + ' (' + v + ')');
+            return;
+          }
+          D.innerHTML = v;
+          D.scrollTop = 0;
+        })
+        .catch(function () {
+          if (n !== seq) return;
+          // fetch rejected outright: nothing is serving this page, which is
+          // what a written-out dashboard.html opened from disk looks like.
+          // Follow the real href instead of leaving an empty overlay open.
+          close();
+          location.href = doc.getAttribute('href');
+        });
+      return;
+    }
+    if (e.target === L || near(e.target, '.lightbox-close')) close();
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' || e.key === 'Esc') close();
+  });
+})();

--- a/tools/dashboard_assets/poll.js
+++ b/tools/dashboard_assets/poll.js
@@ -1,0 +1,92 @@
+// The 4s poll. Inlined into the page by tools/dashboard.py as POLL_JS.
+//
+// DEPENDS ON ITS SIBLINGS, with nothing in the language to say so. Python
+// concatenates rel.js, state.js and this file into ONE <script>, in that
+// order, so all three share a single top-level scope:
+//
+//   R, tag, relTimes  <- rel.js   (`tag` is reassigned below, hence `let` there)
+//   dashMark          <- state.js (exported as window.dashMark)
+//
+// Nothing reads back out: `timer` and `tick` are this file's own, which is what
+// makes `let timer` safe here.
+//
+// Two things sever that scope, and only two: wrapping a sibling in an IIFE (or
+// any other function scope), and emitting `type="module"`. Order and tag count
+// do not — top-level `let`/`const`/`function` in *classic* scripts share the
+// realm's global scope, so three separate <script> tags in any order behave
+// identically, and nothing here touches a sibling's name until the first tick
+// 4s later. Both real breakages are checked by
+// tests/test_dashboard.py::test_the_live_scripts_parse_and_share_one_scope,
+// which compiles the three together and drives one `tick()`.
+//
+// The two symptoms are not the same, which matters when debugging one:
+//
+// - `tag` is read on tick's first line, before the fetch. Losing it throws
+//   synchronously out of the setTimeout callback, so the reschedule at the
+//   bottom never runs: loud in the console, and the poll stops dead.
+// - `R`, `relTimes` and `dashMark` are only touched inside the `.then` chain,
+//   whose `.catch` is empty. Losing one is swallowed: the page renders, keeps
+//   polling forever, never repaints, and the console stays clean.
+//
+// Emitted **only in live mode**, and both of the outer statements are why: the
+// trailing-slash redirect and the `fetch` are each actively wrong on a
+// snapshot.
+//
+// - The redirect exists so relative asset URLs resolve under `/proxy/<port>`.
+//   A snapshot is served at `<prefix>files/<rel>/dashboard.html`, which does
+//   not end in `/`, so this line would navigate the page to `dashboard.html/`
+//   — a Jupyter 404. The page would destroy itself on load.
+// - `files/` responses carry `Content-Security-Policy: sandbox allow-scripts`
+//   with no `allow-same-origin` (measured against the live server), so the
+//   document has an opaque origin and `fetch` cannot send the hub cookie. The
+//   poll could only ever fail, silently, forever.
+//
+// **A hidden tab still fetches**, at 15s instead of 4s. It used to skip the
+// fetch entirely, which is cheaper and wrong: a backgrounded tab is exactly
+// the tab that needs to learn the agent is blocked on a permission prompt, and
+// one that never fetches can never learn anything — it has only the title and
+// the favicon to speak through, and both are painted from the response. The
+// cost is small enough to check rather than argue about: a 304 still runs a
+// full `scan()` at 6.8ms measured, so 15s hidden is ~1.6s of CPU per hour per
+// tab, less than a *visible* tab costs today.
+//
+// The single `timer` handle is not decoration. `tick` schedules the next tick,
+// and the visibilitychange listener calls `tick` directly, so every return to
+// the tab used to start a second concurrent chain that never ended — harmless
+// while hidden ticks were free, a compounding multiplier on real requests now.
+
+if (!location.pathname.endsWith('/')) location.replace(location.pathname + '/');
+
+let timer = 0;
+
+function tick() {
+  const h = tag ? {'If-None-Match': tag} : {};
+  fetch('.', {headers: h}).then(function (r) {
+    if (r.status !== 200) return null;
+    tag = r.headers.get('ETag');
+    return r.text();
+  }).then(function (t) {
+    if (!t) return;
+    const open = [];
+    const ds = R.querySelectorAll('details[open]');
+    for (let i = 0; i < ds.length; i++) if (ds[i].id) open.push(ds[i].id);
+    const doc = new DOMParser().parseFromString(t, 'text/html');
+    const next = doc.getElementById('root');
+    if (!next) return;
+    R.innerHTML = next.innerHTML;
+    for (let j = 0; j < open.length; j++) {
+      const d = R.querySelector('#' + CSS.escape(open[j]));
+      if (d) d.open = true;
+    }
+    relTimes();
+    dashMark();
+  }).catch(function () {});
+  clearTimeout(timer);
+  timer = setTimeout(tick, document.hidden ? 15000 : 4000);
+}
+
+document.addEventListener('visibilitychange', function () {
+  if (document.visibilityState === 'visible') tick();
+});
+
+timer = setTimeout(tick, 4000);

--- a/tools/dashboard_assets/poll.js
+++ b/tools/dashboard_assets/poll.js
@@ -4,29 +4,27 @@
 // concatenates rel.js, state.js and this file into ONE <script>, in that
 // order, so all three share a single top-level scope:
 //
-//   R, tag, relTimes  <- rel.js   (`tag` is reassigned below, hence `let` there)
-//   dashMark          <- state.js (exported as window.dashMark)
+//   rootEl, tag, relTimes  <- rel.js   (`tag` is reassigned below, hence `let`)
+//   dashMark               <- state.js (exported as window.dashMark)
 //
 // Nothing reads back out: `timer` and `tick` are this file's own, which is what
 // makes `let timer` safe here.
 //
-// Two things sever that scope, and only two: wrapping a sibling in an IIFE (or
-// any other function scope), and emitting `type="module"`. Order and tag count
-// do not — top-level `let`/`const`/`function` in *classic* scripts share the
-// realm's global scope, so three separate <script> tags in any order behave
-// identically, and nothing here touches a sibling's name until the first tick
-// 4s later. Both real breakages are checked by
+// Order and tag count do not matter: top-level let/const/function in *classic*
+// scripts land in the realm's global scope, so three separate <script> tags in
+// any order behave identically. One tag is a convenience, not a constraint.
+//
+// Two things sever that scope: an IIFE around a sibling, and `type="module"`.
+// Both are checked by
 // tests/test_dashboard.py::test_the_live_scripts_parse_and_share_one_scope,
 // which compiles the three together and drives one `tick()`.
 //
-// The two symptoms are not the same, which matters when debugging one:
-//
-// - `tag` is read on tick's first line, before the fetch. Losing it throws
-//   synchronously out of the setTimeout callback, so the reschedule at the
-//   bottom never runs: loud in the console, and the poll stops dead.
-// - `R`, `relTimes` and `dashMark` are only touched inside the `.then` chain,
-//   whose `.catch` is empty. Losing one is swallowed: the page renders, keeps
-//   polling forever, never repaints, and the console stays clean.
+// The two symptoms are not the same, which matters when debugging one: `tag` is
+// read synchronously on tick's first line, so losing it throws out of the
+// setTimeout callback and the poll stops dead — loud. `rootEl`, `relTimes` and
+// `dashMark` are only touched inside the `.then` chain, whose `.catch` is
+// empty, so losing one is swallowed: the page keeps polling forever, never
+// repaints, and the console stays clean.
 //
 // Emitted **only in live mode**, and both of the outer statements are why: the
 // trailing-slash redirect and the `fetch` are each actively wrong on a
@@ -46,14 +44,14 @@
 // the tab that needs to learn the agent is blocked on a permission prompt, and
 // one that never fetches can never learn anything — it has only the title and
 // the favicon to speak through, and both are painted from the response. The
-// cost is small enough to check rather than argue about: a 304 still runs a
-// full `scan()` at 6.8ms measured, so 15s hidden is ~1.6s of CPU per hour per
-// tab, less than a *visible* tab costs today.
+// cost is small enough to check rather than argue about: a 304 costs one
+// `fingerprint()` at 0.25-0.84ms measured across the three largest projects on
+// disk, so 15s hidden is under 0.2s of CPU per hour per tab. It used to run a
+// whole `scan()` at 6.8ms, which is what this interval was chosen against.
 //
 // The single `timer` handle is not decoration. `tick` schedules the next tick,
 // and the visibilitychange listener calls `tick` directly, so every return to
-// the tab used to start a second concurrent chain that never ended — harmless
-// while hidden ticks were free, a compounding multiplier on real requests now.
+// the tab used to start a second concurrent chain that never ended.
 
 if (!location.pathname.endsWith('/')) location.replace(location.pathname + '/');
 
@@ -68,14 +66,13 @@ function tick() {
   }).then(function (t) {
     if (!t) return;
     const open = [];
-    const ds = R.querySelectorAll('details[open]');
-    for (let i = 0; i < ds.length; i++) if (ds[i].id) open.push(ds[i].id);
+    for (const d of rootEl.querySelectorAll('details[open]')) if (d.id) open.push(d.id);
     const doc = new DOMParser().parseFromString(t, 'text/html');
     const next = doc.getElementById('root');
     if (!next) return;
-    R.innerHTML = next.innerHTML;
-    for (let j = 0; j < open.length; j++) {
-      const d = R.querySelector('#' + CSS.escape(open[j]));
+    rootEl.innerHTML = next.innerHTML;
+    for (const id of open) {
+      const d = rootEl.querySelector('#' + CSS.escape(id));
       if (d) d.open = true;
     }
     relTimes();

--- a/tools/dashboard_assets/rel.js
+++ b/tools/dashboard_assets/rel.js
@@ -1,0 +1,55 @@
+// Relative timestamps. Inlined into the page by tools/dashboard.py as REL_JS.
+//
+// The page ships in two halves because it has two transports and only one of
+// them can poll. This is the half that always runs, in live mode and in a
+// written-out snapshot alike.
+//
+// Every timestamp renders client-side from `data-epoch` (see the design doc),
+// so without this file the readouts are empty elements — which is why the
+// snapshot gets this half rather than no script at all. It is also what keeps
+// a *stale* snapshot honest: `relTimes` measures age against the reader's
+// clock, not the render time, so an abandoned snapshot visibly ages
+// green -> amber -> grey instead of freezing on a green dot.
+//
+// `R` and `tag` are declared here and read by poll.js, which is concatenated
+// into the same <script>. `tag` is *reassigned* there, so it is `let`; making
+// it `const` compiles fine and then throws inside a promise whose `.catch` is
+// empty, i.e. the page polls forever and never repaints, silently.
+
+const R = document.getElementById('root');
+let tag = null;
+
+function rel(s) {
+  const d = Math.max(0, Date.now() / 1000 - s);
+  if (d < 60) return Math.floor(d) + 's ago';
+  if (d < 3600) return Math.floor(d / 60) + 'm ago';
+  if (d < 86400) return Math.floor(d / 3600) + 'h ago';
+  return Math.floor(d / 86400) + 'd ago';
+}
+
+function since(s) {
+  const d = Math.max(0, Date.now() / 1000 - s);
+  if (d < 3600) return Math.floor(d / 60) + 'm';
+  if (d < 86400) return Math.floor(d / 3600) + 'h ' + Math.floor((d % 3600) / 60) + 'm';
+  return Math.floor(d / 86400) + 'd';
+}
+
+function relTimes() {
+  const n = document.querySelectorAll('[data-epoch]');
+  for (let i = 0; i < n.length; i++) {
+    const el = n[i];
+    const s = parseFloat(el.dataset.epoch);
+    if (!s) {
+      el.textContent = '--';
+      continue;
+    }
+    const age = Date.now() / 1000 - s;
+    el.textContent = (el.dataset.mode === 'since') ? since(s) : rel(s);
+    if (el.dataset.mode !== 'since') {
+      el.className = age < 600 ? 'live' : (age < 3600 ? 'idle' : 'cold');
+    }
+  }
+}
+
+setInterval(relTimes, 15000);
+relTimes();

--- a/tools/dashboard_assets/rel.js
+++ b/tools/dashboard_assets/rel.js
@@ -1,26 +1,26 @@
 // Relative timestamps. Inlined into the page by tools/dashboard.py as REL_JS.
 //
-// The page ships in two halves because it has two transports and only one of
-// them can poll. This is the half that always runs, in live mode and in a
-// written-out snapshot alike.
-//
 // Every timestamp renders client-side from `data-epoch` (see the design doc),
 // so without this file the readouts are empty elements — which is why the
-// snapshot gets this half rather than no script at all. It is also what keeps
+// snapshot gets this file rather than no script at all. It is also what keeps
 // a *stale* snapshot honest: `relTimes` measures age against the reader's
 // clock, not the render time, so an abandoned snapshot visibly ages
 // green -> amber -> grey instead of freezing on a green dot.
 //
-// `R` and `tag` are declared here and read by poll.js, which is concatenated
-// into the same <script>. `tag` is *reassigned* there, so it is `let`; making
-// it `const` compiles fine and then throws inside a promise whose `.catch` is
-// empty, i.e. the page polls forever and never repaints, silently.
+// `rootEl` and `tag` are declared here and read by poll.js, which is
+// concatenated into the same <script>. `tag` is *reassigned* there, so it is
+// `let`; making it `const` compiles fine and then throws inside a promise whose
+// `.catch` is empty, i.e. the page polls forever and never repaints, silently.
 
-const R = document.getElementById('root');
+const rootEl = document.getElementById('root');
 let tag = null;
 
+function age(s) {
+  return Math.max(0, Date.now() / 1000 - s);
+}
+
 function rel(s) {
-  const d = Math.max(0, Date.now() / 1000 - s);
+  const d = age(s);
   if (d < 60) return Math.floor(d) + 's ago';
   if (d < 3600) return Math.floor(d / 60) + 'm ago';
   if (d < 86400) return Math.floor(d / 3600) + 'h ago';
@@ -28,28 +28,31 @@ function rel(s) {
 }
 
 function since(s) {
-  const d = Math.max(0, Date.now() / 1000 - s);
+  const d = age(s);
   if (d < 3600) return Math.floor(d / 60) + 'm';
   if (d < 86400) return Math.floor(d / 3600) + 'h ' + Math.floor((d % 3600) / 60) + 'm';
   return Math.floor(d / 86400) + 'd';
 }
 
 function relTimes() {
-  const n = document.querySelectorAll('[data-epoch]');
-  for (let i = 0; i < n.length; i++) {
-    const el = n[i];
+  for (const el of document.querySelectorAll('[data-epoch]')) {
     const s = parseFloat(el.dataset.epoch);
     if (!s) {
       el.textContent = '--';
       continue;
     }
-    const age = Date.now() / 1000 - s;
-    el.textContent = (el.dataset.mode === 'since') ? since(s) : rel(s);
-    if (el.dataset.mode !== 'since') {
-      el.className = age < 600 ? 'live' : (age < 3600 ? 'idle' : 'cold');
+    if (el.dataset.mode === 'since') {
+      el.textContent = since(s);
+      continue;
     }
+    const d = age(s);
+    el.textContent = rel(s);
+    // The liveness colour belongs to this mode only. 10min -> amber, 1h -> grey.
+    el.className = d < 600 ? 'live' : (d < 3600 ? 'idle' : 'cold');
   }
 }
 
+// Coincidence, not poll.js's hidden cadence: this one repaints text a snapshot
+// has no other way to age. A shared constant would be the wrong abstraction.
 setInterval(relTimes, 15000);
 relTimes();

--- a/tools/dashboard_assets/state.js
+++ b/tools/dashboard_assets/state.js
@@ -1,0 +1,107 @@
+// "The agent needs you" — title marker, favicon dot, waiting strip, OS
+// notification. Inlined into the page by tools/dashboard.py as STATE_JS, in
+// both transports; poll.js calls the exported `window.dashMark` after a swap.
+//
+// Everything here is client-side for the same reason relative times are: a 304
+// freezes whatever the server wrote, and this is the one readout whose whole
+// job is to be current. The server emits `#d-state` inside #root carrying
+// `data-state` and `data-since`; `mark()` reads them after every swap and
+// drives four things off them.
+//
+// Two channels reach a reader who is not looking at the page — the title marker
+// and the favicon — and they are the only two a browser gives a foreground tab.
+// A closed tab gets nothing without a service worker and a push service, which
+// a stdlib server inside a pod cannot be.
+//
+// `#d-detail` is agent-authored text, so it is *not* interpolated here. The
+// server renders it through the same `inline_md` -> `e()` path as the worklog
+// and this copies the resulting node's HTML verbatim; the escaping decision
+// stays in one place, in Python, where it is tested. The notification body
+// takes `textContent` instead, since it is not markup at all.
+//
+// The `(state, since)` pair is the debounce key. Without it every 4s re-render
+// is a fresh transition: the strip would re-pulse and the OS notification would
+// re-fire for one permission prompt, which is how a notification gets muted.
+//
+// The explicit `window.dashMark = mark` is load-bearing, not style:
+// tests/test_dashboard.py runs this file as an ES module under node, where an
+// implicit global would be a ReferenceError, and poll.js calls it by name out
+// of the shared scope. The IIFE around it is only hygiene — it keeps the dozen
+// locals below out of the one scope this file shares with rel.js and poll.js.
+
+(function () {
+  const W = document.getElementById('d-wait');
+  const B = document.getElementById('d-alert');
+  const F = document.getElementById('d-favicon');
+  const BASE = document.title;
+  let last = null;
+  let hiddenAt = document.hidden ? Date.now() : 0;
+
+  const MARK = {waiting: '\u25cf ', turn_ended: '\u2713 '};
+
+  function icon(c) {
+    return 'data:image/svg+xml,' + encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">' +
+      '<circle cx="8" cy="8" r="7" fill="' + c + '"/></svg>');
+  }
+
+  const ICON = {
+    waiting: icon('#d29922'),
+    turn_ended: icon('#3fb950'),
+    '': icon('#30363d'),
+  };
+
+  document.addEventListener('visibilitychange', function () {
+    hiddenAt = document.hidden ? Date.now() : 0;
+  });
+
+  function alertable(s) {
+    // Stop fires at the end of *every* turn. Notifying on each one gets the
+    // whole feature muted inside a day, so it only speaks when the reader has
+    // actually been away — the case where they cannot already see it happen.
+    if (s === 'waiting') return true;
+    return s === 'turn_ended' && hiddenAt > 0 && Date.now() - hiddenAt > 60000;
+  }
+
+  function notify(s, body) {
+    if (!('Notification' in window) || Notification.permission !== 'granted') return;
+    if (!alertable(s)) return;
+    try {
+      new Notification(BASE, {body: body, tag: 'beril-' + BASE});
+    } catch (err) {}
+  }
+
+  function mark() {
+    const c = document.getElementById('d-state');
+    const d = document.getElementById('d-detail');
+    const s = c ? (c.dataset.state || '') : '';
+    const key = s + '|' + (c ? c.dataset.since : '');
+    document.title = (MARK[s] || '') + BASE;
+    if (F) F.href = ICON[s] || ICON[''];
+    if (B) B.hidden = !('Notification' in window) || Notification.permission !== 'default';
+    if (key === last) return;
+    if (s === 'waiting' && W) {
+      W.innerHTML = '<b>The agent is waiting for you.</b> ' + (d ? d.innerHTML : '');
+      W.hidden = false;
+      W.classList.remove('pulse');
+      void W.offsetWidth;
+      W.classList.add('pulse');
+    } else if (W) {
+      W.hidden = true;
+      W.innerHTML = '';
+    }
+    if (last !== null) notify(s, d ? d.textContent : '');
+    last = key;
+  }
+
+  if (B) {
+    B.addEventListener('click', function () {
+      Notification.requestPermission().then(function () {
+        B.hidden = true;
+      });
+    });
+  }
+
+  window.dashMark = mark;
+  mark();
+})();

--- a/tools/dashboard_assets/state.js
+++ b/tools/dashboard_assets/state.js
@@ -2,16 +2,10 @@
 // notification. Inlined into the page by tools/dashboard.py as STATE_JS, in
 // both transports; poll.js calls the exported `window.dashMark` after a swap.
 //
-// Everything here is client-side for the same reason relative times are: a 304
-// freezes whatever the server wrote, and this is the one readout whose whole
-// job is to be current. The server emits `#d-state` inside #root carrying
-// `data-state` and `data-since`; `mark()` reads them after every swap and
-// drives four things off them.
-//
-// Two channels reach a reader who is not looking at the page — the title marker
-// and the favicon — and they are the only two a browser gives a foreground tab.
-// A closed tab gets nothing without a service worker and a push service, which
-// a stdlib server inside a pod cannot be.
+// Client-side for the reason rel.js gives about a 304. The server emits
+// `#d-state` inside #root carrying `data-state` and `data-since`, plus an
+// optional `#d-detail`; that pair is the whole contract, and `mark()` reads it
+// after every swap and drives four things off it.
 //
 // `#d-detail` is agent-authored text, so it is *not* interpolated here. The
 // server renders it through the same `inline_md` -> `e()` path as the worklog
@@ -30,19 +24,23 @@
 // locals below out of the one scope this file shares with rel.js and poll.js.
 
 (function () {
-  const W = document.getElementById('d-wait');
-  const B = document.getElementById('d-alert');
-  const F = document.getElementById('d-favicon');
+  const strip = document.getElementById('d-wait');
+  const alertBtn = document.getElementById('d-alert');
+  const favicon = document.getElementById('d-favicon');
   const BASE = document.title;
   let last = null;
   let hiddenAt = document.hidden ? Date.now() : 0;
 
+  // Long enough that the reader really has left — and the same 60s Claude
+  // Code's own `idle_prompt` notification waits after a Stop.
+  const AWAY_MS = 60000;
+
   const MARK = {waiting: '\u25cf ', turn_ended: '\u2713 '};
 
-  function icon(c) {
+  function icon(fill) {
     return 'data:image/svg+xml,' + encodeURIComponent(
       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">' +
-      '<circle cx="8" cy="8" r="7" fill="' + c + '"/></svg>');
+      '<circle cx="8" cy="8" r="7" fill="' + fill + '"/></svg>');
   }
 
   const ICON = {
@@ -55,49 +53,55 @@
     hiddenAt = document.hidden ? Date.now() : 0;
   });
 
-  function alertable(s) {
+  function alertable(state) {
     // Stop fires at the end of *every* turn. Notifying on each one gets the
     // whole feature muted inside a day, so it only speaks when the reader has
     // actually been away — the case where they cannot already see it happen.
-    if (s === 'waiting') return true;
-    return s === 'turn_ended' && hiddenAt > 0 && Date.now() - hiddenAt > 60000;
+    if (state === 'waiting') return true;
+    return state === 'turn_ended' && hiddenAt > 0 && Date.now() - hiddenAt > AWAY_MS;
   }
 
-  function notify(s, body) {
+  function notify(state, body) {
     if (!('Notification' in window) || Notification.permission !== 'granted') return;
-    if (!alertable(s)) return;
+    if (!alertable(state)) return;
     try {
       new Notification(BASE, {body: body, tag: 'beril-' + BASE});
     } catch (err) {}
   }
 
   function mark() {
-    const c = document.getElementById('d-state');
-    const d = document.getElementById('d-detail');
-    const s = c ? (c.dataset.state || '') : '';
-    const key = s + '|' + (c ? c.dataset.since : '');
-    document.title = (MARK[s] || '') + BASE;
-    if (F) F.href = ICON[s] || ICON[''];
-    if (B) B.hidden = !('Notification' in window) || Notification.permission !== 'default';
-    if (key === last) return;
-    if (s === 'waiting' && W) {
-      W.innerHTML = '<b>The agent is waiting for you.</b> ' + (d ? d.innerHTML : '');
-      W.hidden = false;
-      W.classList.remove('pulse');
-      void W.offsetWidth;
-      W.classList.add('pulse');
-    } else if (W) {
-      W.hidden = true;
-      W.innerHTML = '';
+    const stateEl = document.getElementById('d-state');
+    const detailEl = document.getElementById('d-detail');
+    const state = stateEl ? (stateEl.dataset.state || '') : '';
+    const key = state + '|' + (stateEl ? stateEl.dataset.since : '');
+    document.title = (MARK[state] || '') + BASE;
+    if (favicon) favicon.href = ICON[state] || ICON[''];
+    if (alertBtn) {
+      alertBtn.hidden =
+        !('Notification' in window) || Notification.permission !== 'default';
     }
-    if (last !== null) notify(s, d ? d.textContent : '');
+    if (key === last) return;
+    if (state === 'waiting' && strip) {
+      strip.innerHTML = '<b>The agent is waiting for you.</b> ' +
+        (detailEl ? detailEl.innerHTML : '');
+      strip.hidden = false;
+      strip.classList.remove('pulse');
+      void strip.offsetWidth;  // forced reflow — the only way to restart the CSS animation
+      strip.classList.add('pulse');
+    } else if (strip) {
+      strip.hidden = true;
+      strip.innerHTML = '';
+    }
+    // Never on first paint: whatever state the page loaded with is not a
+    // transition, so announcing it would re-fire on every reload.
+    if (last !== null) notify(state, detailEl ? detailEl.textContent : '');
     last = key;
   }
 
-  if (B) {
-    B.addEventListener('click', function () {
+  if (alertBtn) {
+    alertBtn.addEventListener('click', function () {
       Notification.requestPermission().then(function () {
-        B.hidden = true;
+        alertBtn.hidden = true;
       });
     });
   }


### PR DESCRIPTION
## Summary
- Move the dashboard's inline CSS/JS into `tools/dashboard_assets/` (`dash.css`, `rel.js`, `state.js`, `poll.js`, `lightbox.js`), read at import and inlined by `render()` — no bundler/build step, per the design doc's constraints.
- Fix a CSS specificity bug where the figure gallery's thumbnails lost the width tie to the timeline's smaller thumbnail rule (`.d-links img` had to be ordered above `.d-figs img`).
- Simplify what `dash_stop.py`'s project resolution and `dashboard.py`'s scan/fingerprint extraction expose; defer a few imports (`shutil`, `argparse`) to cut statusline render cost.
- Re-measure and re-pin the `beril-runtime.sh` cost guard (was ~103ms/~16ms, now ~65ms/~8ms) with a real test asserting the interpreter doesn't start, replacing an unfalsifiable assertion.
- Add a `_reap_dashboards` autouse fixture in `tests/test_statusline.py` to kill dashboards spawned by tests, preventing port leaks across runs.
- Drop four dashboard tests that didn't earn their keep, folding their coverage into other tests.

## Testing
- `tests/test_dashboard.py` and `tests/test_statusline.py` updated with new/adjusted coverage, including a node-based harness that parses and exercises the extracted JS files as they're actually concatenated and inlined by `render()`.