### PR TITLE
fix(berdl): require TLS handshake in environment detection

### DIFF
--- a/scripts/berdl_inventory.py
+++ b/scripts/berdl_inventory.py
@@ -62,7 +62,6 @@ import hashlib
 import json
 import logging
 import os
-import socket
 import sys
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
@@ -89,6 +88,11 @@ _WATCHED_LOGGERS = ("berdl_notebook_utils", "berdl_inventory.structure")
 # (the parent of the scripts/ directory) so the path is stable regardless of
 # the user's CWD when invoking the script.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+# Run as `python scripts/berdl_inventory.py`, sys.path[0] is scripts/, not the
+# repo root, so `import scripts.*` fails. Same guard berdl_env.py uses.
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 _DEFAULT_OUTPUT = _REPO_ROOT / "data" / "berdl_inventory.md"
 
 _DEFAULT_CACHE = _REPO_ROOT / "data" / "berdl_inventory_cache.json"
@@ -347,11 +351,9 @@ def _iceberg_only(structure: dict[str, list[str]]) -> dict[str, list[str]]:
 
 def _is_on_cluster(host: str = "spark.berdl.kbase.us", port: int = 443, timeout: float = 2.0) -> bool:
     """Same connectivity probe scripts/detect_berdl_environment.py uses."""
-    try:
-        with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except (socket.timeout, OSError):
-        return False
+    from scripts.detect_berdl_environment import test_connectivity
+
+    return test_connectivity(host, port, timeout=timeout)
 
 
 def fetch_structure_on_cluster() -> dict[str, list[str]]:

--- a/scripts/detect_berdl_environment.py
+++ b/scripts/detect_berdl_environment.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import socket
+import ssl
 import subprocess
 import sys
 from pathlib import Path
@@ -17,11 +18,26 @@ from typing import Any
 
 
 def test_connectivity(host: str, port: int, timeout: float = 2.0) -> bool:
-    """Test if a host:port is reachable."""
+    """Test if a TLS endpoint at host:port actually answers.
+
+    A bare TCP connect is not enough: a TCP-terminating middlebox on the client's
+    path (VPN, corporate proxy, filtering agent) answers the SYN for port 443
+    itself, so connect() succeeds against hosts that are not actually reachable
+    and detection reported "on-cluster" from a laptop. A TLS handshake is
+    end-to-end and still fails when the service is genuinely unreachable.
+
+    Certificate verification is off on purpose — the endpoint's cert SAN does not
+    match every *.berdl.kbase.us name we probe, and we only care that a real
+    server answered. A TLS-intercepting proxy could still fool this.
+    """
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
     try:
-        with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except (socket.timeout, socket.error, OSError):
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            with ctx.wrap_socket(sock, server_hostname=host):
+                return True
+    except (OSError, ssl.SSLError):
         return False
 
 

--- a/tests/scripts/test_berdl_env.py
+++ b/tests/scripts/test_berdl_env.py
@@ -1,6 +1,7 @@
 """Tests for scripts/berdl_env.py."""
 from __future__ import annotations
 
+import contextlib
 import json
 import subprocess
 import sys
@@ -144,3 +145,39 @@ def test_require_environment_returns_env_when_ready(monkeypatch):
         env = require_environment()
         assert env.location == "on-cluster"
         assert env.checks["spark_direct"] is True
+
+
+def test_connectivity_rejects_tcp_only_endpoint():
+    """A host that accepts TCP but never speaks TLS is not "reachable".
+
+    Models a TCP-terminating middlebox (VPN, proxy, filtering agent) on the
+    client's path: it answers the SYN itself, so a bare connect() probe reported
+    the Spark endpoint as reachable — and detection as "on-cluster" — from any
+    laptop sitting behind one.
+    """
+    import socket
+    import threading
+
+    from scripts.detect_berdl_environment import test_connectivity
+
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+
+    stop = threading.Event()
+
+    def accept_and_stall():
+        with contextlib.suppress(OSError):
+            conn, _ = listener.accept()
+            stop.wait(2.0)
+            conn.close()
+
+    thread = threading.Thread(target=accept_and_stall, daemon=True)
+    thread.start()
+    try:
+        assert test_connectivity("127.0.0.1", port, timeout=0.5) is False
+    finally:
+        stop.set()
+        listener.close()
+        thread.join(timeout=2.0)


### PR DESCRIPTION
## Summary

`test_connectivity` used a bare `socket.create_connection()`, which reports success against hosts that are not actually reachable — so environment detection said `on-cluster` from a laptop. It now completes a TLS handshake (`ssl.CERT_NONE`) and only returns `True` if a real server answers.

`_is_on_cluster` in `scripts/berdl_inventory.py` delegates to that helper instead of duplicating the old probe, and gains the repo-root `sys.path` guard `berdl_env.py` already uses — without it, `import scripts.*` raises `ModuleNotFoundError` under the documented `python scripts/berdl_inventory.py` invocation.

## Why now

This is a client-side condition, not a change at `berdl.kbase.us`. A TCP-terminating middlebox on the client's path (VPN, corporate proxy, filtering agent) answers the SYN for port 443 itself and only reaches upstream afterwards, so `connect()` succeeds for any routable host regardless of whether the service is reachable. The Spark endpoint most likely was never reachable off-cluster; the bare-TCP probe simply started returning `True` for everything. A TLS handshake is end-to-end, so it still fails when the service is genuinely unreachable.

## Known limits

- **Unverified on-cluster.** This assumes the Spark endpoint completes a TLS handshake from inside the cluster. `spark_connect_remote` connects with `use_ssl=True` on 443, so it almost certainly does — but if the in-cluster route is plaintext gRPC, this now false-negatives to `off-cluster`. One run of `python scripts/detect_berdl_environment.py` on JupyterHub confirms it. **Please check before merging.**
- **Cost:** off-cluster detection now always spends ~2 s on the doomed handshake (was instant). It is Step 0 for every BERDL skill.
- Cert verification is off, so a TLS-*intercepting* proxy could still fool the probe. Catching that would mean validating the cert chain.

## Testing

- Added `test_connectivity_rejects_tcp_only_endpoint` in `tests/scripts/test_berdl_env.py`: a local listener that accepts TCP but never speaks TLS, asserting `test_connectivity` returns `False`.
- `pytest tests/scripts` — 90 passed.
- Verified `_is_on_cluster` under a real `python scripts/berdl_inventory.py` invocation (fails with `ModuleNotFoundError` without the `sys.path` guard).
- End-to-end: `python scripts/detect_berdl_environment.py` now reports `off-cluster` from a local machine; the pre-fix probe returns `True` on the same machine.
