### PR TITLE
Default Claude to Opus 1M context with auto permission mode

### DIFF
--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -420,7 +420,8 @@ def run_setup() -> int:
                 os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = vertex_cfg.get("credentials_file", "")
                 os.environ["VERTEX_REGION_CLAUDE_HAIKU_4_5"] = "us-east5"
                 os.environ["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
-            os.execvp(binary, [chosen, "--model", "opus", "/berdl_start"])
+            claude_flags = ["--permission-mode", "auto"] if chosen == "claude" else []
+            os.execvp(binary, [chosen, "--model", "opus", *claude_flags, "/berdl_start"])
         else:
             print(f"  Error: '{chosen}' not found on PATH.", file=sys.stderr)
             return 1

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from beril_cli import config
 from beril_cli.detect import detect_user_identity, print_jupyterhub_path_hint
+from beril_cli.start import claude_defaults
 
 
 def _find_repo_root() -> Path | None:
@@ -420,9 +421,8 @@ def run_setup() -> int:
                 os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = vertex_cfg.get("credentials_file", "")
                 os.environ["VERTEX_REGION_CLAUDE_HAIKU_4_5"] = "us-east5"
                 os.environ["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
-            claude_flags = ["--permission-mode", "auto"] if chosen == "claude" else []
-            model = "opus[1m]" if chosen == "claude" else "opus"
-            os.execvp(binary, [chosen, "--model", model, *claude_flags, "/berdl_start"])
+            flags = claude_defaults(chosen, []) or ["--model", "opus"]
+            os.execvp(binary, [chosen, *flags, "/berdl_start"])
         else:
             print(f"  Error: '{chosen}' not found on PATH.", file=sys.stderr)
             return 1

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -421,7 +421,8 @@ def run_setup() -> int:
                 os.environ["VERTEX_REGION_CLAUDE_HAIKU_4_5"] = "us-east5"
                 os.environ["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
             claude_flags = ["--permission-mode", "auto"] if chosen == "claude" else []
-            os.execvp(binary, [chosen, "--model", "opus", *claude_flags, "/berdl_start"])
+            model = "opus[1m]" if chosen == "claude" else "opus"
+            os.execvp(binary, [chosen, "--model", model, *claude_flags, "/berdl_start"])
         else:
             print(f"  Error: '{chosen}' not found on PATH.", file=sys.stderr)
             return 1

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -211,6 +211,10 @@ def run_start(
     if agent == "claude" and "--model" not in extra_args:
         extra_args = ["--model", "opus", *extra_args]
 
+    # Default to auto permission mode for Claude
+    if agent == "claude" and "--permission-mode" not in extra_args:
+        extra_args = ["--permission-mode", "auto", *extra_args]
+
     print(f"Launching {agent}...")
     print_jupyterhub_path_hint(repo_root)
     # Replace the current process with the agent

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -207,9 +207,9 @@ def run_start(
                     file=sys.stderr,
                 )
 
-    # Default to Opus model for Claude
+    # Default to Opus with the 1M-token context window for Claude
     if agent == "claude" and "--model" not in extra_args:
-        extra_args = ["--model", "opus", *extra_args]
+        extra_args = ["--model", "opus[1m]", *extra_args]
 
     # Default to auto permission mode for Claude
     if agent == "claude" and "--permission-mode" not in extra_args:

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -149,6 +149,21 @@ def _checkout_release(repo_root: Path, requested_version: str | None) -> int:
     return 0
 
 
+def claude_defaults(agent: str, extra_args: list[str]) -> list[str]:
+    """Default flags for Claude: Opus with the 1M context window, auto permissions.
+
+    Returns nothing for other agents, and skips any flag the caller already set.
+    """
+    if agent != "claude":
+        return []
+    flags: list[str] = []
+    if "--model" not in extra_args:
+        flags += ["--model", "opus[1m]"]
+    if "--permission-mode" not in extra_args:
+        flags += ["--permission-mode", "auto"]
+    return flags
+
+
 def run_start(
     agent: str | None = None,
     extra_args: list[str] | None = None,
@@ -207,13 +222,7 @@ def run_start(
                     file=sys.stderr,
                 )
 
-    # Default to Opus with the 1M-token context window for Claude
-    if agent == "claude" and "--model" not in extra_args:
-        extra_args = ["--model", "opus[1m]", *extra_args]
-
-    # Default to auto permission mode for Claude
-    if agent == "claude" and "--permission-mode" not in extra_args:
-        extra_args = ["--permission-mode", "auto", *extra_args]
+    extra_args = [*claude_defaults(agent, extra_args), *extra_args]
 
     print(f"Launching {agent}...")
     print_jupyterhub_path_hint(repo_root)

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -362,3 +362,21 @@ def test_explicit_permission_mode_is_not_overridden(monkeypatch, tmp_path):
 def test_claude_defaults_to_opus_1m_context(monkeypatch, tmp_path):
     argv = _exec_argv(monkeypatch, tmp_path)
     assert argv[argv.index("--model") + 1] == "opus[1m]"
+
+
+def test_claude_defaults_only_apply_to_claude():
+    assert start.claude_defaults("codex", []) == []
+    assert start.claude_defaults("claude", []) == [
+        "--model",
+        "opus[1m]",
+        "--permission-mode",
+        "auto",
+    ]
+    assert start.claude_defaults("claude", ["--model", "sonnet"]) == [
+        "--permission-mode",
+        "auto",
+    ]
+    assert start.claude_defaults("claude", ["--permission-mode", "plan"]) == [
+        "--model",
+        "opus[1m]",
+    ]

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -357,3 +357,8 @@ def test_explicit_permission_mode_is_not_overridden(monkeypatch, tmp_path):
     argv = _exec_argv(monkeypatch, tmp_path, extra_args=["--permission-mode", "plan"])
     assert argv.count("--permission-mode") == 1
     assert argv[argv.index("--permission-mode") + 1] == "plan"
+
+
+def test_claude_defaults_to_opus_1m_context(monkeypatch, tmp_path):
+    argv = _exec_argv(monkeypatch, tmp_path)
+    assert argv[argv.index("--model") + 1] == "opus[1m]"

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -319,3 +319,41 @@ def test_non_dev_mode_does_check_out_release(monkeypatch, tmp_path):
         start.run_start(agent="claude", version="v0.0.1", dev_mode=False)
 
     assert checkout_calls == ["v0.0.1"]
+
+
+# ── permission mode ───────────────────────────────────────
+
+
+def _exec_argv(monkeypatch, tmp_path, **kwargs) -> list[str]:
+    """Run run_start up to the exec and return the argv it would have exec'd."""
+    _patch_run(monkeypatch, lambda argv: _completed())
+    monkeypatch.setattr(start.shutil, "which", lambda _agent: "/usr/bin/claude")
+    monkeypatch.setattr(start, "_find_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(start.os, "chdir", lambda _path: None)
+    monkeypatch.setattr(start, "print_jupyterhub_path_hint", lambda _root: None)
+    monkeypatch.setattr(start, "get_default_agent", lambda: "claude")
+    monkeypatch.setattr(start, "get_vertex_config", lambda: {"enabled": False})
+
+    captured: list[str] = []
+
+    def _boom(_binary, argv):
+        captured.extend(argv)
+        raise _ExecvpReached
+
+    monkeypatch.setattr(start.os, "execvp", _boom)
+
+    with pytest.raises(_ExecvpReached):
+        start.run_start(agent="claude", dev_mode=True, **kwargs)
+    return captured
+
+
+def test_claude_launches_in_auto_permission_mode(monkeypatch, tmp_path):
+    argv = _exec_argv(monkeypatch, tmp_path)
+    assert "--permission-mode" in argv
+    assert argv[argv.index("--permission-mode") + 1] == "auto"
+
+
+def test_explicit_permission_mode_is_not_overridden(monkeypatch, tmp_path):
+    argv = _exec_argv(monkeypatch, tmp_path, extra_args=["--permission-mode", "plan"])
+    assert argv.count("--permission-mode") == 1
+    assert argv[argv.index("--permission-mode") + 1] == "plan"


### PR DESCRIPTION
## Summary
- Launch Claude Code with the `opus[1m]` model (1M-token context window) instead of plain `opus`
- Default Claude Code to `--permission-mode auto` when not explicitly overridden, both in `beril_cli/start.py` and the `beril_cli/setup_cmd.py` exec path
- Other CLI agents are unaffected (permission flags and model string only apply when `chosen`/`agent` is `claude`)

## Testing
- Added `test_claude_launches_in_auto_permission_mode`, `test_explicit_permission_mode_is_not_overridden`, and `test_claude_defaults_to_opus_1m_context` to `tests/test_cli_start.py`