### PR TITLE
chore: enable Claude Code thinking summaries

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "showThinkingSummaries": true,
   "permissions": {
     "defaultMode": "auto"
   },


### PR DESCRIPTION
## What

Sets `"showThinkingSummaries": true` in `.claude/settings.json`.

## Why

For future benchmarking purposes.

Claude Code defaults this setting to `false`, which makes it send the API
`thinking.display` parameter as `"omitted"` on current models. The result is
that thinking blocks in session transcripts come back **empty** — so we can't
inspect model reasoning when comparing agent runs.

Turning it on requests API-side thinking summaries and records them in the
conversation and in the transcript view (`ctrl+o`).

Setting it at project scope (rather than in each person's
`~/.claude/settings.json`) means benchmarking runs capture reasoning traces for
every contributor by default.

## Notes

- Verified against the setting's schema in Claude Code 2.1.220: *"Request
  API-side thinking summaries and show them in the conversation and in the
  transcript view (ctrl+o). Set explicitly to override the default for your
  install."*
- Requires a Claude Code restart to take effect.
- **Headless runs are not covered by this.** The setting is only consulted for
  interactive sessions; `claude -p` with `--output-format text`, or `json`
  without `--verbose`, still resolves to `"omitted"`. Scripted benchmark
  harnesses need `--thinking-display summarized` passed explicitly.
- Anyone who wants this off locally can override it in their gitignored
  `.claude/settings.local.json`.
