### PR TITLE
fix(hooks): resolve hook paths against the project root, not cwd

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash .claude/statusline.sh"
+    "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/statusline.sh\""
   },
   "hooks": {
     "SessionStart": [
@@ -12,7 +12,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/beril-runtime.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/beril-runtime.sh\""
           }
         ]
       }
@@ -43,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/beril-runtime.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/beril-runtime.sh\""
           }
         ]
       },
@@ -61,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/agent_state.py"
+            "command": "sh -c 'cd \"${CLAUDE_PROJECT_DIR:-.}\" 2>/dev/null; python3 .claude/hooks/agent_state.py'"
           }
         ]
       }
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/agent_state.py"
+            "command": "sh -c 'cd \"${CLAUDE_PROJECT_DIR:-.}\" 2>/dev/null; python3 .claude/hooks/agent_state.py'"
           }
         ]
       }
@@ -81,7 +81,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/agent_state.py"
+            "command": "sh -c 'cd \"${CLAUDE_PROJECT_DIR:-.}\" 2>/dev/null; python3 .claude/hooks/agent_state.py'"
           }
         ]
       }
@@ -91,7 +91,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/agent_state.py"
+            "command": "sh -c 'cd \"${CLAUDE_PROJECT_DIR:-.}\" 2>/dev/null; python3 .claude/hooks/agent_state.py'"
           }
         ]
       }
@@ -101,7 +101,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/dash_stop.py"
+            "command": "sh -c 'cd \"${CLAUDE_PROJECT_DIR:-.}\" 2>/dev/null; python3 .claude/hooks/dash_stop.py'"
           }
         ]
       }


### PR DESCRIPTION
Reported from a real BERDL session — every `Stop` fired:

```
python3: can't open file '/home/<user>/BERIL-pr-371/projects/
pangenome_pathway_ecology/.claude/hooks/agent_state.py'
```

## Cause

Claude Code runs hooks with cwd set to the session's working directory, not the project root. A bare `.claude/hooks/...` therefore resolves under whatever project subdirectory the session started in. On a repo-root Mac session the two coincide and the bug is invisible; on the hub, where sessions start inside `projects/<id>/`, every one of these hooks was dead.

Nothing failed loudly because a missing hook is non-blocking — Claude Code catches the exit 2, prints a warning, and carries on. The user-visible symptom was the waiting strip never clearing: the `PostToolUse` clear (cd-guarded since 308581a7, for unrelated perf reasons) worked while the `Stop` write did not.

`$CLAUDE_PROJECT_DIR` was already used correctly for `plan-gate.py` as of 3ec304a3 — one day before cca76b59 added the four `agent_state.py` hooks directly beneath it without picking it up.

## Change

All seven remaining entries in `.claude/settings.json`:

- `statusline.sh` and both `beril-runtime.sh` hooks → `$CLAUDE_PROJECT_DIR/` prefix
- the four `agent_state.py` hooks and `dash_stop.py` → `cd "${CLAUDE_PROJECT_DIR:-.}"` form

The python3 hooks get the `cd` form rather than an absolute script path because the scripts also glob `projects/*/` relative to cwd — fixing only the path would launch them against the wrong directory, trading a loud failure for a silent one. This matches the guard already on the `PostToolUse` entry.

## Verification

Reproduced locally by running both forms from a project subdirectory: **exit 2** with the reported error before, **exit 0** after. JSON parses, all 11 hook commands shell-parse, no bare relative paths remain, and all 5 referenced scripts exist. 64 tests pass across `test_agent_state.py`, `test_statusline.py`, `test_plan_gate.py`, `test_skill_wiring.py`.

Note this bug is present on `main` — `.claude/settings.json` was byte-identical between `main` and `beril-submit-to-ov`, and all originating hook commits are already merged. Not a feature-branch regression.

Still untested: whether `beril_cli.project_resolution` imports cleanly under the hub's `python3`. The path fix makes these hooks *launch* on BERDL; that import is a separate question, and per @briehl the interpreter is fine there for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)