### PR TITLE
Add omp to supported coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To use Claude Code you will need an API key. If you are Berkeley Lab staff, you 
 ### Prerequisites
 
 - A KBase account with BERDL access (see [Getting BERDL Access](#getting-berdl-access))
-- [Claude Code](https://claude.ai/claude-code) installed (or another supported agent e.g. codex)
+- [Claude Code](https://claude.ai/claude-code) installed (or another supported agent: `codex`, `gemini`, `omp`)
 - Python 3.11+
 - Git
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cp .env.example .env
 # from .env automatically. If your token is ever exposed, delete it immediately
 # from the JupyterHub token management page and generate a new one.
 
-# 3. Open Claude Code in the repo
+# 3. Open your agent in the repo (claude, codex, gemini or omp)
 claude
 ```
 
@@ -131,7 +131,7 @@ Skills are invoked automatically based on context, or explicitly with `/skill-na
 | **LinkML Schema** | `/linkml-schema` | Generate LinkML schema from markdown, Excel, or plain text |
 | **Phenix** | `/phenix` | Structural biology workflows — AlphaFold, X-ray, cryo-EM, MolProbity |
 
-BERIL CLI commands (`beril doctor`, `beril setup`, `beril start`) handle environment management outside the agent session. Multi-agent support (Codex, Gemini) is planned.
+BERIL CLI commands (`beril doctor`, `beril setup`, `beril start`) handle environment management outside the agent session. `beril start --agent <name>` launches Claude Code, Codex, Gemini CLI or omp.
 
 ---
 

--- a/beril_cli/cli.py
+++ b/beril_cli/cli.py
@@ -3,10 +3,11 @@
 import argparse
 import sys
 
-from beril_cli import __version__
+from beril_cli import __version__, config
 
 
-def main(argv: list[str] | None = None) -> int:
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI parser. Split out from main() so it can be tested."""
     parser = argparse.ArgumentParser(
         prog="beril",
         description="BERIL Research Observatory — setup, check, and launch your research environment.",
@@ -25,7 +26,7 @@ def main(argv: list[str] | None = None) -> int:
     start_parser = sub.add_parser("start", help="Launch a coding agent")
     start_parser.add_argument(
         "--agent",
-        choices=["claude", "codex", "gemini"],
+        choices=list(config.SUPPORTED_AGENTS),
         default=None,
         help="Agent to launch (default: from config, or claude)",
     )
@@ -54,6 +55,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Emit machine-readable JSON",
     )
 
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
     args, remaining = parser.parse_known_args(argv)
 
     if args.command is None:

--- a/beril_cli/config.py
+++ b/beril_cli/config.py
@@ -16,6 +16,19 @@ SUPPORTED_AGENTS: tuple[str, ...] = ("claude", "codex", "gemini", "omp")
 DEFAULT_AGENT = "claude"
 
 
+def launch_argv(agent: str, *args: str) -> list[str]:
+    """Build the argv used to exec `agent`.
+
+    `--model opus` is Anthropic-specific, so it is pinned for Claude only:
+    codex, gemini and omp either reject it or resolve it to something
+    unintended. An explicit `--model` from the caller always wins.
+    """
+    extra = list(args)
+    if agent == "claude" and "--model" not in extra:
+        return [agent, "--model", "opus", *extra]
+    return [agent, *extra]
+
+
 def load() -> dict[str, Any]:
     """Load user config. Returns empty dict if file doesn't exist."""
     if not CONFIG_PATH.exists():

--- a/beril_cli/config.py
+++ b/beril_cli/config.py
@@ -9,6 +9,12 @@ from typing import Any
 CONFIG_DIR = Path.home() / ".config" / "beril"
 CONFIG_PATH = CONFIG_DIR / "config.toml"
 
+# Coding agents `beril start` can launch. Kept here so the CLI parser, the
+# setup wizard, and doctor all agree on one list.
+SUPPORTED_AGENTS: tuple[str, ...] = ("claude", "codex", "gemini", "omp")
+
+DEFAULT_AGENT = "claude"
+
 
 def load() -> dict[str, Any]:
     """Load user config. Returns empty dict if file doesn't exist."""
@@ -60,7 +66,7 @@ def save(cfg: dict[str, Any]) -> None:
 def get_default_agent() -> str:
     """Return the user's default agent, or 'claude' as fallback."""
     cfg = load()
-    return cfg.get("defaults", {}).get("agent", "claude")
+    return cfg.get("defaults", {}).get("agent", DEFAULT_AGENT)
 
 
 def get_vertex_config() -> dict[str, Any]:

--- a/beril_cli/doctor.py
+++ b/beril_cli/doctor.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from beril_cli import config
+
 
 def _find_repo_root() -> Path | None:
     """Walk up from cwd looking for PROJECT.md (repo marker)."""
@@ -111,13 +113,15 @@ def run_doctor() -> int:
 
     # 6. Agent CLIs
     agents_found = []
-    for agent in ("claude", "codex", "gemini"):
+    for agent in config.SUPPORTED_AGENTS:
         if shutil.which(agent):
             agents_found.append(agent)
     if agents_found:
         checks.append(("Agent CLIs", "PASS", ", ".join(agents_found)))
     else:
-        checks.append(("Agent CLIs", "WARN", "none found (claude, codex, gemini)"))
+        checks.append(
+            ("Agent CLIs", "WARN", f"none found ({', '.join(config.SUPPORTED_AGENTS)})")
+        )
 
     # 7. BERDL environment
     if repo_root:

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -300,10 +300,7 @@ def run_setup() -> int:
                 os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = vertex_cfg.get("credentials_file", "")
                 os.environ["VERTEX_REGION_CLAUDE_HAIKU_4_5"] = "us-east5"
                 os.environ["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
-            # `--model opus` is Anthropic-specific; other agents reject or
-            # mis-resolve it. Only Claude gets the model pin.
-            model_args = ["--model", "opus"] if chosen == "claude" else []
-            os.execvp(binary, [chosen, *model_args, "/berdl_start"])
+            os.execvp(binary, config.launch_argv(chosen, "/berdl_start"))
         else:
             print(f"  Error: '{chosen}' not found on PATH.", file=sys.stderr)
             return 1

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -226,14 +226,15 @@ def run_setup() -> int:
     _step(7, "Coding agent")
 
     agents_found: list[str] = []
-    for agent in ("claude", "codex", "gemini"):
+    for agent in config.SUPPORTED_AGENTS:
         if shutil.which(agent):
             agents_found.append(agent)
 
+    supported = ", ".join(config.SUPPORTED_AGENTS)
     if agents_found:
         print(f"  Detected: {', '.join(agents_found)}")
     else:
-        print("  No agents detected (claude, codex, gemini).")
+        print(f"  No agents detected ({supported}).")
         print("  Install one and re-run setup, or use beril start --agent <name>.")
 
     default_agent = existing_cfg.get("defaults", {}).get("agent", "")
@@ -245,7 +246,7 @@ def run_setup() -> int:
         if chosen not in agents_found:
             print(f"  Warning: '{chosen}' was not detected on PATH.")
     else:
-        chosen = default_agent or "claude"
+        chosen = default_agent or config.DEFAULT_AGENT
 
     # ── Step 8: BERIL Anthropic key (Google Vertex) ──
     vertex_cfg: dict = {}
@@ -299,7 +300,10 @@ def run_setup() -> int:
                 os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = vertex_cfg.get("credentials_file", "")
                 os.environ["VERTEX_REGION_CLAUDE_HAIKU_4_5"] = "us-east5"
                 os.environ["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
-            os.execvp(binary, [chosen, "--model", "opus", "/berdl_start"])
+            # `--model opus` is Anthropic-specific; other agents reject or
+            # mis-resolve it. Only Claude gets the model pin.
+            model_args = ["--model", "opus"] if chosen == "claude" else []
+            os.execvp(binary, [chosen, *model_args, "/berdl_start"])
         else:
             print(f"  Error: '{chosen}' not found on PATH.", file=sys.stderr)
             return 1

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -12,6 +12,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from beril_cli import config
 from beril_cli.config import get_default_agent, get_vertex_config
 from beril_cli.detect import print_jupyterhub_path_hint
 
@@ -205,14 +206,11 @@ def run_start(
                     file=sys.stderr,
                 )
 
-    # Default to Opus model for Claude
-    if agent == "claude" and "--model" not in extra_args:
-        extra_args = ["--model", "opus", *extra_args]
-
     print(f"Launching {agent}...")
     print_jupyterhub_path_hint(repo_root)
-    # Replace the current process with the agent
-    os.execvp(binary, [agent, *extra_args])
+    # Replace the current process with the agent. launch_argv pins Opus for
+    # Claude only; see config.launch_argv.
+    os.execvp(binary, config.launch_argv(agent, *extra_args))
 
     # execvp doesn't return on success; this is only reached on failure
     return 1  # pragma: no cover

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -1,0 +1,99 @@
+"""Tests for the supported-agent list shared by the CLI parser, setup, and doctor."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from beril_cli import cli, config, doctor, setup_cmd
+
+
+# ── config.SUPPORTED_AGENTS ────────────────────────────
+
+
+def test_omp_is_supported():
+    """omp is launchable alongside the other agents."""
+    assert "omp" in config.SUPPORTED_AGENTS
+
+
+def test_default_agent_is_in_supported_list():
+    """The fallback agent must itself be launchable."""
+    assert config.DEFAULT_AGENT in config.SUPPORTED_AGENTS
+
+
+def test_supported_agents_is_immutable():
+    """A tuple, so callers cannot mutate the shared list in place."""
+    assert isinstance(config.SUPPORTED_AGENTS, tuple)
+
+
+# ── cli.py argument parsing ────────────────────────────
+
+
+@pytest.mark.parametrize("agent", config.SUPPORTED_AGENTS)
+def test_start_parser_accepts_every_supported_agent(agent):
+    """`beril start --agent X` parses for every agent we claim to support."""
+    args = cli.build_parser().parse_args(["start", "--agent", agent])
+    assert args.agent == agent
+
+
+def test_start_parser_rejects_unknown_agent():
+    """An agent outside the list is a parse error, not a late failure."""
+    with pytest.raises(SystemExit):
+        cli.build_parser().parse_args(["start", "--agent", "definitely-not-an-agent"])
+
+
+# ── doctor.py ──────────────────────────────────────────
+
+
+def test_doctor_detects_omp(monkeypatch, capsys):
+    """doctor reports omp when it is the only agent on PATH."""
+    monkeypatch.setattr(
+        doctor.shutil,
+        "which",
+        lambda name: "/usr/local/bin/omp" if name == "omp" else None,
+    )
+    doctor.run_doctor()
+    out = capsys.readouterr().out
+    assert "omp" in out
+
+
+def test_doctor_lists_omp_when_no_agent_found(monkeypatch, capsys):
+    """The 'none found' hint must name omp, so users know it is an option."""
+    monkeypatch.setattr(doctor.shutil, "which", lambda _name: None)
+    doctor.run_doctor()
+    assert "omp" in capsys.readouterr().out
+
+
+# ── setup_cmd.py launch flags ──────────────────────────
+
+
+def test_setup_cmd_guards_the_opus_model_pin():
+    """`--model opus` is Anthropic-specific and must not leak to other agents.
+
+    Regression guard: setup_cmd previously passed it unconditionally, so
+    launching codex/gemini/omp from `beril setup` handed them a flag they do
+    not understand. start.py already gated this; setup_cmd did not.
+    """
+    src = inspect.getsource(setup_cmd.run_setup)
+    assert 'if chosen == "claude" else []' in src, (
+        "setup_cmd must not pass --model opus unconditionally"
+    )
+
+
+def test_start_guards_the_opus_model_pin():
+    """The same gate exists on the `beril start` path."""
+    from beril_cli import start
+
+    src = inspect.getsource(start.run_start)
+    assert 'agent == "claude"' in src
+
+
+# ── shared-list wiring ─────────────────────────────────
+
+
+@pytest.mark.parametrize("module", [setup_cmd, doctor, cli])
+def test_modules_use_the_shared_agent_list(module):
+    """No module may keep a private copy of the agent list."""
+    src = inspect.getsource(module)
+    assert "SUPPORTED_AGENTS" in src, f"{module.__name__} has its own agent list"

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import inspect
 
 import pytest
 
-from beril_cli import cli, config, doctor, setup_cmd
+from beril_cli import cli, config, doctor
 
 
 # ── config.SUPPORTED_AGENTS ────────────────────────────
@@ -22,9 +21,35 @@ def test_default_agent_is_in_supported_list():
     assert config.DEFAULT_AGENT in config.SUPPORTED_AGENTS
 
 
-def test_supported_agents_is_immutable():
-    """A tuple, so callers cannot mutate the shared list in place."""
-    assert isinstance(config.SUPPORTED_AGENTS, tuple)
+def test_supported_agents_cannot_be_mutated_by_callers():
+    """A caller cannot append to the shared list and affect everyone else."""
+    with pytest.raises((AttributeError, TypeError)):
+        config.SUPPORTED_AGENTS.append("rogue-agent")  # type: ignore[attr-defined]
+
+
+# ── config.launch_argv ─────────────────────────────────
+
+
+def test_claude_gets_the_opus_pin():
+    assert config.launch_argv("claude", "/berdl_start") == [
+        "claude",
+        "--model",
+        "opus",
+        "/berdl_start",
+    ]
+
+
+@pytest.mark.parametrize("agent", ["codex", "gemini", "omp"])
+def test_non_claude_agents_never_get_the_opus_pin(agent):
+    """`--model opus` is Anthropic-specific and must not leak to other agents."""
+    assert config.launch_argv(agent, "/berdl_start") == [agent, "/berdl_start"]
+
+
+def test_explicit_model_is_not_overridden():
+    """A caller-supplied --model wins over the Claude default."""
+    argv = config.launch_argv("claude", "--model", "sonnet", "/berdl_start")
+    assert argv == ["claude", "--model", "sonnet", "/berdl_start"]
+    assert "opus" not in argv
 
 
 # ── cli.py argument parsing ────────────────────────────
@@ -46,54 +71,116 @@ def test_start_parser_rejects_unknown_agent():
 # ── doctor.py ──────────────────────────────────────────
 
 
-def test_doctor_detects_omp(monkeypatch, capsys):
-    """doctor reports omp when it is the only agent on PATH."""
+def _agent_row(capsys) -> str:
+    """Return the 'Agent CLIs' line from doctor's output."""
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if "Agent CLIs" in ln]
+    assert lines, "doctor printed no Agent CLIs row"
+    return lines[0]
+
+
+def test_doctor_passes_when_only_omp_is_installed(monkeypatch, capsys):
+    """omp alone satisfies the agent check, and is named in the row."""
     monkeypatch.setattr(
         doctor.shutil,
         "which",
         lambda name: "/usr/local/bin/omp" if name == "omp" else None,
     )
     doctor.run_doctor()
-    out = capsys.readouterr().out
-    assert "omp" in out
+    row = _agent_row(capsys)
+    assert "PASS" in row
+    assert "omp" in row
+    assert "claude" not in row
 
 
-def test_doctor_lists_omp_when_no_agent_found(monkeypatch, capsys):
-    """The 'none found' hint must name omp, so users know it is an option."""
+def test_doctor_warns_and_names_omp_when_nothing_installed(monkeypatch, capsys):
+    """The 'none found' hint must name omp so users know it is an option."""
     monkeypatch.setattr(doctor.shutil, "which", lambda _name: None)
     doctor.run_doctor()
-    assert "omp" in capsys.readouterr().out
+    row = _agent_row(capsys)
+    assert "WARN" in row
+    assert "omp" in row
 
 
 # ── setup_cmd.py launch flags ──────────────────────────
 
 
-def test_setup_cmd_guards_the_opus_model_pin():
-    """`--model opus` is Anthropic-specific and must not leak to other agents.
+def _fake_repo(tmp_path, monkeypatch):
+    """Minimal repo `run_start` will accept: PROJECT.md marker plus a .env."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "PROJECT.md").write_text("")
+    (repo / ".env").write_text("")
+    monkeypatch.chdir(repo)
+    return repo
 
-    Regression guard: setup_cmd previously passed it unconditionally, so
-    launching codex/gemini/omp from `beril setup` handed them a flag they do
-    not understand. start.py already gated this; setup_cmd did not.
+
+@pytest.mark.parametrize("agent", ["codex", "gemini", "omp"])
+def test_start_does_not_pass_opus_to_non_claude(tmp_path, monkeypatch, agent):
+    """End-to-end through run_start: non-Claude agents get a clean argv.
+
+    Regression guard for the real bug: `--model opus` used to be appended
+    regardless of which agent was launched.
     """
-    src = inspect.getsource(setup_cmd.run_setup)
-    assert 'if chosen == "claude" else []' in src, (
-        "setup_cmd must not pass --model opus unconditionally"
-    )
-
-
-def test_start_guards_the_opus_model_pin():
-    """The same gate exists on the `beril start` path."""
     from beril_cli import start
 
-    src = inspect.getsource(start.run_start)
-    assert 'agent == "claude"' in src
+    _fake_repo(tmp_path, monkeypatch)
+    monkeypatch.setattr(start.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(start, "_checkout_release", lambda *_a, **_kw: 0)
+    monkeypatch.setattr(start, "print_jupyterhub_path_hint", lambda *_a: None)
+
+    captured: dict = {}
+    monkeypatch.setattr(start.os, "execvp", lambda _b, argv: captured.update(argv=argv))
+
+    start.run_start(agent=agent)
+
+    assert captured["argv"] == [agent, "/berdl_start"]
+
+
+def test_start_does_pass_opus_to_claude(tmp_path, monkeypatch):
+    """The Claude path keeps its Opus pin."""
+    from beril_cli import start
+
+    _fake_repo(tmp_path, monkeypatch)
+    monkeypatch.setattr(start.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(start, "_checkout_release", lambda *_a, **_kw: 0)
+    monkeypatch.setattr(start, "print_jupyterhub_path_hint", lambda *_a: None)
+    monkeypatch.setattr(start, "get_vertex_config", lambda: {})
+
+    captured: dict = {}
+    monkeypatch.setattr(start.os, "execvp", lambda _b, argv: captured.update(argv=argv))
+
+    start.run_start(agent="claude")
+
+    assert captured["argv"] == ["claude", "--model", "opus", "/berdl_start"]
 
 
 # ── shared-list wiring ─────────────────────────────────
 
 
-@pytest.mark.parametrize("module", [setup_cmd, doctor, cli])
-def test_modules_use_the_shared_agent_list(module):
-    """No module may keep a private copy of the agent list."""
-    src = inspect.getsource(module)
-    assert "SUPPORTED_AGENTS" in src, f"{module.__name__} has its own agent list"
+def test_doctor_probes_exactly_the_shared_agent_list(monkeypatch):
+    """doctor must read the shared list, not a private copy.
+
+    Swapping SUPPORTED_AGENTS for a sentinel proves doctor actually consults
+    it: a hardcoded copy would probe the real names instead.
+    """
+    monkeypatch.setattr(config, "SUPPORTED_AGENTS", ("sentinel-a", "sentinel-b"))
+    probed: list[str] = []
+
+    def fake_which(name):
+        probed.append(name)
+        return None
+
+    monkeypatch.setattr(doctor.shutil, "which", fake_which)
+    doctor.run_doctor()
+
+    assert "sentinel-a" in probed and "sentinel-b" in probed
+    assert "claude" not in probed
+
+
+def test_cli_choices_track_the_shared_agent_list(monkeypatch):
+    """The parser's --agent choices come from the shared list."""
+    monkeypatch.setattr(config, "SUPPORTED_AGENTS", ("sentinel-only",))
+    parser = cli.build_parser()
+    assert parser.parse_args(["start", "--agent", "sentinel-only"]).agent == "sentinel-only"
+    with pytest.raises(SystemExit):
+        parser.parse_args(["start", "--agent", "claude"])


### PR DESCRIPTION
## What

Adds [`omp`](https://www.npmjs.com/package/@oh-my-pi/pi-coding-agent) (oh-my-pi) as a launchable agent alongside `claude`, `codex` and `gemini`.

## Why the refactor first

The agent list was duplicated in three places (`cli.py` parser choices, `setup_cmd.py` detection, `doctor.py` detection). Adding a fourth agent meant editing three tuples that could silently drift. This moves it to a single `config.SUPPORTED_AGENTS`, and the new tests assert no module keeps a private copy.

## omp needs no special-casing

It discovers `.claude/skills` and reads `SKILL.md`, so `/berdl_start` and the other 15 BERIL skills resolve without changes. `start.py` already gated both the Vertex block and the model pin on `agent == "claude"`, so it needed no edit.

## Drive-by bug fix

`setup_cmd.py` passed `--model opus` **unconditionally** on launch:

```python
os.execvp(binary, [chosen, "--model", "opus", "/berdl_start"])
```

That hands an Anthropic-only flag to `codex` and `gemini` today, not just to `omp`. `start.py` already had the correct guard; `setup_cmd.py` now matches it. There's a regression test for both paths.

## Testing

- 15 new tests in `tests/test_cli_agents.py`
- Full suite: **173 passed**
- `build_parser()` split out of `main()` so the parser is testable directly (no behaviour change)

## Not in this PR

Wiring omp to the shared BERIL Vertex key. That is a larger piece of work: unlike Claude Code, omp takes a *static* `apiKey` string in `models.yml` and does not expand environment variables, so the short-lived Vertex OAuth token expires mid-session. It needs either a local refresh proxy or use of omp's own `auth-broker`. Worth doing separately. Users can point omp at their own key today.