### PR TITLE
Add omp agent support; fix --model opus leaking to non-Claude agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To use Claude Code you will need an API key. If you are Berkeley Lab staff, you 
 ### Prerequisites
 
 - A KBase account with BERDL access (see [Getting BERDL Access](#getting-berdl-access))
-- [Claude Code](https://claude.ai/claude-code) installed (or another supported agent e.g. codex)
+- [Claude Code](https://claude.ai/claude-code) installed (or another supported agent: `codex`, `gemini`, `omp`)
 - Python 3.11+
 - Git
 
@@ -107,7 +107,7 @@ cp .env.example .env
 # from .env automatically. If your token is ever exposed, delete it immediately
 # from the JupyterHub token management page and generate a new one.
 
-# 3. Open Claude Code in the repo
+# 3. Open your agent in the repo (claude, codex, gemini or omp)
 claude
 ```
 
@@ -157,7 +157,7 @@ Skills are invoked automatically based on context, or explicitly with `/skill-na
 | **LinkML Schema** | `/linkml-schema` | Generate LinkML schema from markdown, Excel, or plain text |
 | **Phenix** | `/phenix` | Structural biology workflows — AlphaFold, X-ray, cryo-EM, MolProbity |
 
-BERIL CLI commands (`beril doctor`, `beril setup`, `beril start`) handle environment management outside the agent session. Multi-agent support (Codex, Gemini) is planned.
+BERIL CLI commands (`beril doctor`, `beril setup`, `beril start`) handle environment management outside the agent session. `beril start --agent <name>` launches Claude Code, Codex, Gemini CLI or omp.
 
 ---
 

--- a/beril_cli/cli.py
+++ b/beril_cli/cli.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import argparse
 import sys
 
-from beril_cli import __version__
+from beril_cli import __version__, config
 
 
-def main(argv: list[str] | None = None) -> int:
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI parser. Split out from main() so it can be tested."""
     parser = argparse.ArgumentParser(
         prog="beril",
         description="BERIL Research Observatory — setup, check, and launch your research environment.",
@@ -27,7 +28,7 @@ def main(argv: list[str] | None = None) -> int:
     start_parser = sub.add_parser("start", help="Launch a coding agent")
     start_parser.add_argument(
         "--agent",
-        choices=["claude", "codex", "gemini"],
+        choices=list(config.SUPPORTED_AGENTS),
         default=None,
         help="Agent to launch (default: from config, or claude)",
     )
@@ -154,6 +155,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Write/merge the active project's runtime.json (hook)",
     )
 
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
     args, remaining = parser.parse_known_args(argv)
 
     if args.command is None:

--- a/beril_cli/config.py
+++ b/beril_cli/config.py
@@ -12,6 +12,12 @@ CONFIG_PATH = CONFIG_DIR / "config.toml"
 
 DEFAULT_BASE_URL = "https://beril.kbase.us"
 
+# Coding agents `beril start` can launch. Kept here so the CLI parser, the
+# setup wizard and doctor all agree on one list.
+SUPPORTED_AGENTS: tuple[str, ...] = ("claude", "codex", "gemini", "omp")
+
+DEFAULT_AGENT = "claude"
+
 
 def load() -> dict[str, Any]:
     """Load user config. Returns empty dict if file doesn't exist."""
@@ -71,7 +77,7 @@ def save(cfg: dict[str, Any]) -> None:
 def get_default_agent() -> str:
     """Return the user's default agent, or 'claude' as fallback."""
     cfg = load()
-    return cfg.get("defaults", {}).get("agent", "claude")
+    return cfg.get("defaults", {}).get("agent", DEFAULT_AGENT)
 
 
 def get_vertex_config() -> dict[str, Any]:

--- a/beril_cli/doctor.py
+++ b/beril_cli/doctor.py
@@ -199,13 +199,15 @@ def run_doctor() -> int:
 
     # 6. Agent CLIs
     agents_found = []
-    for agent in ("claude", "codex", "gemini"):
+    for agent in config.SUPPORTED_AGENTS:
         if shutil.which(agent):
             agents_found.append(agent)
     if agents_found:
         checks.append(("Agent CLIs", "PASS", ", ".join(agents_found)))
     else:
-        checks.append(("Agent CLIs", "WARN", "none found (claude, codex, gemini)"))
+        checks.append(
+            ("Agent CLIs", "WARN", f"none found ({', '.join(config.SUPPORTED_AGENTS)})")
+        )
 
     # 7. BERIL webapp: login state + service availability. These are
     # informational (WARN, not FAIL) so a transient outage doesn't make doctor

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -390,14 +390,14 @@ def run_setup() -> int:
     _step(8, "Coding agent")
 
     agents_found: list[str] = []
-    for agent in ("claude", "codex", "gemini"):
+    for agent in config.SUPPORTED_AGENTS:
         if shutil.which(agent):
             agents_found.append(agent)
 
     if agents_found:
         print(f"  Detected: {', '.join(agents_found)}")
     else:
-        print("  No agents detected (claude, codex, gemini).")
+        print(f"  No agents detected ({', '.join(config.SUPPORTED_AGENTS)}).")
         print("  Install one and re-run setup, or use beril start --agent <name>.")
 
     default_agent = existing_cfg.get("defaults", {}).get("agent", "")
@@ -409,7 +409,7 @@ def run_setup() -> int:
         if chosen not in agents_found:
             print(f"  Warning: '{chosen}' was not detected on PATH.")
     else:
-        chosen = default_agent or "claude"
+        chosen = default_agent or config.DEFAULT_AGENT
 
     # ── Step 9: BERIL Anthropic key (Google Vertex) ──
     vertex_cfg: dict = {}
@@ -472,7 +472,7 @@ def run_setup() -> int:
                 os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = vertex_cfg.get("credentials_file", "")
                 os.environ["VERTEX_REGION_CLAUDE_HAIKU_4_5"] = "us-east5"
                 os.environ["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
-            flags = claude_defaults(chosen, []) or ["--model", "opus"]
+            flags = claude_defaults(chosen, [])
             os.execvp(binary, [chosen, *flags, "/berdl_start"])
         else:
             print(f"  Error: '{chosen}' not found on PATH.", file=sys.stderr)

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -1,0 +1,157 @@
+"""Tests for the supported-agent list shared by the CLI parser, setup, and doctor."""
+
+from __future__ import annotations
+
+import pytest
+
+from beril_cli import cli, config, doctor, start
+
+
+# ── config.SUPPORTED_AGENTS ────────────────────────────
+
+
+def test_omp_is_supported():
+    """omp is launchable alongside the other agents."""
+    assert "omp" in config.SUPPORTED_AGENTS
+
+
+def test_default_agent_is_in_supported_list():
+    """The fallback agent must itself be launchable."""
+    assert config.DEFAULT_AGENT in config.SUPPORTED_AGENTS
+
+
+def test_supported_agents_cannot_be_mutated_by_callers():
+    """A caller cannot append to the shared list and affect everyone else."""
+    with pytest.raises((AttributeError, TypeError)):
+        config.SUPPORTED_AGENTS.append("rogue")  # type: ignore[attr-defined]
+
+
+# ── claude_defaults: Claude-only flags ─────────────────
+
+
+@pytest.mark.parametrize("agent", ["codex", "gemini", "omp"])
+def test_claude_defaults_returns_nothing_for_other_agents(agent):
+    assert start.claude_defaults(agent, []) == []
+
+
+def test_claude_defaults_pins_opus_for_claude():
+    flags = start.claude_defaults("claude", [])
+    assert "--model" in flags and "opus[1m]" in flags
+
+
+def test_claude_defaults_respects_caller_supplied_model():
+    flags = start.claude_defaults("claude", ["--model", "sonnet"])
+    assert "--model" not in flags
+
+
+# ── cli.py argument parsing ────────────────────────────
+
+
+@pytest.mark.parametrize("agent", config.SUPPORTED_AGENTS)
+def test_start_parser_accepts_every_supported_agent(agent):
+    """`beril start --agent X` parses for every agent we claim to support."""
+    assert cli.build_parser().parse_args(["start", "--agent", agent]).agent == agent
+
+
+def test_start_parser_rejects_unknown_agent():
+    """An agent outside the list is a parse error, not a late failure."""
+    with pytest.raises(SystemExit):
+        cli.build_parser().parse_args(["start", "--agent", "definitely-not-an-agent"])
+
+
+def test_cli_choices_track_the_shared_agent_list(monkeypatch):
+    """The parser's --agent choices come from the shared list, not a copy."""
+    monkeypatch.setattr(config, "SUPPORTED_AGENTS", ("sentinel-only",))
+    parser = cli.build_parser()
+    assert parser.parse_args(["start", "--agent", "sentinel-only"]).agent == "sentinel-only"
+    with pytest.raises(SystemExit):
+        parser.parse_args(["start", "--agent", "claude"])
+
+
+# ── doctor.py ──────────────────────────────────────────
+
+
+def _agent_row(capsys) -> str:
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if "Agent CLIs" in ln]
+    assert lines, "doctor printed no Agent CLIs row"
+    return lines[0]
+
+
+def test_doctor_passes_when_only_omp_is_installed(monkeypatch, capsys):
+    """omp alone satisfies the agent check and is named in the row."""
+    monkeypatch.setattr(
+        doctor.shutil, "which", lambda n: "/usr/local/bin/omp" if n == "omp" else None
+    )
+    doctor.run_doctor()
+    row = _agent_row(capsys)
+    assert "PASS" in row and "omp" in row
+
+
+def test_doctor_warns_and_names_omp_when_nothing_installed(monkeypatch, capsys):
+    """The 'none found' hint must name omp so users know it is an option."""
+    monkeypatch.setattr(doctor.shutil, "which", lambda _n: None)
+    doctor.run_doctor()
+    row = _agent_row(capsys)
+    assert "WARN" in row and "omp" in row
+
+
+def test_doctor_probes_exactly_the_shared_agent_list(monkeypatch):
+    """Swapping in a sentinel proves doctor consults the shared list."""
+    monkeypatch.setattr(config, "SUPPORTED_AGENTS", ("sentinel-a", "sentinel-b"))
+    probed: list[str] = []
+
+    def fake_which(name):
+        probed.append(name)
+        return None
+
+    monkeypatch.setattr(doctor.shutil, "which", fake_which)
+    doctor.run_doctor()
+
+    assert "sentinel-a" in probed and "sentinel-b" in probed
+    assert "claude" not in probed
+
+
+# ── the launch argv actually handed to execvp ──────────
+
+
+def _fake_repo(tmp_path, monkeypatch):
+    """Minimal repo run_start accepts: PROJECT.md marker plus a .env."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "PROJECT.md").write_text("")
+    (repo / ".env").write_text("")
+    monkeypatch.chdir(repo)
+    return repo
+
+
+@pytest.mark.parametrize("agent", ["codex", "gemini", "omp"])
+def test_start_does_not_pass_claude_flags_to_other_agents(tmp_path, monkeypatch, agent):
+    """End-to-end through run_start: non-Claude agents get a clean argv."""
+    _fake_repo(tmp_path, monkeypatch)
+    monkeypatch.setattr(start.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(start, "_checkout_release", lambda *_a, **_kw: 0)
+    monkeypatch.setattr(start, "print_jupyterhub_path_hint", lambda *_a: None)
+
+    captured: dict = {}
+    monkeypatch.setattr(start.os, "execvp", lambda _b, argv: captured.update(argv=argv))
+
+    start.run_start(agent=agent)
+
+    assert captured["argv"] == [agent, "/berdl_start"]
+
+
+def test_setup_launch_does_not_pass_claude_flags_to_other_agents():
+    """Regression: setup used `claude_defaults(chosen, []) or ["--model", "opus"]`.
+
+    `claude_defaults` returns [] for non-Claude agents, and `[] or [...]`
+    evaluates to the right-hand side, so the fallback reinstated exactly the
+    flag the function exists to withhold. codex/gemini/omp were launched with
+    `--model opus`.
+    """
+    for agent in ("codex", "gemini", "omp"):
+        flags = start.claude_defaults(agent, [])
+        argv = [agent, *flags, "/berdl_start"]
+        assert argv == [agent, "/berdl_start"], f"{agent} got Claude-only flags"
+
+    claude_argv = ["claude", *start.claude_defaults("claude", []), "/berdl_start"]
+    assert "--model" in claude_argv and "opus[1m]" in claude_argv

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -26,6 +26,31 @@ def test_supported_agents_cannot_be_mutated_by_callers():
         config.SUPPORTED_AGENTS.append("rogue")  # type: ignore[attr-defined]
 
 
+# ── config.get_default_agent ───────────────────────────
+
+
+def test_get_default_agent_falls_back_when_unconfigured(tmp_path, monkeypatch):
+    """With no config file on disk, the shared DEFAULT_AGENT is used."""
+    monkeypatch.setattr(config, "CONFIG_PATH", tmp_path / "absent.toml")
+    assert config.get_default_agent() == config.DEFAULT_AGENT
+
+
+def test_get_default_agent_reads_configured_agent(tmp_path, monkeypatch):
+    """An agent pinned in config.toml wins over the fallback."""
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[defaults]\nagent = "omp"\n')
+    monkeypatch.setattr(config, "CONFIG_PATH", cfg)
+    assert config.get_default_agent() == "omp"
+
+
+def test_get_default_agent_falls_back_when_section_absent(tmp_path, monkeypatch):
+    """A config.toml without a [defaults] section still yields the fallback."""
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[user]\nname = "someone"\n')
+    monkeypatch.setattr(config, "CONFIG_PATH", cfg)
+    assert config.get_default_agent() == config.DEFAULT_AGENT
+
+
 # ── claude_defaults: Claude-only flags ─────────────────
 
 


### PR DESCRIPTION
## Bug fix (independent of omp, affects `codex` and `gemini` today)

`beril_cli/setup_cmd.py` launches with:

```python
flags = claude_defaults(chosen, []) or ["--model", "opus"]
```

`claude_defaults()` correctly returns `[]` for non-Claude agents. But `[] or [...]` evaluates to the right-hand side, so the fallback reinstates exactly the flag the function exists to withhold:

```
claude -> ['claude', '--model', 'opus[1m]', '--permission-mode', 'auto', '/berdl_start']
codex  -> ['codex',  '--model', 'opus', '/berdl_start']     <-- wrong
gemini -> ['gemini', '--model', 'opus', '/berdl_start']     <-- wrong
```

Dropping the `or` clause fixes it. The Claude path is untouched and still gets `opus[1m]` and `--permission-mode auto`.

This is worth reviewing on its own even if you don't want the omp part.

## omp support

Adds `omp` ([oh-my-pi](https://www.npmjs.com/package/@oh-my-pi/pi-coding-agent)) as a launchable agent. It needs no special-casing: it discovers `.claude/skills` and reads `SKILL.md`, so `/berdl_start` and the other skills resolve unchanged. The Vertex block and `claude_defaults` are already correctly gated on `agent == "claude"`.

## Consolidation

The agent list was duplicated in three places (`cli.py` parser choices, `doctor.py` detection, `setup_cmd.py` detection), so adding an agent meant editing three tuples that could drift. Now one `config.SUPPORTED_AGENTS`.

## Tests

21 new tests, behavioural rather than source-matching:

- `run_start` driven end-to-end with `os.execvp` captured, asserting the real argv per agent
- Shared-list tests swap `SUPPORTED_AGENTS` for a sentinel tuple, so a private hardcoded copy fails them
- Doctor tests assert the `Agent CLIs` row status, not a substring of stdout

Full suite: **544 passed**.

`build_parser()` is split out of `main()` so the parser is testable directly. No behaviour change.

## Docs

`README.md:160` said "Multi-agent support (Codex, Gemini) is planned" — both were already supported, so that line was stale before this PR. Updated, along with two other Claude-only references.

## Not included

Wiring omp to the shared BERIL Vertex key. Unlike Claude Code, omp takes a *static* `apiKey` string in `models.yml` and does not expand environment variables, so a short-lived Vertex OAuth token expires mid-session. That needs either a local refresh proxy or omp's `auth-broker`, and belongs in its own PR. Users can point omp at their own key today.