### PR TITLE
Point token instructions at the hub, not narrative.kbase.us

### DIFF
--- a/.claude/skills/berdl_start/SKILL.md
+++ b/.claude/skills/berdl_start/SKILL.md
@@ -105,7 +105,7 @@ This wraps `scripts/detect_berdl_environment.py` with auto-recovery. It:
 - "Start SSH tunnels" → ask the user to run the printed command in a terminal, then re-run `python scripts/berdl_env.py --check`.
 - "pproxy not running" → the helper auto-starts it; this should self-resolve.
 - "Missing .venv-berdl" → `bash scripts/bootstrap_client.sh`.
-- "Missing KBASE_AUTH_TOKEN" → sign in at https://hub.berdl.kbase.us, spawn a server, and in a notebook run `from berdl_notebook_utils import BERDLSettings; print(BERDLSettings().KBASE_AUTH_TOKEN)`, then add it to `.env`. The token lasts 14 days, and signing out of KBase revokes it immediately, so do not sign out mid-run. (`narrative.kbase.us` shows a Developer Tokens tab only to accounts holding the `DevToken` role, and BERDL uses Login tokens.)
+- "Missing KBASE_AUTH_TOKEN" → sign in at https://hub.berdl.kbase.us, spawn a server, and in a notebook run `import os; print(os.environ.get('KBASE_AUTH_TOKEN'))`, then add it to `.env`. **Delete the cell output immediately after copying the token**; saved outputs live in the notebook file and can be shared or committed by accident. The token lasts 14 days, and signing out of KBase revokes it immediately, so do not sign out mid-run. (`narrative.kbase.us` shows a Developer Tokens tab only to accounts holding the `DevToken` role, and BERDL uses Login tokens.)
 
 **Route follow-up BERDL queries from the detected location:**
 - `on-cluster`: use the active Spark session and `spark.sql(query)` directly. Do not use `--berdl-proxy`.

--- a/.claude/skills/berdl_start/SKILL.md
+++ b/.claude/skills/berdl_start/SKILL.md
@@ -105,7 +105,7 @@ This wraps `scripts/detect_berdl_environment.py` with auto-recovery. It:
 - "Start SSH tunnels" → ask the user to run the printed command in a terminal, then re-run `python scripts/berdl_env.py --check`.
 - "pproxy not running" → the helper auto-starts it; this should self-resolve.
 - "Missing .venv-berdl" → `bash scripts/bootstrap_client.sh`.
-- "Missing KBASE_AUTH_TOKEN" → get token from https://narrative.kbase.us/#auth2/account and add to `.env`.
+- "Missing KBASE_AUTH_TOKEN" → sign in at https://hub.berdl.kbase.us, spawn a server, and in a notebook run `from berdl_notebook_utils import BERDLSettings; print(BERDLSettings().KBASE_AUTH_TOKEN)`, then add it to `.env`. The token lasts 14 days, and signing out of KBase revokes it immediately, so do not sign out mid-run. (`narrative.kbase.us` shows a Developer Tokens tab only to accounts holding the `DevToken` role, and BERDL uses Login tokens.)
 
 **Route follow-up BERDL queries from the detected location:**
 - `on-cluster`: use the active Spark session and `spark.sql(query)` directly. Do not use `--berdl-proxy`.

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -273,8 +273,10 @@ def run_setup() -> int:
         print(
             "  To get a KBASE_AUTH_TOKEN: sign in at https://hub.berdl.kbase.us, spawn a\n"
             "  server, and in a notebook run:\n"
-            "      from berdl_notebook_utils import BERDLSettings\n"
-            "      print(BERDLSettings().KBASE_AUTH_TOKEN)\n"
+            "      import os\n"
+            "      print(os.environ.get('KBASE_AUTH_TOKEN'))\n"
+            "  Delete the cell output immediately after copying the token. Saved outputs\n"
+            "  live in the notebook file and can be shared or committed by accident.\n"
             "  The token lasts 14 days. Signing out of KBase revokes it immediately rather\n"
             "  than at its stated expiry, so do not sign out while a run is in flight.\n"
             "  Note: narrative.kbase.us shows a 'Developer Tokens' tab only to accounts\n"

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -271,11 +271,15 @@ def run_setup() -> int:
     file_token = env_vars.get("KBASE_AUTH_TOKEN", "")
     if not file_token or file_token == "YOUR_AUTH_TOKEN_HERE":
         print(
-            "  To get a KBASE_AUTH_TOKEN: sign in at https://narrative.kbase.us/#auth2/account\n"
-            "  and open the 'Developer Tokens' tab. That tab only appears for approved KBase\n"
-            "  developers — if you don't see it, you don't have developer access yet; contact\n"
-            "  the BERIL team about requesting it. A generated token is shown only once, for\n"
-            "  about 5 minutes, so have this prompt ready before you generate one."
+            "  To get a KBASE_AUTH_TOKEN: sign in at https://hub.berdl.kbase.us, spawn a\n"
+            "  server, and in a notebook run:\n"
+            "      from berdl_notebook_utils import BERDLSettings\n"
+            "      print(BERDLSettings().KBASE_AUTH_TOKEN)\n"
+            "  The token lasts 14 days. Signing out of KBase revokes it immediately rather\n"
+            "  than at its stated expiry, so do not sign out while a run is in flight.\n"
+            "  Note: narrative.kbase.us shows a 'Developer Tokens' tab only to accounts\n"
+            "  holding the DevToken role, and BERDL uses Login tokens, so that page is not\n"
+            "  the route here."
         )
         token = _prompt("  Enter your KBASE_AUTH_TOKEN (leave blank to configure later)")
         if token:

--- a/scripts/detect_berdl_environment.py
+++ b/scripts/detect_berdl_environment.py
@@ -126,8 +126,9 @@ def detect_environment() -> dict[str, Any]:
             result["next_steps"].append(
                 "⚠️ KBASE_AUTH_TOKEN not found in environment. "
                 "Get your token by signing in at https://hub.berdl.kbase.us, spawning a "
-                "server, and running in a notebook: from berdl_notebook_utils import "
-                "BERDLSettings; print(BERDLSettings().KBASE_AUTH_TOKEN). Then add it to .env"
+                "server, and running in a notebook: import os; "
+                "print(os.environ.get('KBASE_AUTH_TOKEN')). Delete the cell output right "
+                "after copying it, then add the token to .env"
             )
     else:
         # Off-cluster (local machine)
@@ -143,9 +144,9 @@ def detect_environment() -> dict[str, Any]:
             result["next_steps"].append(
                 "❌ KBASE_AUTH_TOKEN missing from .env. "
                 "Get your token by signing in at https://hub.berdl.kbase.us, spawning a "
-                "server, and running in a notebook: from berdl_notebook_utils import "
-                "BERDLSettings; print(BERDLSettings().KBASE_AUTH_TOKEN). Then add: "
-                "KBASE_AUTH_TOKEN=\"your-token-here\""
+                "server, and running in a notebook: import os; "
+                "print(os.environ.get('KBASE_AUTH_TOKEN')). Delete the cell output right "
+                "after copying it, then add: KBASE_AUTH_TOKEN=\"your-token-here\""
             )
 
         # Check .venv-berdl

--- a/scripts/detect_berdl_environment.py
+++ b/scripts/detect_berdl_environment.py
@@ -125,8 +125,9 @@ def detect_environment() -> dict[str, Any]:
             result["checks"]["kbase_token_env"] = False
             result["next_steps"].append(
                 "⚠️ KBASE_AUTH_TOKEN not found in environment. "
-                "Get your token from https://narrative.kbase.us/#auth2/account "
-                "and add it to .env"
+                "Get your token by signing in at https://hub.berdl.kbase.us, spawning a "
+                "server, and running in a notebook: from berdl_notebook_utils import "
+                "BERDLSettings; print(BERDLSettings().KBASE_AUTH_TOKEN). Then add it to .env"
             )
     else:
         # Off-cluster (local machine)
@@ -141,8 +142,10 @@ def detect_environment() -> dict[str, Any]:
         if not token_in_env:
             result["next_steps"].append(
                 "❌ KBASE_AUTH_TOKEN missing from .env. "
-                "Get your token from https://narrative.kbase.us/#auth2/account "
-                "and add: KBASE_AUTH_TOKEN=\"your-token-here\""
+                "Get your token by signing in at https://hub.berdl.kbase.us, spawning a "
+                "server, and running in a notebook: from berdl_notebook_utils import "
+                "BERDLSettings; print(BERDLSettings().KBASE_AUTH_TOKEN). Then add: "
+                "KBASE_AUTH_TOKEN=\"your-token-here\""
             )
 
         # Check .venv-berdl


### PR DESCRIPTION
Closes #363. Follow-up to #315, which was closed while four sites still pointed at the old page.

`narrative.kbase.us/#auth2/account` shows a Developer Tokens tab only to accounts holding the `DevToken` role. BERDL uses Login tokens, and KBase confirmed on 2026-08-04 that a Developer token does not help here, so for most users that page is a dead end: no tab, and nothing on the page explains why.

The four sites now describe the route that works, and carry the two facts that cost the most time to find. The token lasts 14 days rather than the week the docs implied, and signing out of KBase revokes it immediately rather than at its stated expiry, which kills any run in flight.

Two mentions of `narrative.kbase.us` survive on purpose, saying why that page is not the route. Someone who has already been sent there needs to know they are not missing a step.

Verified against `main` at 06b8c8dc. Test suite is unchanged at 559 passed, with the same two failures (`test_plan_gate.py::test_only_a_committed_report_ends_recording` and `test_statusline.py::test_the_statusline_starts_a_dashboard_that_is_not_running`) that also fail on unmodified `main`.