### PR TITLE
Never commit vendored BERDL packages to this public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,13 @@
 docs/plans/
 docs/superpowers/
 
+# Vendored packages captured from a BERDL pod (see issue #316).
+# berdl_remote and spark_connect_remote are pinned from github.com/BERDataLakehouse,
+# which returns 404, so these local copies cannot be re-fetched. They are third-party
+# code and this repository is public: never commit them.
+vendor/
+*.tgz
+
 # Large data files
 *.npy
 *.pkl


### PR DESCRIPTION
A working checkout can accumulate `vendor/*.tgz` holding `berdl_remote` 0.1.0, `spark_connect_remote` 0.2.0 and `berdl_notebook_utils` 0.0.1, captured from a BERDL pod. Nothing in `.gitignore` covered them: no `vendor`, no `*.tgz`, and this repo has no `local/` convention either.

Those are third-party packages and this repository is public, so a single `git add -A` publishes them. That is a disclosure problem rather than a tidiness one, which is why this is a change rather than a note.

They exist locally because the two repos `scripts/bootstrap_client.sh` pins are unreachable (#316), so a captured copy is the only way off-cluster setup completes at all. Deleting them is not an option; ignoring them is.

Verified with `git check-ignore -v` rather than by reading the pattern:

```
$ git check-ignore -v vendor/ vendor/berdl-unreproducible-packages-2026-07-31.tgz
.gitignore:19:vendor/   vendor/
.gitignore:19:vendor/   vendor/berdl-unreproducible-packages-2026-07-31.tgz
```

`*.tgz` is included as well, since the same capture is easy to drop elsewhere in a checkout.