### PR TITLE
Orient NMDC users to canonical BERDL resources

### DIFF
--- a/.claude/skills/berdl_start/SKILL.md
+++ b/.claude/skills/berdl_start/SKILL.md
@@ -168,6 +168,14 @@ For deeper inspection, suggest the user run:
 
 **Do not run `COUNT(*)` per database in this phase** — it's expensive and not needed for orientation.
 
+### NMDC collection orientation
+
+If the inventory or the user's question involves an `nmdc` database, read
+`docs/datasets/nmdc/README.md` before recommending tables. It distinguishes the
+canonical `nmdc` tenant from derived or scoped `kbase.nmdc_*` products and gives
+the standard biosample-to-result join. Use the live inventory for availability;
+use the guide for provenance and resource roles.
+
 ---
 
 ## Phase 1.7: Session Naming Reminder

--- a/docs/datasets/nmdc/README.md
+++ b/docs/datasets/nmdc/README.md
@@ -1,0 +1,59 @@
+# NMDC data in BERDL
+
+Use the `nmdc` tenant for NMDC's canonical metadata and analysis results. Do
+not select a database only because its name contains `nmdc`; BERDL also hosts
+derived products and external mirrors with that label.
+
+## Canonical resources
+
+| Resource | Role |
+|---|---|
+| `nmdc.metadata` | Schema-driven NMDC metadata, including biosamples, studies, workflow executions, and provenance side tables |
+| `nmdc.results` | NMDC workflow results, including functional annotations, taxonomy reports, and MAG quality statistics |
+| `nmdc.ref_data` | Redistributable reference data intentionally co-hosted with the canonical ingest |
+
+`nmdc.ncbi_biosamples` is an external NCBI BioSample mirror. It is useful for
+NCBI coverage, but it is not NMDC-native metadata.
+
+## Derived resources
+
+The `kbase.nmdc_*` namespaces are useful derived or scoped products, not the
+default representation of all NMDC data:
+
+- `kbase.nmdc_arkin` contains Arkin-group integrations and derived products.
+- `kbase.nmdc_mags` is a specific MAG catalog.
+- `kbase.nmdc_neon` is scoped to the NSF NEON program.
+
+Start with the canonical tenant, then use a derived resource when its scope or
+added transformation is specifically required.
+
+## Standard biosample-to-result join
+
+`nmdc.metadata.biosample_to_workflow_run` is the universal bridge from a
+biosample to result tables keyed by `workflow_run_id`. For example, retrieve
+canonical CheckM MAG quality metrics with:
+
+```sql
+SELECT b2wr.biosample_id,
+       quality.completeness,
+       quality.contamination,
+       quality.strain_heterogeneity
+FROM nmdc.metadata.biosample_to_workflow_run AS b2wr
+JOIN nmdc.results.checkm_statistics AS quality
+  ON quality.workflow_run_id = b2wr.workflow_run_id
+```
+
+The same bridge connects biosamples to functional annotations and taxonomy
+reports in `nmdc.results`.
+
+## Maintained upstream documentation
+
+The producing repository explains the relational model and provenance joins in
+more detail:
+
+- [Guide for BERDL agents](https://github.com/microbiomedata/nmdc-lakehouse/blob/main/docs/for_berdl_claude.md)
+- [`nmdc.metadata` table reference](https://github.com/microbiomedata/nmdc-lakehouse/blob/main/docs/nmdc_metadata_tables.md)
+- [`biosample_to_workflow_run` design and examples](https://github.com/microbiomedata/nmdc-lakehouse/blob/main/docs/biosample_to_workflow_run.md)
+
+Treat live, access-aware inventory as authoritative for availability. The
+upstream repository is authoritative for ingest design and maintenance.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -13,7 +13,7 @@
   - [UniProt](schemas/uniprot.md) (`kbase_uniprot`)
   - [UniRef](schemas/uniref.md) (`kbase_uniref50/90/100`)
   - [ENIGMA CORAL](schemas/enigma.md) (`enigma_coral`)
-  - [NMDC](schemas/nmdc.md) (`nmdc_arkin`, `nmdc_ncbi_biosamples`)
+  - [NMDC](datasets/nmdc/) (`nmdc.metadata`, `nmdc.results`, `nmdc.ref_data`)
   - [PhageFoundry](schemas/phagefoundry.md) (4 genome browsers)
   - [PlanetMicrobe](schemas/planetmicrobe.md) (`planetmicrobe_planetmicrobe`)
   - [PROTECT](schemas/protect.md) (`protect_genomedepot`)

--- a/tests/test_nmdc_orientation.py
+++ b/tests/test_nmdc_orientation.py
@@ -1,0 +1,35 @@
+"""Guard the canonical NMDC orientation against documentation drift."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+NMDC_GUIDE = ROOT / "docs" / "datasets" / "nmdc" / "README.md"
+
+
+def test_nmdc_guide_identifies_canonical_and_derived_resources():
+    guide = NMDC_GUIDE.read_text(encoding="utf-8")
+
+    for resource in ("nmdc.metadata", "nmdc.results", "nmdc.ref_data"):
+        assert f"`{resource}`" in guide
+
+    for resource in ("kbase.nmdc_arkin", "kbase.nmdc_mags", "kbase.nmdc_neon"):
+        assert f"`{resource}`" in guide
+
+    assert "nmdc.metadata.biosample_to_workflow_run" in guide
+    assert "nmdc.results.checkm_statistics" in guide
+
+
+def test_berdl_start_loads_nmdc_guide_for_nmdc_questions():
+    start_skill = (
+        ROOT / ".claude" / "skills" / "berdl_start" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "docs/datasets/nmdc/README.md" in start_skill
+
+
+def test_schema_index_links_to_existing_nmdc_guide():
+    schema_index = (ROOT / "docs" / "schema.md").read_text(encoding="utf-8")
+
+    assert "[NMDC](datasets/nmdc/)" in schema_index
+    assert NMDC_GUIDE.is_file()


### PR DESCRIPTION
## Why

Agents and new users can see both canonical and derived NMDC resources in BERDL but lacked local guidance about which to use. The schema index reinforced the problem by linking to a nonexistent NMDC page and naming only legacy derived namespaces.

## What changed

- add a concise NMDC collection guide that distinguishes canonical `nmdc` resources from derived/scoped `kbase.nmdc_*` products
- document the standard `biosample_to_workflow_run` join, including the canonical CheckM quality path
- make `/berdl_start` load the guide before recommending NMDC tables
- repair the NMDC link in the schema index
- add regression coverage for the guide content and startup wiring

## Validation

- `uv run --group test pytest tests/test_nmdc_orientation.py tests/test_skill_wiring.py` — 5 passed
- `uv run --group test pytest tests/` — 563 passed; 1 unrelated environmental failure because local dashboard process PID 3045 already occupied the statusline test's fixed port 8766
- `git diff --check`

## Documentation impact

This adds the missing primary NMDC orientation page and links it at startup. Live inventory remains authoritative for availability; upstream `nmdc-lakehouse` documentation remains authoritative for ingest design.

## Non-goals

- vendoring or synchronizing the full upstream documentation set
- changing inventory collection metadata or grouping
- implementing the catalog-wide governance plan in #323
- changing any BERDL datasets

Closes #259.
