### PR TITLE
Give omp a session directory a collector can name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,10 @@ projects/*/.agent-state.json.tmp
 # ignoring it preserves the de-facto behaviour and stops a fresh clone showing an
 # untracked file after the SessionStart hook writes one.
 projects/*/runtime.json
+# omp session transcripts, when `beril start --agent omp` points omp at the checkout
+# (beril_cli/start.py::omp_defaults). Same genus as runtime.json: machine-local, and
+# the full conversation including whatever the agent happened to read.
+.omp-sessions/
 
 # UI application
 ui/data/cache.json

--- a/.gitignore
+++ b/.gitignore
@@ -112,10 +112,6 @@ projects/*/.agent-state.json.tmp
 # ignoring it preserves the de-facto behaviour and stops a fresh clone showing an
 # untracked file after the SessionStart hook writes one.
 projects/*/runtime.json
-# omp session transcripts, when `beril start --agent omp` points omp at the checkout
-# (beril_cli/start.py::omp_defaults). Same genus as runtime.json: machine-local, and
-# the full conversation including whatever the agent happened to read.
-.omp-sessions/
 
 # UI application
 ui/data/cache.json

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Skills are invoked automatically based on context, or explicitly with `/skill-na
 | **LinkML Schema** | `/linkml-schema` | Generate LinkML schema from markdown, Excel, or plain text |
 | **Phenix** | `/phenix` | Structural biology workflows — AlphaFold, X-ray, cryo-EM, MolProbity |
 
-BERIL CLI commands (`beril doctor`, `beril setup`, `beril start`) handle environment management outside the agent session. `beril start --agent <name>` launches Claude Code, Codex, Gemini CLI or omp.
+BERIL CLI commands (`beril doctor`, `beril setup`, `beril start`) handle environment management outside the agent session. `beril start --agent <name>` launches Claude Code, Codex, Gemini CLI or omp. With `--agent omp`, session transcripts are written to `.omp-sessions/` in the checkout (gitignored) and the path is printed at launch, so a session can be handed to a transcript reader afterwards.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Skills are invoked automatically based on context, or explicitly with `/skill-na
 | **LinkML Schema** | `/linkml-schema` | Generate LinkML schema from markdown, Excel, or plain text |
 | **Phenix** | `/phenix` | Structural biology workflows — AlphaFold, X-ray, cryo-EM, MolProbity |
 
-BERIL CLI commands (`beril doctor`, `beril setup`, `beril start`) handle environment management outside the agent session. `beril start --agent <name>` launches Claude Code, Codex, Gemini CLI or omp. With `--agent omp`, session transcripts are written to `.omp-sessions/` in the checkout (gitignored) and the path is printed at launch, so a session can be handed to a transcript reader afterwards.
+BERIL CLI commands (`beril doctor`, `beril setup`, `beril start`) handle environment management outside the agent session. `beril start --agent <name>` launches Claude Code, Codex, Gemini CLI or omp. With `--agent omp`, session transcripts are written under `~/.beril/omp-sessions/<checkout>/` — in `$HOME`, which persists across BERDL pod restarts where the checkout does not — and the path is printed at launch, so a session can be handed to a transcript reader afterwards.
 
 ---
 

--- a/beril_cli/setup_cmd.py
+++ b/beril_cli/setup_cmd.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from beril_cli import auth_store, config
 from beril_cli.auth_cmd import run_login
 from beril_cli.detect import detect_user_identity, print_jupyterhub_path_hint
-from beril_cli.start import claude_defaults
+from beril_cli.start import announce_omp_session, claude_defaults, omp_defaults
 
 
 def _find_repo_root() -> Path | None:
@@ -478,8 +478,12 @@ def run_setup() -> int:
                 os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = vertex_cfg.get("credentials_file", "")
                 os.environ["VERTEX_REGION_CLAUDE_HAIKU_4_5"] = "us-east5"
                 os.environ["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
+            # The same session directory `beril start` gives omp, so a session begun
+            # from the wizard is as collectable as one begun later (start.py::omp_defaults).
+            session_flags = omp_defaults(chosen, [], repo_root)
+            announce_omp_session(session_flags)
             flags = claude_defaults(chosen, [])
-            os.execvp(binary, [chosen, *flags, "/berdl_start"])
+            os.execvp(binary, [chosen, *flags, *session_flags, "/berdl_start"])
         else:
             print(f"  Error: '{chosen}' not found on PATH.", file=sys.stderr)
             return 1

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -17,6 +17,11 @@ from beril_cli.detect import print_jupyterhub_path_hint
 
 GITHUB_API_TIMEOUT_SECONDS = 10
 
+#: Where omp is told to keep session transcripts, relative to the repo root. Gitignored:
+#: a transcript is machine-local and holds whatever the agent read, the same reasoning
+#: that keeps ``projects/*/runtime.json`` out of the tree.
+OMP_SESSION_DIR = ".omp-sessions"
+
 
 def _sync_auth_token(env_path: Path) -> None:
     """Sync KBASE_AUTH_TOKEN from live environment into .env if available."""
@@ -149,6 +154,16 @@ def _checkout_release(repo_root: Path, requested_version: str | None) -> int:
     return 0
 
 
+def _has_flag(extra_args: list[str], name: str) -> bool:
+    """Whether the caller already passed ``name``, in either form.
+
+    Both ``--flag value`` and ``--flag=value`` count. Plain membership misses the
+    second, and re-adding a default the caller already set hands the agent the same
+    flag twice with two different values.
+    """
+    return any(arg == name or arg.startswith(f"{name}=") for arg in extra_args)
+
+
 def claude_defaults(agent: str, extra_args: list[str]) -> list[str]:
     """Default flags for Claude: Opus with the 1M context window, auto permissions.
 
@@ -157,11 +172,51 @@ def claude_defaults(agent: str, extra_args: list[str]) -> list[str]:
     if agent != "claude":
         return []
     flags: list[str] = []
-    if "--model" not in extra_args:
+    if not _has_flag(extra_args, "--model"):
         flags += ["--model", "opus[1m]"]
-    if "--permission-mode" not in extra_args:
+    if not _has_flag(extra_args, "--permission-mode"):
         flags += ["--permission-mode", "auto"]
     return flags
+
+
+def omp_defaults(agent: str, extra_args: list[str], repo_root: Path) -> list[str]:
+    """Default flags for omp: a session directory inside the checkout.
+
+    Returns nothing for other agents, and skips the flag if the caller already set it.
+
+    omp writes its transcript to ``~/.omp/agent/sessions/<encoded-cwd>/`` under a name
+    it picks -- a timestamp and a UUID -- so the path is knowable only after the fact.
+    Because ``beril start`` launches from the repo root, every project on a machine
+    also shares one such directory. Nothing downstream can name a session file, and
+    naming one is exactly what a transcript reader needs: evalome's ``collect`` takes
+    ``--transcript <path>``, and unlike Claude Code, omp fires no SessionStart hook to
+    supply it.
+
+    Pointing omp at the checkout fixes the directory without inventing the filename.
+    The newest ``.jsonl`` under it is the session just launched, printed at launch so
+    the operator can hand it straight to a collector.
+
+    Repo-root, not per-project: ``/berdl_start`` scaffolds the project *during* the
+    session, so at launch there is no project directory to write into yet.
+    """
+    if agent != "omp" or _has_flag(extra_args, "--session-dir"):
+        return []
+    return ["--session-dir", str(repo_root / OMP_SESSION_DIR)]
+
+
+def announce_omp_session(session_flags: list[str]) -> None:
+    """Create the session directory and tell the operator where it is.
+
+    A no-op for anything but omp, so both launch sites can call it unconditionally.
+    Created here rather than left to omp, so the path printed has something behind it
+    even when the launch then fails -- an operator sent to an absent directory cannot
+    tell "the agent wrote nothing" from "I was told the wrong place".
+    """
+    if not session_flags:
+        return
+    session_dir = Path(session_flags[1])
+    session_dir.mkdir(parents=True, exist_ok=True)
+    print(f"omp transcripts: {session_dir} (this session is the newest *.jsonl)")
 
 
 def run_start(
@@ -222,9 +277,13 @@ def run_start(
                     file=sys.stderr,
                 )
 
-    extra_args = [*claude_defaults(agent, extra_args), *extra_args]
+    # Computed from the operator's own args, so this runs after the onboarding default
+    # above and never itself counts as "the user already passed a prompt".
+    session_flags = omp_defaults(agent, extra_args, repo_root)
+    extra_args = [*claude_defaults(agent, extra_args), *session_flags, *extra_args]
 
     print(f"Launching {agent}...")
+    announce_omp_session(session_flags)
     print_jupyterhub_path_hint(repo_root)
     # Replace the current process with the agent
     os.execvp(binary, [agent, *extra_args])

--- a/beril_cli/start.py
+++ b/beril_cli/start.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -17,10 +18,28 @@ from beril_cli.detect import print_jupyterhub_path_hint
 
 GITHUB_API_TIMEOUT_SECONDS = 10
 
-#: Where omp is told to keep session transcripts, relative to the repo root. Gitignored:
-#: a transcript is machine-local and holds whatever the agent read, the same reasoning
-#: that keeps ``projects/*/runtime.json`` out of the tree.
-OMP_SESSION_DIR = ".omp-sessions"
+#: Where omp is told to keep session transcripts: under $HOME, one directory per checkout.
+#:
+#: Not inside the checkout, for two reasons and the first is BERIL's own deployment. BERDL
+#: compute nodes are ephemeral pods (PROJECT.md) while ``$HOME`` persists -- `beril setup`
+#: says so itself -- so a transcript in the working tree is the copy that does not survive a
+#: pod restart, and one under $HOME is the copy that does. Second, a session transcript is
+#: the entire conversation including whatever the agent read, which is a different privacy
+#: weight from `projects/*/runtime.json`; keeping it out of a public repo's tree means it
+#: cannot be reached by an ignore rule drifting, a `git add -f`, or a Docker build context.
+OMP_SESSION_ROOT = Path.home() / ".beril" / "omp-sessions"
+
+
+def omp_session_dir(repo_root: Path) -> Path:
+    """The session directory for one checkout, stable across runs and unique to it.
+
+    Keyed by the resolved path, not the directory name: two clones both called
+    ``BERIL-research-observatory`` are different checkouts whose sessions must not mix. The
+    name is kept as a prefix so the directory is still recognisable to a person listing it.
+    """
+    resolved = Path(repo_root).resolve()
+    digest = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()[:8]
+    return OMP_SESSION_ROOT / f"{resolved.name}-{digest}"
 
 
 def _sync_auth_token(env_path: Path) -> None:
@@ -201,22 +220,21 @@ def omp_defaults(agent: str, extra_args: list[str], repo_root: Path) -> list[str
     """
     if agent != "omp" or _has_flag(extra_args, "--session-dir"):
         return []
-    return ["--session-dir", str(repo_root / OMP_SESSION_DIR)]
+    return ["--session-dir", str(omp_session_dir(repo_root))]
 
 
 def announce_omp_session(session_flags: list[str]) -> None:
-    """Create the session directory and tell the operator where it is.
+    """Tell the operator where the transcript will land. A no-op for any other agent.
 
-    A no-op for anything but omp, so both launch sites can call it unconditionally.
-    Created here rather than left to omp, so the path printed has something behind it
-    even when the launch then fails -- an operator sent to an absent directory cannot
-    tell "the agent wrote nothing" from "I was told the wrong place".
+    Deliberately does not create the directory. omp creates it itself, recursively, when it
+    opens the session -- verified against the shipped binary -- so a `mkdir` here buys
+    nothing and can only fail. It would run *between* "Launching omp..." and `execvp`, where
+    a path occupied by a file, a read-only mount or a full disk raises and the agent never
+    starts, having told the operator it was starting.
     """
     if not session_flags:
         return
-    session_dir = Path(session_flags[1])
-    session_dir.mkdir(parents=True, exist_ok=True)
-    print(f"omp transcripts: {session_dir} (this session is the newest *.jsonl)")
+    print(f"omp transcripts: {session_flags[1]} (this session is the newest *.jsonl)")
 
 
 def run_start(

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from beril_cli import cli, config, doctor, start
@@ -149,9 +151,8 @@ def _fake_repo(tmp_path, monkeypatch):
     return repo
 
 
-@pytest.mark.parametrize("agent", ["codex", "gemini", "omp"])
-def test_start_does_not_pass_claude_flags_to_other_agents(tmp_path, monkeypatch, agent):
-    """End-to-end through run_start: non-Claude agents get a clean argv."""
+def _launch(tmp_path, monkeypatch, **kwargs) -> list[str]:
+    """Drive run_start to the execvp boundary and return the argv it would exec."""
     _fake_repo(tmp_path, monkeypatch)
     monkeypatch.setattr(start.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
     monkeypatch.setattr(start, "_checkout_release", lambda *_a, **_kw: 0)
@@ -160,9 +161,21 @@ def test_start_does_not_pass_claude_flags_to_other_agents(tmp_path, monkeypatch,
     captured: dict = {}
     monkeypatch.setattr(start.os, "execvp", lambda _b, argv: captured.update(argv=argv))
 
-    start.run_start(agent=agent)
+    start.run_start(**kwargs)
+    return captured["argv"]
 
-    assert captured["argv"] == [agent, "/berdl_start"]
+
+@pytest.mark.parametrize("agent", ["codex", "gemini", "omp"])
+def test_start_does_not_pass_claude_flags_to_other_agents(tmp_path, monkeypatch, agent):
+    """End-to-end through run_start: no Claude-only flag reaches another agent."""
+    argv = _launch(tmp_path, monkeypatch, agent=agent)
+    assert "--model" not in argv and "--permission-mode" not in argv
+
+
+@pytest.mark.parametrize("agent", ["codex", "gemini"])
+def test_start_argv_is_bare_for_agents_with_no_defaults(tmp_path, monkeypatch, agent):
+    """codex and gemini get nothing but the onboarding prompt."""
+    assert _launch(tmp_path, monkeypatch, agent=agent) == [agent, "/berdl_start"]
 
 
 def test_setup_launch_does_not_pass_claude_flags_to_other_agents():
@@ -180,3 +193,71 @@ def test_setup_launch_does_not_pass_claude_flags_to_other_agents():
 
     claude_argv = ["claude", *start.claude_defaults("claude", []), "/berdl_start"]
     assert "--model" in claude_argv and "opus[1m]" in claude_argv
+
+
+# ── omp: a session directory the collector can name ────
+
+
+@pytest.mark.parametrize("agent", ["claude", "codex", "gemini"])
+def test_omp_defaults_returns_nothing_for_other_agents(agent, tmp_path):
+    assert start.omp_defaults(agent, [], tmp_path) == []
+
+
+def test_omp_defaults_points_at_the_checkout(tmp_path):
+    """The directory is derived from the repo root, not from the operator's home."""
+    assert start.omp_defaults("omp", [], tmp_path) == [
+        "--session-dir",
+        str(tmp_path / start.OMP_SESSION_DIR),
+    ]
+
+
+@pytest.mark.parametrize(
+    "supplied",
+    [["--session-dir", "/somewhere/else"], ["--session-dir=/somewhere/else"]],
+)
+def test_omp_defaults_respects_a_caller_supplied_session_dir(supplied, tmp_path):
+    """Both flag spellings count: passing the default too would hand omp two values."""
+    assert start.omp_defaults("omp", supplied, tmp_path) == []
+
+
+def test_has_flag_matches_both_spellings():
+    assert start._has_flag(["--model", "sonnet"], "--model")
+    assert start._has_flag(["--model=sonnet"], "--model")
+    assert not start._has_flag(["--model-something"], "--model")
+    assert not start._has_flag([], "--model")
+
+
+def test_start_gives_omp_a_session_dir_and_still_onboards(tmp_path, monkeypatch):
+    """The regression this exists to prevent.
+
+    The onboarding guard is `if not skip_onboard and not extra_args`, so an operator
+    who passed --session-dir by hand silently lost /berdl_start. Injecting the flag
+    on BERIL's side keeps both.
+    """
+    argv = _launch(tmp_path, monkeypatch, agent="omp")
+    expected = str(tmp_path / "repo" / start.OMP_SESSION_DIR)
+    assert argv == ["omp", "--session-dir", expected, "/berdl_start"]
+
+
+def test_start_lets_the_operator_override_the_session_dir(tmp_path, monkeypatch):
+    """An explicit --session-dir wins, and is not doubled."""
+    argv = _launch(
+        tmp_path, monkeypatch, agent="omp", extra_args=["--session-dir", "/elsewhere"]
+    )
+    assert argv.count("--session-dir") == 1
+    assert argv == ["omp", "--session-dir", "/elsewhere"]
+
+
+def test_start_creates_and_announces_the_omp_session_dir(tmp_path, monkeypatch, capsys):
+    """A collector needs the path, so it is printed -- and it exists when printed."""
+    argv = _launch(tmp_path, monkeypatch, agent="omp")
+    session_dir = Path(argv[2])
+    assert session_dir.is_dir()
+    assert str(session_dir) in capsys.readouterr().out
+
+
+def test_claude_is_unaffected_by_the_omp_session_dir(tmp_path, monkeypatch):
+    """Claude keeps its own defaults and gains no session flag."""
+    argv = _launch(tmp_path, monkeypatch, agent="claude")
+    assert "--session-dir" not in argv
+    assert "--model" in argv and "opus[1m]" in argv

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -203,12 +203,28 @@ def test_omp_defaults_returns_nothing_for_other_agents(agent, tmp_path):
     assert start.omp_defaults(agent, [], tmp_path) == []
 
 
-def test_omp_defaults_points_at_the_checkout(tmp_path):
-    """The directory is derived from the repo root, not from the operator's home."""
-    assert start.omp_defaults("omp", [], tmp_path) == [
-        "--session-dir",
-        str(tmp_path / start.OMP_SESSION_DIR),
-    ]
+def test_omp_defaults_points_under_home_not_into_the_checkout(tmp_path):
+    """BERDL pods are ephemeral and $HOME persists, so the transcript lives in $HOME.
+
+    Asserted against the literal layout, not against `omp_session_dir` -- comparing the
+    constant to itself would pass however the path were renamed, and nothing else pins it.
+    """
+    (flag, value), = [start.omp_defaults("omp", [], tmp_path)[i : i + 2] for i in (0,)]
+    assert flag == "--session-dir"
+    path = Path(value)
+    assert path.parent == Path.home() / ".beril" / "omp-sessions"
+    assert path.name.startswith(f"{tmp_path.resolve().name}-")
+    # Nothing is written into the checkout.
+    assert not any(tmp_path.iterdir())
+
+
+def test_two_checkouts_with_one_name_get_different_directories(tmp_path):
+    """Keyed by resolved path: two clones of the same repo must not share sessions."""
+    a, b = tmp_path / "one" / "BERIL", tmp_path / "two" / "BERIL"
+    for d in (a, b):
+        d.mkdir(parents=True)
+    assert start.omp_session_dir(a) != start.omp_session_dir(b)
+    assert start.omp_session_dir(a) == start.omp_session_dir(a)  # stable across runs
 
 
 @pytest.mark.parametrize(
@@ -228,15 +244,27 @@ def test_has_flag_matches_both_spellings():
 
 
 def test_start_gives_omp_a_session_dir_and_still_onboards(tmp_path, monkeypatch):
-    """The regression this exists to prevent.
+    """On the default path the operator gets both.
 
-    The onboarding guard is `if not skip_onboard and not extra_args`, so an operator
-    who passed --session-dir by hand silently lost /berdl_start. Injecting the flag
-    on BERIL's side keeps both.
+    The onboarding guard is `if not skip_onboard and not extra_args`, so an operator who
+    passed --session-dir by hand lost /berdl_start. Injecting on BERIL's side sidesteps
+    that -- it does not repair the guard, which still drops onboarding for *any* forwarded
+    flag. See test_any_forwarded_flag_still_costs_onboarding.
     """
     argv = _launch(tmp_path, monkeypatch, agent="omp")
-    expected = str(tmp_path / "repo" / start.OMP_SESSION_DIR)
+    expected = str(start.omp_session_dir(tmp_path / "repo"))
     assert argv == ["omp", "--session-dir", expected, "/berdl_start"]
+
+
+def test_any_forwarded_flag_still_costs_onboarding(tmp_path, monkeypatch):
+    """Pre-existing and NOT fixed here: the guard cannot tell a flag from a prompt.
+
+    Pinned rather than left implicit so the limitation is visible, and so a later fix has
+    a test to change deliberately.
+    """
+    argv = _launch(tmp_path, monkeypatch, agent="omp", extra_args=["--thinking", "high"])
+    assert "/berdl_start" not in argv
+    assert "--session-dir" in argv  # the session dir is still injected
 
 
 def test_start_lets_the_operator_override_the_session_dir(tmp_path, monkeypatch):
@@ -248,12 +276,23 @@ def test_start_lets_the_operator_override_the_session_dir(tmp_path, monkeypatch)
     assert argv == ["omp", "--session-dir", "/elsewhere"]
 
 
-def test_start_creates_and_announces_the_omp_session_dir(tmp_path, monkeypatch, capsys):
-    """A collector needs the path, so it is printed -- and it exists when printed."""
+def test_start_announces_the_omp_session_dir_without_creating_it(tmp_path, monkeypatch):
+    """A collector needs the path, so it is printed. omp creates the directory itself.
+
+    Creating it here would run between "Launching omp..." and execvp, where a path occupied
+    by a file raises and the agent never starts.
+    """
     argv = _launch(tmp_path, monkeypatch, agent="omp")
-    session_dir = Path(argv[2])
-    assert session_dir.is_dir()
-    assert str(session_dir) in capsys.readouterr().out
+    assert str(start.omp_session_dir(tmp_path / "repo")) == argv[2]
+
+
+def test_announce_does_not_touch_the_filesystem(tmp_path, capsys):
+    """Pinned against a path that cannot be created: a plain file where the dir would go."""
+    blocked = tmp_path / "blocked"
+    blocked.write_text("")  # a FILE, so mkdir here would raise FileExistsError
+    start.announce_omp_session(["--session-dir", str(blocked / "nested")])
+    assert str(blocked / "nested") in capsys.readouterr().out
+    assert blocked.is_file()
 
 
 def test_claude_is_unaffected_by_the_omp_session_dir(tmp_path, monkeypatch):
@@ -261,3 +300,13 @@ def test_claude_is_unaffected_by_the_omp_session_dir(tmp_path, monkeypatch):
     argv = _launch(tmp_path, monkeypatch, agent="claude")
     assert "--session-dir" not in argv
     assert "--model" in argv and "opus[1m]" in argv
+
+
+def test_a_caller_supplied_model_with_equals_is_not_doubled(tmp_path, monkeypatch):
+    """End-to-end for the `--model=x` fix: `"--model" not in extra_args` misses this form.
+
+    The helper test alone let a revert to the old membership check pass the whole suite.
+    """
+    argv = _launch(tmp_path, monkeypatch, agent="claude", extra_args=["--model=sonnet"])
+    assert argv.count("--model") == 0  # the default was withheld
+    assert argv == ["claude", "--permission-mode", "auto", "--model=sonnet"]

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -558,9 +558,10 @@ class TestRunSetupOrchestrator:
         setup_cmd.run_setup()
 
         _binary, argv = execvp.call_args.args
-        expected = str(happy_setup.repo / start.OMP_SESSION_DIR)
+        expected = str(start.omp_session_dir(happy_setup.repo))
         assert argv == ["omp", "--session-dir", expected, "/berdl_start"]
-        assert (happy_setup.repo / start.OMP_SESSION_DIR).is_dir()
+        # Under $HOME, so nothing is written into the checkout.
+        assert not (happy_setup.repo / ".omp-sessions").exists()
 
     def test_vertex_env_injected_before_launch(self, happy_setup, monkeypatch):
         # When Vertex is enabled and claude launches, the Vertex env vars are set

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from beril_cli import setup_cmd
+from beril_cli import setup_cmd, start
 from beril_cli.auth_store import AuthRecord
 
 
@@ -539,6 +539,28 @@ class TestRunSetupOrchestrator:
         binary, argv = execvp.call_args.args
         assert binary == "/usr/bin/claude"
         assert argv[0] == "claude" and "/berdl_start" in argv
+
+    def test_launching_omp_from_the_wizard_sets_a_session_dir(self, happy_setup, monkeypatch):
+        """A session begun from setup must be as collectable as one begun from start.
+
+        `beril start` and `beril setup` are two launch sites for the same agent; only
+        the first having a knowable transcript path is the kind of split that put the
+        agent list in three places before it was shared.
+        """
+        monkeypatch.setattr(
+            setup_cmd.shutil, "which",
+            lambda name: "/usr/bin/omp" if name == "omp" else None,
+        )
+        monkeypatch.setattr(setup_cmd, "_prompt", lambda q, default="": "omp")
+        execvp = MagicMock()
+        monkeypatch.setattr(setup_cmd.os, "execvp", execvp)
+
+        setup_cmd.run_setup()
+
+        _binary, argv = execvp.call_args.args
+        expected = str(happy_setup.repo / start.OMP_SESSION_DIR)
+        assert argv == ["omp", "--session-dir", expected, "/berdl_start"]
+        assert (happy_setup.repo / start.OMP_SESSION_DIR).is_dir()
 
     def test_vertex_env_injected_before_launch(self, happy_setup, monkeypatch):
         # When Vertex is enabled and claude launches, the Vertex env vars are set


### PR DESCRIPTION
## Why

`beril start --agent omp` launches omp with no session flags, so omp writes its transcript to `~/.omp/agent/sessions/<encoded-cwd>/` under a name it picks — a timestamp and a UUID, knowable only after the fact. Because `beril start` chdirs to the repo root first, every project in a checkout also shares one such directory.

Claude Code gets a SessionStart hook that hands BERIL the exact `transcript_path` (`audit_cmd.py::_agent_signals_from_transcript`); omp fires no such hook, so a transcript reader has nothing to be pointed at. This is the BERIL half of adding omp support to evalome, whose `collect` takes `--transcript <path>`.

## What

Pass `--session-dir ~/.beril/omp-sessions/<name>-<hash>/` for omp and print it at launch, at both launch sites (`beril start` and `beril setup` step 11).

**In `$HOME`, not in the checkout.** BERDL compute nodes are ephemeral pods (PROJECT.md) while `$HOME` persists — `beril setup` says exactly that at step 10 — so a transcript in the working tree is the copy that does *not* survive a pod restart. It would also put full agent conversations inside a public repo's tree, one ignore-drift or `git add -f` from being committed, and inside the Docker build context. Keyed by hash of the resolved path, so two clones sharing a directory name do not share sessions.

**No mkdir.** omp creates the directory itself, recursively, on open (verified against the shipped binary). Creating it here would run between `print("Launching omp...")` and `execvp`, where a path occupied by a file or a read-only mount raises *after* the operator was told the agent was starting.

**Repo-root, not per-project** — `/berdl_start` scaffolds the project *during* the session, so at launch there is no project directory yet.

**Injected by BERIL rather than left to the operator.** The onboarding guard is `if not skip_onboard and not extra_args`, so an operator passing `--session-dir` by hand loses `/berdl_start`. Injecting after the guard means the default path gets both.

## Scope, stated honestly

This **routes around** the onboarding guard; it does not repair it. Any forwarded flag still drops `/berdl_start` — `--thinking high` does, and so does an explicitly passed `--session-dir`. That is pre-existing and now pinned by `test_any_forwarded_flag_still_costs_onboarding` so it is visible rather than implicit. Fixing it properly needs a per-agent "is this argv carrying a user message?" scanner, which is more machinery than this PR should carry.

Two more known gaps, both deliberate:

- `_has_flag` matches the flag appearing inside *message text*: `-p "--session-dir=x is what I mean"` suppresses the injected default. Same shared-substring weakness; same per-agent-parsing fix.
- `--session-dir` bypasses omp's `autoResume`. It is off by default, so this affects only operators who enabled it.

## Drive-by (same bug class — happy to drop it)

`claude_defaults` tested `"--model" not in extra_args`, which misses `--model=sonnet` and hands Claude the flag twice. `_has_flag` matches both spellings. Note the caveat: I could not verify how Claude Code resolves a repeated `--model`, so this is "stops passing a duplicate flag", not a demonstrated wrong-model bug.

## Verification

582 tests pass. Two mutations that previously survived the whole suite now fail:

- renaming the session-root constant — every assertion compared the constant to itself, so the old version passed while transcripts landed in a tracked path
- reverting the `--model=x` fix — only the helper was tested directly, with no end-to-end coverage

```
$ beril start --agent omp --dev
omp transcripts: ~/.beril/omp-sessions/BERIL-research-observatory-<hash> (this session is the newest *.jsonl)
argv: ['omp', '--session-dir', '<that path>', '/berdl_start']
```

Claude's argv is unchanged on the default path, and deliberately changed for `--model=x` / `--permission-mode=x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
